### PR TITLE
Formalizar checkpoint de memoria antes de PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Resumen
+
+- 
+
+## Verificacion
+
+- [ ] `npm run lint` si aplica
+- [ ] `npm run build` si aplica
+- [ ] Verificacion visual/manual si aplica
+
+## Memoria
+
+- [ ] He revisado issue/contexto, diff y commits de la rama contra la base.
+- [ ] He actualizado `.memory/` o confirmo que no aplica.
+- [ ] No se han guardado secretos ni datos sensibles.
+
+Estado de memoria: <!-- actualizada en .memory/... | no aplica -->
+
+## Notas
+
+- 

--- a/.memory/MEMORY.md
+++ b/.memory/MEMORY.md
@@ -1,8 +1,12 @@
 # Memory — CulturaApp
 
+Mapa estructurado ampliado: [core.md](core.md)
+
 ## Proyecto
 
 - [Memoria centralizada en .memory/](project_memory_centralization.md) — Memoria movida de ruta Claude a .memory/ en el repo (2026-05-03)
+- [Routing/deploy](projects/routing-deploy.md) — Vercel necesita fallback SPA para recargas de rutas protegidas; deploy real sigue pendiente
+- [Estado general](projects/culturaapp-status.md) — Estado implementado del MVP, `/work` y brechas pendientes
 
 ## Referencias
 
@@ -11,6 +15,7 @@
 ## Comportamiento obligatorio
 
 - [Leer y actualizar memoria siempre](feedback_memory_always.md) — Leer MEMORY.md al inicio y guardar proactivamente sin que el usuario lo pida
+- [Checkpoint de memoria pre-PR](topics/agent-workflows.md) — Antes de abrir PR, actualizar `.memory/` o declarar `Memoria: no aplica`
 
 ## Feedback y preferencias
 

--- a/.memory/core.md
+++ b/.memory/core.md
@@ -11,6 +11,7 @@ Repository-local memory for CulturaApp agents. This file is a compact map; detai
 - Overall CulturaApp implementation timeline: see [projects/culturaapp-status.md](projects/culturaapp-status.md).
 - Calendar layout and mobile week UX: see [projects/calendar.md](projects/calendar.md).
 - Dashboard finance calculations: see [projects/dashboard-finance.md](projects/dashboard-finance.md).
+- Routing/deploy caveats: see [projects/routing-deploy.md](projects/routing-deploy.md).
 - Settings/profile data access: see [projects/settings.md](projects/settings.md).
 - Topic index: see [topics/README.md](topics/README.md).
 - Project-area index: see [projects/README.md](projects/README.md).
@@ -24,4 +25,4 @@ Repository-local memory for CulturaApp agents. This file is a compact map; detai
 ## Maintenance
 
 - Created: 2026-05-03
-- Last curated: 2026-05-03 after reviewing tracked Markdown docs and git commits through `37ff950`.
+- Last curated: 2026-05-03 after reviewing GitHub issues `#1`-`#13`, local commits through `7835a83`, and confirming there are no recent PRs in `dignacioconde/culturApp`.

--- a/.memory/me.md
+++ b/.memory/me.md
@@ -8,6 +8,7 @@ Durable collaboration preferences and user-provided context for CulturaApp agent
 - Responses should be concise unless more detail is requested.
 - When the user asks to run OpenCode agents, use the repository agent workflow instead of doing broad manual investigation first.
 - Before committing, pushing, closing an issue, or wrapping a meaningful session, explicitly check whether new durable preferences, product decisions, or workflow lessons should be saved in `.memory/`.
+- Before opening a PR, whether working through OpenCode agents or directly as Codex/Claude Code, complete the memory checkpoint: update `.memory/` with durable context or explicitly state `Memoria: no aplica`.
 - Do not duplicate every issue, PR, or commit in `.memory/`; use GitHub issues, PRs, and commits as the operational history when reconstructing task context. Save only durable preferences, product decisions, recurring gotchas, or workflow lessons.
 
 ## Privacy Boundary

