### PR TITLE
Rediseño visual editorial para Cachés — estética backstage/gira

### DIFF
--- a/src/pages/Dashboard/KpiCard.jsx
+++ b/src/pages/Dashboard/KpiCard.jsx
@@ -15,13 +15,6 @@ export function KpiCard({ title, value, subtitle, icon: Icon, color = 'red', pro
     indigo: 'bg-[#6366f1]',
   }
 
-  const borderTop = {
-    red: 'border-t-[#C94035]',
-    green: 'border-t-[#2D6A4F]',
-    amber: 'border-t-[#D4921A]',
-    indigo: 'border-t-[#6366f1]',
-  }
-
   return (
     <Card className="p-4 sm:p-5 min-w-0 border-t-2">
       <div className="flex items-start gap-3 sm:gap-4">


### PR DESCRIPTION
## Resumen

Rediseño del sistema visual de Cachés con estética editorial backstage/gira:

- Sistema de color (5 base + 2 acento): paper/ink/red con acentos amber/green/success
- Tipografía: DM Serif Display (display), Instrument Sans (UI), DM Mono (datos)
- Tokens CSS en `src/index.css` con transiciones contextuales
- Componentes actualizados: Sidebar, TopBar, Button, Badge, KpiCard, STATUS_COLORS

## Memoria

no aplica

Closes #46