### PR TITLE
Automatizar borrado de rama tras merge a main

### DIFF
--- a/.github/workflows/delete-branch.yml
+++ b/.github/workflows/delete-branch.yml
@@ -1,0 +1,21 @@
+name: Delete branch on merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  delete-branch:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Delete merged branch
+        run: |
+          echo "Deleting branch: ${{ github.event.pull_request.head.ref }}"
+          git push origin :${{ github.event.pull_request.head.ref }} --force

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "agents:plan": "node .opencode/scripts/run-planner.mjs",
     "agents:run": "node .opencode/scripts/run-agent.mjs",
     "agents:parallel": "node .opencode/scripts/run-parallel-agents.mjs",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "postmerge": "git branch -D $(git rev-parse --abbrev-ref HEAD) 2>/dev/null || true"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.104.1",


### PR DESCRIPTION
## Summary

- Añade workflow `.github/workflows/delete-branch.yml` que detecta cuando un PR se mergea a `main` y borra automáticamente la rama remota.
- Añade script `postmerge` en `package.json` para borrar la rama local tras el merge.

## Verificación

- `npm run lint` ✓
- `npm run build` ✓

## Memoria

- actualizada en `.memory/topics/agent-workflows.md` — El flujo ahora incluye cleanup automático post-merge.

Closes #22