--- a/.memory/projects/README.md
+++ b/.memory/projects/README.md
@@ -18,4 +18,5 @@ Prefer this folder when the memory is about a specific app area rather than a re
 - [culturaapp-status.md](culturaapp-status.md): high-level implementation timeline and commit-backed state.
 - [calendar.md](calendar.md): React Big Calendar layout gotchas and pending mobile week UX.
 - [dashboard-finance.md](dashboard-finance.md): dashboard KPI definitions and fixed calculation issues.
+- [routing-deploy.md](routing-deploy.md): Vercel SPA fallback, protected-route refresh behavior, and deploy status caveat.
 - [settings.md](settings.md): profile access via hook and 409/profile trigger caveat.

--- a/.memory/projects/routing-deploy.md
+++ b/.memory/projects/routing-deploy.md
@@ -1,0 +1,13 @@
+# Routing And Deploy Memory
+
+## 2026-05-03 - Vercel Needs SPA Fallback For Protected Routes
+
+- Context: Issue `#4` was a P0: refreshing protected React Router routes returned `404 Not Found` in production-style routing.
+- Durable memory: keep `vercel.json` with a catch-all rewrite to `/` so Vercel serves the Vite SPA entry and React Router handles `/dashboard`, `/events`, `/projects`, `/calendar/events`, `/calendar/projects`, `/settings`, `/work`, and future app routes. Do not remove this when touching deploy config unless replacing it with an equivalent SPA fallback.
+- Source: issue `#4`; commit `d56ed37`; `vercel.json`.
+
+## 2026-05-03 - Deploy Config Exists But Production Deploy Is Still Pending
+
+- Context: The SPA fallback was added before the project was marked deployed in the docs.
+- Durable memory: `vercel.json` being present does not mean the Vercel deployment is complete. Keep "Deploy en Vercel" as a pending release task until a real deployment is created and verified.
+- Source: `AGENTS.md`; commit `d56ed37`; project status docs.

--- a/.memory/projects/settings.md
+++ b/.memory/projects/settings.md
@@ -11,3 +11,9 @@
 - Context: Docs preserve a known Supabase gotcha where the auth trigger previously failed without explicit `public.profiles`.
 - Durable memory: if project/event creation returns 409, check whether the authenticated user lacks a row in `profiles`; the documented repair is inserting missing profile ids from `auth.users` after ensuring `handle_new_user` inserts into `public.profiles`.
 - Source: `AGENTS.md`; Supabase initialization docs in `README.md`.
+
+## 2026-05-03 - `profiles.tax_rate` Is The Canonical IRPF Source
+
+- Context: Commit `e7267d4` fixed income forms that still defaulted IRPF from `user.user_metadata.tax_rate`.
+- Durable memory: default IRPF in settings, event incomes, and project incomes must come from `profiles.tax_rate` via `useProfile`; do not rely on Supabase auth metadata for the current profile tax rate.
+- Source: commit `e7267d4`; `src/hooks/useProfile.js`; `src/pages/Events/EventDetail.jsx`; `src/pages/Projects/ProjectDetail.jsx`.

--- a/.memory/topics/agent-workflows.md
+++ b/.memory/topics/agent-workflows.md
@@ -23,3 +23,9 @@
 - Context: Calendar responsive work showed that lint/build were insufficient for `react-big-calendar` layout regressions.
 - Durable memory: prompts for visual/responsive agents must include route, viewport or condition, symptom/capture, and a visual acceptance criterion; for calendars, require evidence that toolbar, header, and month rows are visible.
 - Source: commit `2efe2b6`; `AGENTS.md`; `.opencode/README.md`; `TECHDOC.md`.
