### PR TITLE
docs(product-brain): complete indices and document curation flow

### DIFF
--- a/docs/project/START_HERE.md
+++ b/docs/project/START_HERE.md
@@ -10,6 +10,7 @@ aliases:
 tags:
   - product-brain
   - caches
+  - navigation
 ---
 
 # Product Brain de Cachés
@@ -46,9 +47,9 @@ npm run pb:push     # Exportar cambios al vault de iCloud
 
 ## Índices
 
-- [[indexes/issues.index|Issues]]
-- [[indexes/knowledge.index|Knowledge]]
-- [[indexes/decisions.index|Decisions]]
+- [[indexes/issues.index|Issues (CACH)]]
+- [[indexes/knowledge.index|Knowledge (ZK)]]
+- [[indexes/decisions.index|Decisions (ADR)]]
 - [[indexes/releases.index|Releases]]
 
 ## Planes activos

--- a/docs/project/context/README.md
+++ b/docs/project/context/README.md
@@ -21,6 +21,7 @@ Contexto estable de producto para Cachés: usuarios, propuesta de valor, restric
 - [[data-finance-model-20260504|Modelo de datos y finanzas — 2026-05-04]]
 - [[ux-mobile-guardrails-20260504|Guardrails UX y mobile — 2026-05-04]]
 - [[beta-readiness-risk-map-20260504|Beta readiness y mapa de riesgos — 2026-05-04]]
+- [[curation-flow-20260504|Flujo de curation del inbox — 2026-05-04]]
 
 ## Regla
 

--- a/docs/project/context/curation-flow-20260504.md
+++ b/docs/project/context/curation-flow-20260504.md
@@ -1,0 +1,91 @@
+---
+id: PB-CURATION-FLOW
+type: context
+status: Active
+created: 2026-05-04
+updated: 2026-05-04
+tags:
+  - product-brain
+  - workflow
+  - inbox
+---
+
+# Flujo de Curation del Inbox
+
+Proceso para clasificar y gestionar capturas rápidas en el inbox del Product Brain.
+
+## Entrada: Inbox
+
+Cuando capturas una idea rápida con `/product-brain-capture` o directamente en `inbox/`, la nota entra sin clasificar. El objetivo es mover cada captura a su destino apropiado o rechazarla.
+
+## Clasificaciones posibles
+
+| Clase | Destino | Criterio |
+|-------|---------|----------|
+| **ZK** | `knowledge/` | Notas de investigación, learning, patrones técnicos. Titulo: `PB-ZK-YYYYMMDD-topic` |
+| **Issue** | `issues/` | Trabajo de producto con usuario/problema claro. Titulo: `CACH-###` (autoincremental) |
+| **ADR** | `decisions/` | Decisión arquitectónica o de producto que afecta múltiples áreas. Titulo: `ADR-####` |
+| **Release** | `releases/` | Criterios de salida, notas de release, bloqueadores. |
+| **Context** | `context/` | Snapshots estables: análisis, mapas, modelos financieros. Titulo: `*-YYYYMMDD.md` |
+| **Duplicado** | Inbox → merge | Misma idea ya existe en otro archivo. Linkear y archivar la copia. |
+| **Rechazado** | Inbox → delete | Idea contradice contexto, es demasiado grande, o no tiene usuario claro. Documentar por qué. |
+
+## Proceso de Curation
+
+1. **Leer entrada** — Entiende el problema, la solución y por qué importa.
+2. **Challenge** — ¿Está repetida? ¿Contradice contexto? ¿Tiene usuario claro? ¿Es prematura?
+   - Si falla challenge → **Rechazado**
+3. **Elegir clase** — Usa tabla arriba según el tipo de información.
+4. **Mover y reformatear** — Copia contenido a destino con frontmatter, título y estructura correcta.
+5. **Linkear** — Si hay archivos relacionados (issues, ADRs, ZK), agrega links en sección "Related".
+6. **Deletear inbox** — Borra la entrada original.
+
+## Ejemplo: Issue
+
+```markdown
+---
+id: CACH-026
+type: issue
+status: Backlog
+priority: High
+release: RELEASE-0.1-beta
+created: 2026-05-04
+updated: 2026-05-04
+---
+
+# CACH-026 — Título descriptivo
+
+## Summary
+Una línea con el qué y el para qué.
+
+## Context
+Por qué importa, dónde estamos.
+
+## Problem
+Detalles de lo que no funciona.
+
+## Proposed Solution
+Qué haría roto arreglado.
+
+## Acceptance Criteria
+- [ ] Criterio 1
+- [ ] Criterio 2
+
+## Related
+- [[../knowledge/PB-ZK-...]]
+- [[../decisions/ADR-...]]
+```
+
+## Modo "Alfred"
+
+Si dudas, clasifica así:
+- **¿Es observación de algo visto?** → ZK
+- **¿Es trabajo de producto con usuario claro?** → Issue
+- **¿Decide algo que afecta múltiples áreas?** → ADR
+- **¿Es estado estable del proyecto?** → Context
+
+## Cadencia
+
+- **Daily** — Revisar inbox tras captura manual o `pb:capture`.
+- **Weekly** — Barrer inbox residual y listar entradas sin clasificar.
+- **Monthly** — Archivado: borrar rechazados documentados, consolidar ZK viejo.


### PR DESCRIPTION
## Summary

Complete the Product Brain index structure and document the inbox curation workflow.

## Changes

- Add prefixes to index links (CACH, ZK, ADR) for clarity
- Create `curation-flow-20260504.md` documenting inbox classification and workflow
- Link curation flow from context README
- Update START_HERE navigation tags
- Indices (issues, knowledge, decisions, releases) already complete and current

## Verification

- ✅ All index files exist and references are correct
- ✅ START_HERE.md links work and are up-to-date
- ✅ Curation flow documented with examples
- ✅ `npm run pb:status` passes

Fixes #36
