### PR TITLE
fix(pb:capture): lee desde stdin cuando no hay argumento

### DIFF
--- a/.memory/feedback_product_brain.md
+++ b/.memory/feedback_product_brain.md
@@ -9,8 +9,9 @@ Nombre canónico del producto: **Cachés**. Usar `CACH` como prefijo de issues M
 ```bash
 npm run pb:init     # Inicializar Product Brain (primera vez)
 npm run pb:status   # Ver estado actual
-npm run pb:pull     # Importar cambios del vault de iCloud
-npm run pb:push     # Exportar cambios al vault de iCloud
+npm run pb:pull    # Importar cambios del vault de iCloud
+npm run pb:push    # Exportar cambios al vault de iCloud
+npm run pb:capture # Capturar nota (argumento o stdin)
 ```
 
 ## Estructura

--- a/scripts/product-brain-capture.mjs
+++ b/scripts/product-brain-capture.mjs
@@ -17,6 +17,7 @@
 import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { createHash } from 'crypto';
 import { dirname, join, relative, resolve } from 'path';
+import { createInterface } from 'readline';
 
 const PROJECT_ROOT = process.cwd();
 const REPO_BRAIN_PATH = process.env.PRODUCT_BRAIN_REPO_PATH
@@ -89,6 +90,19 @@ function log(message) {
 function fail(message) {
   console.error(`[pb:capture] ERROR: ${message}`);
   process.exit(1);
+}
+
+function readFromStdin() {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    const rl = createInterface({
+      input: process.stdin,
+      crlfDelay: Infinity,
+    });
+    rl.on('line', (line) => chunks.push(line));
+    rl.on('close', () => resolve(chunks.join('\n').trim()));
+    rl.on('error', reject);
+  });
 }
 
 function getPrefix(text) {
@@ -309,9 +323,21 @@ if (options.help) {
   process.exit(0);
 }
 
-if (cleanArgs.length === 0) {
-  fail('Falta contenido. Usar --help para ayuda.');
+async function main() {
+  let input = cleanArgs.join(' ');
+
+  if (!input) {
+    // Try to read from stdin only if stdin is not a TTY (i.e., piped data)
+    if (!process.stdin.isTTY) {
+      input = await readFromStdin();
+    }
+  }
+
+  if (!input) {
+    fail('Falta contenido. Usar --help para ayuda o passar un argumento, o usar: echo "PB ..." | npm run pb:capture');
+  }
+
+  commandCapture(input, options);
 }
 
-const input = cleanArgs.join(' ');
-commandCapture(input, options);
+main().catch(err => fail(err.message));


### PR DESCRIPTION
## Summary

- Corrige `scripts/product-brain-capture.mjs` para leer desde stdin cuando no hay argumento posicional
- Añade validación para contenido vacío con mensaje de error mejorado
- Actualiza `.memory/feedback_product_brain.md` con `npm run pb:capture` documentado
- Verificaciones: lint OK, build OK, pruebas directas OK

## Verificaciones

- [x] lint
- [x] build
- [x] `echo "PB idea: test" | npm run pb:capture -- --dry-run`
- [x] `npm run pb:capture -- --dry-run -- "PB idea: test"`

## Memoria

No aplica — fix de bug conocido, sin preferencias nuevas.

## Closes

Closes #32