+
+## 2026-05-03 - Memory Gate Before Pull Requests
+
+- Context: The user asked that memory be filled before PR creation, for OpenCode agents and also for Codex or Claude Code when they work without agents.
+- Durable memory: no PR should be opened until the worker has reviewed issue/context, branch diff, and commits against base, then either updated `.memory/` with durable preferences, product decisions, recurring gotchas, or workflow rules, or explicitly declared `Memoria: no aplica`. The PR body must include the memory status. OpenCode should route durable memory writes through `cultura-docs`; Codex and Claude Code may update `.memory/` directly when not using agents.
+- Source: user instruction on 2026-05-03; issue `#13`; `AGENTS.md`; `.github/pull_request_template.md`; `.opencode/README.md`.

--- a/.memory/topics/forms.md
+++ b/.memory/topics/forms.md
@@ -11,3 +11,21 @@
 - Context: Calendar and form UX was standardized around a practical workday rather than midnight defaults.
 - Durable memory: event start defaults should be `08:00`; end time should use the selected start time as reference when the user has not chosen another; UI should use 24h time and values compatible with Supabase (`YYYY-MM-DD`, `YYYY-MM-DDTHH:mm`).
 - Source: `AGENTS.md`; `README.md`; `TECHDOC.md`; commits `48f8b89` and `fc99c25`.
+
+## 2026-05-03 - Date Controls Must Support Manual Typing
+
+- Context: Issue `#5` captured the user's preference to type dates manually while preserving current calendar preselection and mobile-friendly custom controls.
+- Durable memory: shared date controls should allow manual `DD/MM/YYYY` entry, keep the visual picker available, and still emit database-compatible values (`YYYY-MM-DD`; datetime controls keep `YYYY-MM-DDTHH:mm`). Do not fall back to native browser date controls in app pages.
+- Source: issue `#5`; commit `d56ed37`; `src/components/ui/Input.jsx`.
+
+## 2026-05-03 - Events Are One-Day By Default
+
+- Context: Issue `#7` clarified that the normal cultural event is a same-day occurrence, with multi-day events as an explicit exception.
+- Durable memory: `EventForm` should default end datetime to the same date, one hour after start, and show a separate `Evento de varios días` option before asking for a different end date. Keep the 08:00 start default and calendar prefill behavior.
+- Source: issue `#7`; commit `d56ed37`; `src/pages/Events/EventForm.jsx`.
+
+## 2026-05-03 - Decimal Inputs Should Accept Comma And Dot
+
+- Context: Issue `#11` found that IRPF values with decimals are real user inputs and native numeric controls can block comma decimals depending on browser/locale.
+- Durable memory: for decimal finance percentages such as `tax_rate`, prefer text inputs with `inputMode="decimal"` plus `parseDecimal()` from `src/lib/formatters.js`, accepting both `15,5` and `15.5`; validate IRPF in the `0-100` range before saving.
+- Source: issue `#11`; commit `ce89ea3`; `src/lib/formatters.js`; `src/pages/Settings/Settings.jsx`; income forms in event/project detail.

--- a/.opencode/AGENT_TASK_TEMPLATE.md
+++ b/.opencode/AGENT_TASK_TEMPLATE.md
@@ -23,8 +23,12 @@ Ejemplo: frontend -> src/pages/Events; data -> src/hooks; docs -> README.md.
 VERIFICACION:
 Indica comandos esperados. Por defecto, npm run lint y npm run build si se toca codigo.
 
+MEMORIA PRE-PR:
+Si el siguiente paso es abrir PR, revisa issue, diff y commits contra base. Actualiza `.memory/` si hay contexto durable o declara `Memoria: no aplica`. No abras PR hasta que esa decision este reflejada.
+
 SALIDA:
 Subagentes usados, cambios realizados, verificacion ejecutada y riesgos/bloqueos restantes.
+Si aplica, incluye `Memoria: actualizada/no aplica`.
 ```
 
 Ejemplo corto:
@@ -44,6 +48,9 @@ frontend -> src/pages/Events; data -> src/hooks/useEvents.js; testing -> verific
 
 VERIFICACION:
 npm run lint y npm run build.
+
+MEMORIA PRE-PR:
+Actualizar memoria si aparecen preferencias, decisiones duraderas o gotchas; si no, declarar no aplica.
 
 SALIDA:
 Resumen breve con cambios, pruebas y riesgos.

--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -27,6 +27,8 @@ Cuando el usuario pida ejecutar agentes, no hagas una revision manual previa del
 
 Cuando se descubra un problema nuevo, el flujo por defecto es: issue en GitHub -> agentes con contexto de la issue -> fix verificado -> commit -> push -> comentario en la issue con resumen/commit/verificaciones -> cerrar issue como completada. No cierres issues antes de pushear y comentar el commit y las verificaciones.
 
+Antes de abrir una PR, todos los agentes deben completar el **checkpoint de memoria pre-PR**: revisar issue, diff y commits contra la base; activar `@cultura-docs` si hay preferencias, decisiones duraderas, gotchas recurrentes o reglas de trabajo que guardar; o declarar `Memoria: no aplica`. Si `.memory/` cambia, esos archivos deben quedar commiteados y pusheados antes de crear la PR. La descripcion de PR debe incluir `Memoria: actualizada` o `Memoria: no aplica`.
+
 Ejemplo con alcance explicito:
 
 ```bash
@@ -164,6 +166,7 @@ Comandos esperados, por ejemplo npm run lint y npm run build.
 
 SALIDA:
 Subagentes usados, cambios, verificacion y riesgos/bloqueos.
+Si la tarea termina en PR, incluye tambien `Memoria: actualizada/no aplica`.
 ```
 
 Ejemplo:

--- a/.opencode/agents/cultura-docs.md
+++ b/.opencode/agents/cultura-docs.md
@@ -18,6 +18,7 @@ Mantienes la documentacion fiel al estado real del codigo y facil de usar para a
 - Publica `done` cuando documentes una senal y `bloqueo` si falta validacion manual.
 - Actualizar `README.md`, `TECHDOC.md` y `AGENTS.md` cuando cambie arquitectura o flujo.
 - `CLAUDE.md` es una redirección corta hacia `AGENTS.md` y `.memory/`. Solo actualizarla si cambian las rutas o el protocolo de memoria, no para sincronizar contenido.
+- Atender el checkpoint de memoria pre-PR cuando el lead lo pida: revisar issue, diff y commits contra base; actualizar `.memory/` si hay contexto durable o responder `Memoria: no aplica`.
 - Documentar lecciones UX relevantes, especialmente decisiones que evitan regresiones: selectores propios frente a nativos, horarios por defecto de eventos y limitaciones de `react-big-calendar` en móvil.
 - Documentar SQL, RLS, variables de entorno y deploy.
 - Mantener instrucciones claras para nuevos agentes de OpenCode.
@@ -36,6 +37,7 @@ Eres el unico agente con permiso para escribir en la memoria persistente. El lea
 - Preferencias o correcciones del usuario (tipo `feedback`)
 - Decisiones de proyecto no obvias con motivacion y fecha (tipo `project`)
 - Recursos externos relevantes como issues o servicios (tipo `reference`)
+- Checkpoints pre-PR que descubran contexto durable; no dupliques historial operativo de GitHub.
 
 **Formato de cada archivo de memoria**:
 

--- a/.opencode/agents/cultura-lead.md
+++ b/.opencode/agents/cultura-lead.md
@@ -27,7 +27,8 @@ Tu objetivo no es ser el implementador principal. Tu trabajo es recibir una dire
 5. Si un subagente publica `schema_changed`, `api_changed`, `ui_changed`, `needs_review` o `bloqueo`, activa los agentes dependientes.
 6. Para cambios de codigo, cierra siempre con `@cultura-testing`; para cambios medianos/grandes o sensibles, tambien con `@cultura-review`.
 7. Si durante la tarea se detecta una preferencia nueva, una correccion del usuario o una decision de proyecto no obvia, activa `@cultura-docs` para que la persista en memoria antes de cerrar.
-8. Devuelve un resumen final con: subagentes usados, cambios realizados, verificacion y riesgos/bloqueos.
+8. Antes de abrir o preparar una PR, ejecuta el checkpoint de memoria pre-PR: revisa issue, diff y commits contra base; activa `@cultura-docs` si hay memoria durable que guardar, o declara `Memoria: no aplica`.
+9. Devuelve un resumen final con: subagentes usados, cambios realizados, verificacion, memoria pre-PR y riesgos/bloqueos.
 
 ## Tabla de enrutado
 
@@ -47,6 +48,7 @@ Tu objetivo no es ser el implementador principal. Tu trabajo es recibir una dire
 - No edites `src/**`, SQL, README, TECHDOC ni configuracion de app directamente. Si un cambio toca esas rutas, delegalo.
 - Pregunta solo ante bloqueo real: credenciales, accion destructiva, cambio remoto, decision de producto irreversible o ownership ambiguo en escritura paralela.
 - No ejecutes cambios remotos en Supabase, Vercel o GitHub sin confirmacion explicita.
+- No abras PR hasta que la memoria pre-PR este actualizada o declarada como no aplicable.
 - No leas ni publiques secretos de `.env.local`.
 - Si la directriz no trae ownership y hay riesgo de conflicto, delega primero una exploracion sin escritura y luego pide o define ownership antes de implementar.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ El proyecto tiene un sistema de memoria persistente en `.memory/` (directorio en
 
 **Durante la tarea**: si se descubre algo nuevo sobre preferencias del usuario, decisiones no obvias o contexto del proyecto, delegarlo a `@cultura-docs` para que lo persista.
 
+**Gate obligatorio antes de abrir PR**: ningun agente, Codex o Claude Code debe abrir una PR sin hacer un checkpoint de memoria. Revisar issue relacionada, diff y commits de la rama contra la base; guardar en `.memory/` solo preferencias, decisiones duraderas, gotchas recurrentes o reglas de trabajo. Si no hay nada durable que guardar, declararlo explicitamente como `Memoria: no aplica`. Si se actualiza `.memory/`, esos cambios deben quedar commiteados y pusheados antes de crear la PR. Incluir siempre en la descripcion de la PR una seccion `Memoria` con `actualizada` o `no aplica`.
+
 **Tipos de memoria**:
 - `feedback`: correcciones o validaciones de decisiones ("no hagas X", "sí, exactamente así")
 - `project`: decisiones de producto, bugs conocidos, iniciativas activas con fecha
@@ -86,10 +88,12 @@ Cuando se descubra un problema nuevo que requiera seguimiento, usar este flujo p
 1. Abrir o localizar una issue en GitHub con contexto, alcance y criterios de aceptacion.
 2. Ejecutar agentes OpenCode con esa issue como contexto, ownership claro y verificacion obligatoria.
 3. Implementar/ajustar el fix y ejecutar `npm run lint` y `npm run build` si toca codigo de app.
-4. Crear un commit con los cambios relacionados.
-5. Hacer push del commit a GitHub.
-6. Comentar la issue con resumen, commit y verificaciones ejecutadas.
-7. Cerrar la issue como completada solo despues del push, el commit y el comentario.
+4. Hacer checkpoint de memoria pre-PR: issue, diff y commits contra base. Activar `@cultura-docs` si hay que persistir memoria; si no, documentar `Memoria: no aplica`.
+5. Crear commit(s) con los cambios relacionados, incluyendo `.memory/` si se actualizo.
+6. Hacer push del commit a GitHub.
+7. Abrir PR solo cuando la memoria este actualizada o marcada como no aplicable, usando la plantilla de PR.
+8. Comentar la issue con resumen, commit/PR y verificaciones ejecutadas.
+9. Cerrar la issue como completada solo despues del push, el comentario y la PR creada o mergeada segun proceda.
 
 Si el problema es visual, incluir tambien ruta, viewport, captura/sintoma y criterio visual de aceptacion.
 
@@ -127,7 +131,24 @@ Una tarea de agente se considera terminada solo cuando:
 - Ejecuta `npm run lint` si esta disponible y aplica al cambio.
 - Si toca logica financiera, explica el calculo afectado.
 - Si toca datos, respeta RLS, `user_id` y el modelo evento/proyecto.
+- Si va a abrir PR, completa el checkpoint de memoria pre-PR y lo refleja en la descripcion de la PR.
 - Entrega resumen corto: archivos tocados, cambios hechos y pruebas ejecutadas.
+
+### Checkpoint de memoria pre-PR
+
+Aplica a **OpenCode agents**, **Codex trabajando directo** y **Claude Code trabajando directo**. No es opcional cuando el siguiente paso sea abrir una PR.
+
+1. Leer `.memory/MEMORY.md` y los archivos relevantes enlazados.
+2. Revisar la issue o contexto de la tarea, el diff actual y los commits de la rama contra la base.
+3. Decidir si surgio memoria durable:
+   - preferencias o correcciones del usuario;
+   - decisiones de producto o arquitectura no obvias;
+   - gotchas recurrentes que evitaran redescubrimiento;
+   - reglas de workflow o referencias externas utiles.
+4. No guardar historial operativo, rutas sueltas, listas de commits, estado temporal, secretos ni datos sensibles.
+5. Si aplica, actualizar `.memory/` antes del commit final de la rama. En OpenCode, el lead debe activar `@cultura-docs`; Codex y Claude Code pueden editar `.memory/` directamente siguiendo `memory-protocol`.
+6. Si no aplica, dejar constancia en el cierre y en la PR: `Memoria: no aplica`.
+7. La descripcion de la PR debe incluir `Memoria: actualizada en ...` o `Memoria: no aplica`.
 
 ### Issues visuales y responsive
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,3 +9,5 @@ Archivo de contexto para Claude Code.
 **Fuente de verdad del proyecto:** `AGENTS.md` — contiene arquitectura, stack, modelo de datos, convenciones, flujo de agentes y estado del proyecto. Léelo completo antes de tocar cualquier archivo.
 
 **Sistema de memoria:** `.memory/` — directorio en la raíz del repo (versionado en git). Preferencias, decisiones y contexto acumulado que persiste entre conversaciones y sesiones de agentes. `cultura-docs` es el único agente con permiso de escritura; Claude Code puede leer y escribir directamente.
+
+**Antes de abrir PR sin agentes:** hacer el checkpoint de memoria definido en `AGENTS.md`: revisar issue, diff y commits contra base; actualizar `.memory/` si hay preferencias, decisiones duraderas, gotchas o reglas nuevas; o declarar `Memoria: no aplica`. No crear la PR hasta que la memoria este commiteada/pusheada o marcada como no aplicable, e incluirlo en la descripcion de la PR.


### PR DESCRIPTION
## Resumen

- Añade un gate obligatorio de memoria antes de abrir PR en `AGENTS.md`, aplicable a OpenCode agents, Codex directo y Claude Code directo.
- Refuerza el flujo en `CLAUDE.md`, `.opencode/README.md`, `AGENT_TASK_TEMPLATE.md`, `cultura-lead` y `cultura-docs`.
- Añade plantilla de PR con sección `Memoria`.
- Actualiza `.memory/` con la regla de workflow y contexto durable derivado de issues/commits recientes.

Closes #13

## Verificacion

- [x] `git diff --check`
- [ ] `npm run lint` no aplica, solo Markdown/docs de agentes y memoria
- [ ] `npm run build` no aplica, solo Markdown/docs de agentes y memoria

## Memoria

- [x] He revisado issue/contexto, diff y commits de la rama contra la base.
- [x] He actualizado `.memory/`.
- [x] No se han guardado secretos ni datos sensibles.

Estado de memoria: actualizada en `.memory/topics/agent-workflows.md`, `.memory/me.md`, `.memory/MEMORY.md`, `.memory/core.md`, `.memory/topics/forms.md`, `.memory/projects/settings.md` y `.memory/projects/routing-deploy.md`.