### PR TITLE
fix(product-brain): valida enlaces y ruta IA

### DIFF
--- a/.memory/feedback_product_brain.md
+++ b/.memory/feedback_product_brain.md
@@ -9,6 +9,7 @@ Nombre canónico del producto: **Cachés**. Usar `CACH` como prefijo de issues M
 ```bash
 npm run pb:init     # Inicializar Product Brain (primera vez)
 npm run pb:status   # Ver estado actual
+npm run pb:check    # Validar frontmatter, índices y wikilinks internos
 npm run pb:pull    # Importar cambios del vault de iCloud
 npm run pb:push    # Exportar cambios al vault de iCloud
 npm run pb:capture # Capturar nota (argumento o stdin)
@@ -43,5 +44,11 @@ npm run pb:capture # Capturar nota (argumento o stdin)
 - No crear GitHub Issues salvo que el usuario pida implementación. No usar `.memory/` como backlog del Product Brain.
 - No capturar secretos ni datos sensibles de clientes sin confirmación explícita.
 - En barridos del Product Brain, revisar tambien que `decisions/` y `releases/` tengan las decisiones y cortes de producto realmente duraderos; no quedarse solo en `context/`, `knowledge/` e `issues/`.
+
+## Lectura IA y consistencia
+
+- `docs/project/START_HERE.md` debe mantener una ruta mínima de lectura para agentes: leer START_HERE, elegir índice por tipo de tarea, abrir solo enlaces relevantes y ejecutar `npm run pb:check` antes de cerrar cambios.
+- Los IDs canónicos de issues Markdown son los nombres de archivo completos, por ejemplo `CACH-0026` y `CACH-B0001`. No usar wikilinks cortos como `CACH-026` o `CACH-B001`.
+- Antes de abrir PR que toque `docs/project/`, ejecutar `npm run pb:check`; el validador cubre frontmatter de issues, índices principales y wikilinks internos.
 
 Actualizado: 2026-05-04

--- a/docs/project/START_HERE.md
+++ b/docs/project/START_HERE.md
@@ -41,9 +41,25 @@ docs/project/
 ```bash
 npm run pb:init      # Inicializar Product Brain (primera vez)
 npm run pb:status   # Ver estado actual y archivos pendientes
+npm run pb:check    # Validar frontmatter, índices y wikilinks internos
 npm run pb:pull     # Importar cambios del vault de iCloud
 npm run pb:push     # Exportar cambios al vault de iCloud
 ```
+
+## Ruta Mínima Para Agentes
+
+Para orientar una tarea sin leer todo el Product Brain:
+
+1. Leer este archivo.
+2. Leer solo el índice del tipo de trabajo:
+   - Backlog: [[indexes/issues.index|Issues Index]]
+   - Decisiones: [[indexes/decisions.index|Decisions Index]]
+   - Conocimiento técnico: [[indexes/knowledge.index|Knowledge Index]]
+   - Release: [[indexes/releases.index|Releases Index]]
+3. Abrir únicamente los archivos enlazados que afecten a la tarea.
+4. Ejecutar `npm run pb:check` antes de cerrar cambios en `docs/project/`.
+
+Los IDs canónicos de issues son los nombres de archivo completos, por ejemplo `CACH-0026` y `CACH-B0001`. No usar formas cortas como `CACH-026` o `CACH-B001` en wikilinks.
 
 ## Índices
 
@@ -60,7 +76,7 @@ npm run pb:push     # Exportar cambios al vault de iCloud
 
 Product Brain es la fuente de verdad de producto. GitHub Issues se crean solo cuando una issue vaya a implementarse con rama, agentes, PR y merge.
 
-Las issues Markdown usan el prefijo `CACH`, por ejemplo [[issues/CACH-026|CACH-026]].
+Las issues Markdown usan el prefijo `CACH`, por ejemplo [[issues/CACH-0026|CACH-0026]].
 
 ## Normas De Sync
 

--- a/docs/project/context/beta-readiness-risk-map-20260504.md
+++ b/docs/project/context/beta-readiness-risk-map-20260504.md
@@ -23,11 +23,11 @@ La beta debería priorizar confianza, comprensión rápida y reversibilidad de d
 
 ## Bloqueadores Antes De Beta
 
-1. Confianza del MVP: horas de agenda, fechas reales de cobro, decimales y pendientes vencidos. Ver [[../issues/CACH-B014|CACH-B014]].
-2. Portabilidad de datos: exportación e importación mínima. Ver [[../issues/CACH-B005|CACH-B005]].
-3. Onboarding y acceso beta: invitaciones, explicación del modelo mental y consentimiento de analítica. Ver [[../issues/CACH-B006|CACH-B006]].
-4. Mobile financiero: reducir fricción en detalles, tablas y formularios. Ver [[../issues/CACH-B002|CACH-B002]].
-5. Cobro rápido: acción frecuente y de alto valor para uso real. Ver [[../issues/CACH-B003|CACH-B003]].
+1. Confianza del MVP: horas de agenda, fechas reales de cobro, decimales y pendientes vencidos. Ver [[../issues/CACH-B0014|CACH-B0014]].
+2. Portabilidad de datos: exportación e importación mínima. Ver [[../issues/CACH-B0005|CACH-B0005]].
+3. Onboarding y acceso beta: invitaciones, explicación del modelo mental y consentimiento de analítica. Ver [[../issues/CACH-B0006|CACH-B0006]].
+4. Mobile financiero: reducir fricción en detalles, tablas y formularios. Ver [[../issues/CACH-B0002|CACH-B0002]].
+5. Cobro rápido: acción frecuente y de alto valor para uso real. Ver [[../issues/CACH-B0003|CACH-B0003]].
 
 ## Riesgos De Producto
 
@@ -39,10 +39,10 @@ La beta debería priorizar confianza, comprensión rápida y reversibilidad de d
 
 ## Cosas Que Pueden Esperar
 
-- Perfil público, referidos y viralidad: después de beta funcional. Ver [[../issues/CACH-B012|CACH-B012]].
-- Gestión documental: post-MVP salvo evidencia fuerte. Ver [[../issues/CACH-B013|CACH-B013]].
-- PWA/offline/notificaciones completas: valiosas, pero no deben bloquear la portabilidad ni el onboarding. Ver [[../issues/CACH-B008|CACH-B008]].
-- Inteligencia financiera Pro: depende de datos fiables y de decisiones de liquidación. Ver [[../issues/CACH-B009|CACH-B009]].
+- Perfil público, referidos y viralidad: después de beta funcional. Ver [[../issues/CACH-B0012|CACH-B0012]].
+- Gestión documental: post-MVP salvo evidencia fuerte. Ver [[../issues/CACH-B0013|CACH-B0013]].
+- PWA/offline/notificaciones completas: valiosas, pero no deben bloquear la portabilidad ni el onboarding. Ver [[../issues/CACH-B0008|CACH-B0008]].
+- Inteligencia financiera Pro: depende de datos fiables y de decisiones de liquidación. Ver [[../issues/CACH-B0009|CACH-B0009]].
 
 ## Criterio De Salida Para Primera Beta
 
@@ -54,11 +54,11 @@ La beta debería priorizar confianza, comprensión rápida y reversibilidad de d
 
 ## Relacionado Con
 
-- [[../issues/CACH-B002]]
-- [[../issues/CACH-B003]]
-- [[../issues/CACH-B005]]
-- [[../issues/CACH-B006]]
-- [[../issues/CACH-B008]]
-- [[../issues/CACH-B009]]
-- [[../issues/CACH-B012]]
-- [[../issues/CACH-B013]]
+- [[../issues/CACH-B0002]]
+- [[../issues/CACH-B0003]]
+- [[../issues/CACH-B0005]]
+- [[../issues/CACH-B0006]]
+- [[../issues/CACH-B0008]]
+- [[../issues/CACH-B0009]]
+- [[../issues/CACH-B0012]]
+- [[../issues/CACH-B0013]]

--- a/docs/project/context/curation-flow-20260504.md
+++ b/docs/project/context/curation-flow-20260504.md
@@ -44,7 +44,7 @@ Cuando capturas una idea rápida con `/product-brain-capture` o directamente en 
 
 ```markdown
 ---
-id: CACH-026
+id: CACH-0026
 type: issue
 status: Backlog
 priority: High
@@ -53,7 +53,7 @@ created: 2026-05-04
 updated: 2026-05-04
 ---
 
-# CACH-026 — Título descriptivo
+# CACH-0026 — Título descriptivo
 
 ## Summary
 Una línea con el qué y el para qué.

--- a/docs/project/context/ui-direction-v3-20260504.md
+++ b/docs/project/context/ui-direction-v3-20260504.md
@@ -255,7 +255,7 @@ Hacer:
 
 ## Relacionado Con
 
-- [[../issues/CACH-B001]]
-- [[../issues/CACH-B002]]
-- [[../issues/CACH-B007]]
+- [[../issues/CACH-B0001]]
+- [[../issues/CACH-B0002]]
+- [[../issues/CACH-B0007]]
 - [[ux-mobile-guardrails-20260504]]

--- a/docs/project/decisions/ADR-0001-project-event-finance-model.md
+++ b/docs/project/decisions/ADR-0001-project-event-finance-model.md
@@ -47,6 +47,6 @@ No forzar todos los ingresos/gastos a evento ni todos a proyecto sin una decisio
 
 - [[../context/product-snapshot-20260504]]
 - [[../context/data-finance-model-20260504]]
-- [[../issues/CACH-B001]]
-- [[../issues/CACH-B004]]
-- [[../issues/CACH-B007]]
+- [[../issues/CACH-B0001]]
+- [[../issues/CACH-B0004]]
+- [[../issues/CACH-B0007]]

--- a/docs/project/decisions/ADR-0002-beta-trust-before-pro.md
+++ b/docs/project/decisions/ADR-0002-beta-trust-before-pro.md
@@ -48,7 +48,7 @@ Las features Pro quedan despues de que el usuario pueda confiar en los datos bas
 
 - [[../context/beta-readiness-risk-map-20260504]]
 - [[../releases/RELEASE-0.1-beta]]
-- [[../issues/CACH-B014]]
-- [[../issues/CACH-B005]]
-- [[../issues/CACH-B006]]
-- [[../issues/CACH-B009]]
+- [[../issues/CACH-B0014]]
+- [[../issues/CACH-B0005]]
+- [[../issues/CACH-B0006]]
+- [[../issues/CACH-B0009]]

--- a/docs/project/decisions/ADR-0003-repo-native-product-brain.md
+++ b/docs/project/decisions/ADR-0003-repo-native-product-brain.md
@@ -42,6 +42,6 @@ El Product Brain vive en `docs/project/` y se sincroniza manualmente con el vaul
 ## Related
 
 - [[../START_HERE]]
-- [[../issues/CACH-026]]
-- [[../issues/CACH-028]]
-- [[../issues/CACH-B010]]
+- [[../issues/CACH-0026]]
+- [[../issues/CACH-0028]]
+- [[../issues/CACH-B0010]]

--- a/docs/project/decisions/ADR-0004-profile-data-source-and-hooks.md
+++ b/docs/project/decisions/ADR-0004-profile-data-source-and-hooks.md
@@ -46,4 +46,4 @@ Las paginas y componentes no deben llamar a Supabase directamente para datos de 
 
 - [[../context/data-finance-model-20260504]]
 - [[../knowledge/PB-ZK-20260504-profile-409]]
-- [[../issues/CACH-B014]]
+- [[../issues/CACH-B0014]]

--- a/docs/project/indexes/issues.index.md
+++ b/docs/project/indexes/issues.index.md
@@ -13,19 +13,19 @@ tags:
 
 # Issues Index
 
-- [[../issues/CACH-026|CACH-026]] — Setup inicial Product Brain
-- [[../issues/CACH-028|CACH-028]] — Corregir sync iCloud y estructura versionada
-- [[../issues/CACH-B001|CACH-B001]] — Rediseñar Trabajos y jerarquía proyecto-evento
-- [[../issues/CACH-B002|CACH-B002]] — Simplificar experiencia mobile financiera
-- [[../issues/CACH-B003|CACH-B003]] — Cobro rápido y gestión de pendientes
-- [[../issues/CACH-B004|CACH-B004]] — Contratantes, facturación y liquidación neta
-- [[../issues/CACH-B005|CACH-B005]] — Importación, exportación y portabilidad de datos
-- [[../issues/CACH-B006|CACH-B006]] — Onboarding y acceso beta
-- [[../issues/CACH-B007|CACH-B007]] — Calendario unificado e interacción rápida
-- [[../issues/CACH-B008|CACH-B008]] — PWA, notificaciones y offline
-- [[../issues/CACH-B009|CACH-B009]] — Inteligencia financiera y features Pro
-- [[../issues/CACH-B010|CACH-B010]] — Tooling de agentes y modelos de desarrollo
-- [[../issues/CACH-B011|CACH-B011]] — Categorías, etiquetas y taxonomía
-- [[../issues/CACH-B012|CACH-B012]] — Perfil público, viralidad y referidos
-- [[../issues/CACH-B013|CACH-B013]] — Gestión documental por proyecto/evento
-- [[../issues/CACH-B014|CACH-B014]] — Endurecer agenda, cobros y captura del MVP
+- [[../issues/CACH-0026|CACH-0026]] — Setup inicial Product Brain
+- [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada
+- [[../issues/CACH-B0001|CACH-B0001]] — Rediseñar Trabajos y jerarquía proyecto-evento
+- [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
+- [[../issues/CACH-B0003|CACH-B0003]] — Cobro rápido y gestión de pendientes
+- [[../issues/CACH-B0004|CACH-B0004]] — Contratantes, facturación y liquidación neta
+- [[../issues/CACH-B0005|CACH-B0005]] — Importación, exportación y portabilidad de datos
+- [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta
+- [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interacción rápida
+- [[../issues/CACH-B0008|CACH-B0008]] — PWA, notificaciones y offline
+- [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro
+- [[../issues/CACH-B0010|CACH-B0010]] — Tooling de agentes y modelos de desarrollo
+- [[../issues/CACH-B0011|CACH-B0011]] — Categorías, etiquetas y taxonomía
+- [[../issues/CACH-B0012|CACH-B0012]] — Perfil público, viralidad y referidos
+- [[../issues/CACH-B0013|CACH-B0013]] — Gestión documental por proyecto/evento
+- [[../issues/CACH-B0014|CACH-B0014]] — Endurecer agenda, cobros y captura del MVP

--- a/docs/project/indexes/knowledge.index.md
+++ b/docs/project/indexes/knowledge.index.md
@@ -17,3 +17,4 @@ tags:
 - [[../knowledge/PB-ZK-20260504-technical-audit|PB-ZK-20260504-TECH-AUDIT]] — Auditoría técnica repo 2026-05-04
 - [[../knowledge/PB-ZK-20260504-profile-409|PB-ZK-20260504-PROFILE-409]] — 409 en creación por profile faltante
 - [[../knowledge/PB-ZK-20260504-rbc-height|PB-ZK-20260504-RBC-HEIGHT]] — React Big Calendar necesita altura real
+- [[../knowledge/PB-ZK-20260504-ai-readable-product-brain|PB-ZK-20260504-AI-READABLE-PRODUCT-BRAIN]] — Product Brain legible por IA

--- a/docs/project/issues/CACH-0026.md
+++ b/docs/project/issues/CACH-0026.md
@@ -14,7 +14,7 @@ tags:
   - issue
 ---
 
-# CACH-026 — Setup inicial Product Brain
+# CACH-0026 — Setup inicial Product Brain
 
 ## Problema
 
@@ -37,9 +37,9 @@ Crear Product Brain repo-native en `docs/project/` con sync manual al vault Obsi
 
 ## Notas De Implementación
 
-La primera implementación se completó en la PR #27 y generó una corrección posterior en [[CACH-028]] para ajustar la ruta real del vault iCloud y versionar la estructura completa.
+La primera implementación se completó en la PR #27 y generó una corrección posterior en [[CACH-0028]] para ajustar la ruta real del vault iCloud y versionar la estructura completa.
 
 ## Véase también
 
 - [[START_HERE|Product Brain]]
-- [[CACH-028]]
+- [[CACH-0028]]

--- a/docs/project/issues/CACH-0028.md
+++ b/docs/project/issues/CACH-0028.md
@@ -14,7 +14,7 @@ tags:
   - issue
 ---
 
-# CACH-028 — Corregir sync iCloud y estructura versionada
+# CACH-0028 — Corregir sync iCloud y estructura versionada
 
 ## Summary
 
@@ -42,5 +42,5 @@ La primera versión apuntaba por defecto a un vault legacy y no dejaba versionad
 
 ## Related
 
-- [[CACH-026]]
+- [[CACH-0026]]
 - [[START_HERE|Product Brain]]

--- a/docs/project/issues/CACH-B0011.md
+++ b/docs/project/issues/CACH-B0011.md
@@ -15,7 +15,7 @@ tags:
   - data
 ---
 
-# CACH-B011 — Categorías, etiquetas y taxonomía
+# CACH-B0011 — Categorías, etiquetas y taxonomía
 
 ## Summary
 
@@ -45,5 +45,5 @@ Las categorías afectan a proyectos, eventos, ingresos, gastos, presupuestos y f
 
 ## Related
 
-- [[CACH-B009]]
+- [[CACH-B0009]]
 

--- a/docs/project/issues/CACH-B0012.md
+++ b/docs/project/issues/CACH-B0012.md
@@ -14,7 +14,7 @@ tags:
   - gtm
 ---
 
-# CACH-B012 — Perfil público, viralidad y referidos
+# CACH-B0012 — Perfil público, viralidad y referidos
 
 ## Summary
 
@@ -44,6 +44,6 @@ Cada perfil público puede ser una puerta de entrada a Cachés, pero también in
 
 ## Related
 
-- [[CACH-B006]]
-- [[CACH-B007]]
+- [[CACH-B0006]]
+- [[CACH-B0007]]
 

--- a/docs/project/issues/CACH-B0013.md
+++ b/docs/project/issues/CACH-B0013.md
@@ -14,7 +14,7 @@ tags:
   - data
 ---
 
-# CACH-B013 — Gestión documental por proyecto/evento
+# CACH-B0013 — Gestión documental por proyecto/evento
 
 ## Summary
 
@@ -43,5 +43,5 @@ Los documentos forman parte del flujo real de trabajo cultural, pero añaden cos
 
 ## Related
 
-- [[CACH-B004]]
+- [[CACH-B0004]]
 

--- a/docs/project/issues/README.md
+++ b/docs/project/issues/README.md
@@ -14,6 +14,6 @@ tags:
 
 # Issues
 
-Backlog ejecutable en Markdown. Las issues usan prefijo `CACH`, por ejemplo [[CACH-026]].
+Backlog ejecutable en Markdown. Las issues usan prefijo `CACH`, por ejemplo [[CACH-0026]].
 
 GitHub Issues se crean solo cuando una issue vaya a implementarse.

--- a/docs/project/knowledge/PB-ZK-20260504-2005.md
+++ b/docs/project/knowledge/PB-ZK-20260504-2005.md
@@ -18,4 +18,4 @@ Cuando estoy en un evento y termino, me gustar√≠a poder marcarlo como cobrado r√
 
 ## Relacionado Con
 
-- [[../issues/CACH-B003|CACH-B003]]
+- [[../issues/CACH-B0003|CACH-B0003]]

--- a/docs/project/knowledge/PB-ZK-20260504-ai-readable-product-brain.md
+++ b/docs/project/knowledge/PB-ZK-20260504-ai-readable-product-brain.md
@@ -1,0 +1,39 @@
+---
+id: PB-ZK-20260504-AI-READABLE-PRODUCT-BRAIN
+type: zk
+status: Active
+created: 2026-05-04
+updated: 2026-05-04
+aliases:
+  - Product Brain legible por IA
+tags:
+  - product-brain
+  - knowledge
+  - agents
+  - docs
+---
+
+# Product Brain legible por IA — 2026-05-04
+
+## Idea
+
+Un Product Brain útil para agentes necesita tres capas: una ruta mínima de lectura, IDs canónicos estables y validación automática.
+
+## Aprendizaje
+
+La estructura por carpetas (`context/`, `issues/`, `decisions/`, `knowledge/`) es buena para lectura humana e IA, pero se degrada rápido si los wikilinks usan formas cortas (`CACH-B001`) que no coinciden con filenames (`CACH-B0001.md`).
+
+Los agentes tienden a declarar la tarea resuelta tras corregir una parte visible si no hay una comprobación ejecutable. `npm run pb:check` convierte esa consistencia en gate verificable.
+
+## Reglas Prácticas
+
+- Mantener `START_HERE.md` como ruta de entrada, no como documento exhaustivo.
+- Usar siempre el ID completo del filename en wikilinks: `CACH-0026`, `CACH-B0001`.
+- Ejecutar `npm run pb:check` antes de cerrar cambios en `docs/project/`.
+- Si se añade un archivo a `issues/`, `decisions/`, `knowledge/` o `releases/`, actualizar su índice correspondiente.
+
+## Relacionado Con
+
+- [[../START_HERE|START_HERE]]
+- [[../issues/CACH-B0010|CACH-B0010]]
+- [[../decisions/ADR-0003-repo-native-product-brain|ADR-0003-repo-native-product-brain]]

--- a/docs/project/knowledge/PB-ZK-20260504-profile-409.md
+++ b/docs/project/knowledge/PB-ZK-20260504-profile-409.md
@@ -40,4 +40,4 @@ Esto bloqueo a usuarios reales durante el MVP.
 
 - [[../context/data-finance-model-20260504]]
 - [[../decisions/ADR-0004-profile-data-source-and-hooks]]
-- [[../issues/CACH-B014]]
+- [[../issues/CACH-B0014]]

--- a/docs/project/knowledge/PB-ZK-20260504-rbc-height.md
+++ b/docs/project/knowledge/PB-ZK-20260504-rbc-height.md
@@ -39,5 +39,5 @@ En bugs visuales de calendario:
 ## Relacionado Con
 
 - [[../context/ux-mobile-guardrails-20260504]]
-- [[../issues/CACH-B007]]
-- [[../issues/CACH-B014]]
+- [[../issues/CACH-B0007]]
+- [[../issues/CACH-B0014]]

--- a/docs/project/knowledge/README.md
+++ b/docs/project/knowledge/README.md
@@ -22,3 +22,4 @@ Notas Zettelkasten, investigación e insights de dominio. Una nota debe contener
 - [[PB-ZK-20260504-technical-audit|Auditoría técnica repo — 2026-05-04]]
 - [[PB-ZK-20260504-profile-409|409 en creación por profile faltante]]
 - [[PB-ZK-20260504-rbc-height|React Big Calendar necesita altura real]]
+- [[PB-ZK-20260504-ai-readable-product-brain|Product Brain legible por IA]]

--- a/docs/project/plans/backlog-mayo-2026.md
+++ b/docs/project/plans/backlog-mayo-2026.md
@@ -18,95 +18,95 @@ Curación del backlog bruto de 52 ideas/issues. GitHub Issues solo se crearán c
 
 ## Clusters ejecutables
 
-- [[../issues/CACH-B001|CACH-B001]] — Rediseñar Trabajos y jerarquía proyecto-evento
-- [[../issues/CACH-B002|CACH-B002]] — Simplificar experiencia mobile financiera
-- [[../issues/CACH-B003|CACH-B003]] — Cobro rápido y gestión de pendientes
-- [[../issues/CACH-B004|CACH-B004]] — Contratantes, facturación y liquidación neta
-- [[../issues/CACH-B005|CACH-B005]] — Importación, exportación y portabilidad de datos
-- [[../issues/CACH-B006|CACH-B006]] — Onboarding y acceso beta
-- [[../issues/CACH-B007|CACH-B007]] — Calendario unificado e interacción rápida
-- [[../issues/CACH-B008|CACH-B008]] — PWA, notificaciones y offline
-- [[../issues/CACH-B009|CACH-B009]] — Inteligencia financiera y features Pro
-- [[../issues/CACH-B010|CACH-B010]] — Tooling de agentes y modelos de desarrollo
-- [[../issues/CACH-B011|CACH-B011]] — Categorías, etiquetas y taxonomía
-- [[../issues/CACH-B012|CACH-B012]] — Perfil público, viralidad y referidos
-- [[../issues/CACH-B013|CACH-B013]] — Gestión documental por proyecto/evento
-- [[../issues/CACH-B014|CACH-B014]] — Endurecer agenda, cobros y captura del MVP
+- [[../issues/CACH-B0001|CACH-B0001]] — Rediseñar Trabajos y jerarquía proyecto-evento
+- [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
+- [[../issues/CACH-B0003|CACH-B0003]] — Cobro rápido y gestión de pendientes
+- [[../issues/CACH-B0004|CACH-B0004]] — Contratantes, facturación y liquidación neta
+- [[../issues/CACH-B0005|CACH-B0005]] — Importación, exportación y portabilidad de datos
+- [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta
+- [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interacción rápida
+- [[../issues/CACH-B0008|CACH-B0008]] — PWA, notificaciones y offline
+- [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro
+- [[../issues/CACH-B0010|CACH-B0010]] — Tooling de agentes y modelos de desarrollo
+- [[../issues/CACH-B0011|CACH-B0011]] — Categorías, etiquetas y taxonomía
+- [[../issues/CACH-B0012|CACH-B0012]] — Perfil público, viralidad y referidos
+- [[../issues/CACH-B0013|CACH-B0013]] — Gestión documental por proyecto/evento
+- [[../issues/CACH-B0014|CACH-B0014]] — Endurecer agenda, cobros y captura del MVP
 
 ## Clasificación de las 52 entradas
 
 | Fuente | Tipo PB | Cluster | Prioridad | Nota |
 |---|---|---|---|---|
-| #1 | contexto/guardrail | [[../issues/CACH-B007|CACH-B007]] | Alta | Mantener preferencia de fechas manuales y preselección. |
-| #2 | issue | [[../issues/CACH-B007|CACH-B007]] | Alta | Evento de un día por defecto; rango solo si cambia. |
-| #3 | issue | [[../issues/CACH-B002|CACH-B002]] | Alta | Resumen financiero colapsable en mobile. |
-| #4 | issue cluster | [[../issues/CACH-B001|CACH-B001]] | Alta | Absorbe rediseño de Trabajos, duplicados, badge y texto Proyecto. |
-| #5 | issue con decisión de datos | [[../issues/CACH-B004|CACH-B004]] | Alta | Entidad contratante y datos de facturación. |
-| #6 | issue | [[../issues/CACH-B007|CACH-B007]] | Media | Calendario único con filtros. |
-| #7 | issue con decisión UX/datos | [[../issues/CACH-B004|CACH-B004]] | Media | Ingresos/gastos unificados por proyecto como opción. |
-| #8 | issue pequeña | [[../issues/CACH-B001|CACH-B001]] | Alta | Trabajos antes que Dashboard. |
-| #9 | tooling interno | [[../issues/CACH-B010|CACH-B010]] | Media | Issues desde Codex replicando dependencias del contenedor. |
-| #10 | issue | [[../issues/CACH-B001|CACH-B001]] | Media | Notas editables en evento/proyecto. |
-| #11 | issue | [[../issues/CACH-B002|CACH-B002]] | Alta | Dashboard financiero reducido en mobile. |
-| #12 | release/proceso | [[../issues/CACH-B006|CACH-B006]] | Media | Sistema de releases. |
-| #13 | issue | [[../issues/CACH-B002|CACH-B002]] | Alta | Botones editar/eliminar demasiado grandes en mobile. |
-| #14 | issue | [[../issues/CACH-B002|CACH-B002]] | Alta | Simplificar formularios de ingresos/gastos en mobile. |
-| #15 | issue | [[../issues/CACH-B002|CACH-B002]] | Media | Alternativa mobile a tablas de ingresos/gastos. |
-| #16 | dependiente/spike | [[../issues/CACH-B011|CACH-B011]] | Baja | No implementar antes de resolver #39. |
-| #17 | issue beta | [[../issues/CACH-B006|CACH-B006]] | Alta | Invitación a beta con waitlist. |
-| #18 | subtarea beta | [[../issues/CACH-B006|CACH-B006]] | Baja | UI waitlist y código de invitación. |
-| #19 | beta/privacy | [[../issues/CACH-B006|CACH-B006]] | Media | Eventos de uso con consentimiento explícito. |
-| #20 | issue | [[../issues/CACH-B007|CACH-B007]] | Media | Modal/resumen al pulsar calendario. |
-| #21 | tooling interno | [[../issues/CACH-B010|CACH-B010]] | Baja | Skill autobrowse. |
-| #22 | tooling interno | [[../issues/CACH-B010|CACH-B010]] | Media | Crear issue desde notas/ideas. |
-| #23 | spike tooling | [[../issues/CACH-B010|CACH-B010]] | Media | LLM local 8B para desarrollo. |
-| #24 | spike tooling | [[../issues/CACH-B010|CACH-B010]] | Baja | Casos de uso del LLM local. |
-| #25 | spike tooling | [[../issues/CACH-B010|CACH-B010]] | Media | Routing inteligente entre modelos. |
-| #26 | issue crítica | [[../issues/CACH-B005|CACH-B005]] | Alta | Backup y exportación de datos. |
-| #27 | issue beta/UX | [[../issues/CACH-B006|CACH-B006]] | Alta | Onboarding corto hacia primer aha moment. |
-| #28 | issue Pro | [[../issues/CACH-B009|CACH-B009]] | Baja | Salud financiera por proyecto. |
-| #29 | issue Pro | [[../issues/CACH-B009|CACH-B009]] | Baja | Flujo de caja mensual. |
-| #30 | issue | [[../issues/CACH-B003|CACH-B003]] | Media | Recordatorio de cobro pendiente. |
-| #31 | infraestructura base | [[../issues/CACH-B008|CACH-B008]] | Media | Sistema de notificaciones. |
-| #32 | issue GTM | [[../issues/CACH-B012|CACH-B012]] | Baja | Perfil público y calendario compartible. |
-| #33 | spike UX | [[../issues/CACH-B001|CACH-B001]] | Baja | Plantillas de proyecto. |
-| #34 | spike estratégico | [[../issues/CACH-B004|CACH-B004]] | Baja | Cooperativa/colaborativo: decidir individual vs colaborativo. |
-| #35 | infraestructura | [[../issues/CACH-B008|CACH-B008]] | Media | Convertir Cachés en PWA. |
-| #36 | issue | [[../issues/CACH-B007|CACH-B007]] | Baja | Disponibilidad en calendario. |
-| #37 | issue Pro | [[../issues/CACH-B009|CACH-B009]] | Media | Objetivos de ingresos. |
-| #38 | issue post-MVP | [[../issues/CACH-B013|CACH-B013]] | Baja | Documentos por proyecto/evento. |
-| #39 | spike taxonomía | [[../issues/CACH-B011|CACH-B011]] | Media | Repensar categorías y etiquetas. |
-| #40 | infraestructura | [[../issues/CACH-B006|CACH-B006]] | Baja | i18n post-MVP. |
-| #41 | issue | [[../issues/CACH-B008|CACH-B008]] | Media | Recordatorio de eventos próximos. |
-| #42 | infraestructura | [[../issues/CACH-B008|CACH-B008]] | Media | Offline básico. |
-| #43 | spike GTM | [[../issues/CACH-B012|CACH-B012]] | Baja | Referidos para monetización. |
-| #44 | issue beta/GTM | [[../issues/CACH-B008|CACH-B008]] | Media | Resumen semanal automático. |
-| #45 | spike infra/coste | [[../issues/CACH-B008|CACH-B008]] | Baja | Periodicidad configurable de resúmenes. |
-| #46 | issue crítica de flujo | [[../issues/CACH-B003|CACH-B003]] | Alta | Marcar ingresos como cobrados rápido. |
-| #47 | issue Pro | [[../issues/CACH-B009|CACH-B009]] | Baja | Presupuestos por categoría de gasto. |
-| #48 | issue con decisión financiera | [[../issues/CACH-B004|CACH-B004]] | Alta | Liquidación neta de proyecto/evento. |
-| #49 | issue Pro | [[../issues/CACH-B009|CACH-B009]] | Media | Simulación de escenarios. |
-| #50 | issue Pro | [[../issues/CACH-B009|CACH-B009]] | Baja | Rentabilidad/hora al cerrar proyecto. |
-| #51 | spike datos/producto | [[../issues/CACH-B004|CACH-B004]] | Media | CRM ligero de contratación. |
-| #52 | issue crítica | [[../issues/CACH-B005|CACH-B005]] | Alta | Migración/importación de datos. |
+| #1 | contexto/guardrail | [[../issues/CACH-B0007|CACH-B0007]] | Alta | Mantener preferencia de fechas manuales y preselección. |
+| #2 | issue | [[../issues/CACH-B0007|CACH-B0007]] | Alta | Evento de un día por defecto; rango solo si cambia. |
+| #3 | issue | [[../issues/CACH-B0002|CACH-B0002]] | Alta | Resumen financiero colapsable en mobile. |
+| #4 | issue cluster | [[../issues/CACH-B0001|CACH-B0001]] | Alta | Absorbe rediseño de Trabajos, duplicados, badge y texto Proyecto. |
+| #5 | issue con decisión de datos | [[../issues/CACH-B0004|CACH-B0004]] | Alta | Entidad contratante y datos de facturación. |
+| #6 | issue | [[../issues/CACH-B0007|CACH-B0007]] | Media | Calendario único con filtros. |
+| #7 | issue con decisión UX/datos | [[../issues/CACH-B0004|CACH-B0004]] | Media | Ingresos/gastos unificados por proyecto como opción. |
+| #8 | issue pequeña | [[../issues/CACH-B0001|CACH-B0001]] | Alta | Trabajos antes que Dashboard. |
+| #9 | tooling interno | [[../issues/CACH-B0010|CACH-B0010]] | Media | Issues desde Codex replicando dependencias del contenedor. |
+| #10 | issue | [[../issues/CACH-B0001|CACH-B0001]] | Media | Notas editables en evento/proyecto. |
+| #11 | issue | [[../issues/CACH-B0002|CACH-B0002]] | Alta | Dashboard financiero reducido en mobile. |
+| #12 | release/proceso | [[../issues/CACH-B0006|CACH-B0006]] | Media | Sistema de releases. |
+| #13 | issue | [[../issues/CACH-B0002|CACH-B0002]] | Alta | Botones editar/eliminar demasiado grandes en mobile. |
+| #14 | issue | [[../issues/CACH-B0002|CACH-B0002]] | Alta | Simplificar formularios de ingresos/gastos en mobile. |
+| #15 | issue | [[../issues/CACH-B0002|CACH-B0002]] | Media | Alternativa mobile a tablas de ingresos/gastos. |
+| #16 | dependiente/spike | [[../issues/CACH-B0011|CACH-B0011]] | Baja | No implementar antes de resolver #39. |
+| #17 | issue beta | [[../issues/CACH-B0006|CACH-B0006]] | Alta | Invitación a beta con waitlist. |
+| #18 | subtarea beta | [[../issues/CACH-B0006|CACH-B0006]] | Baja | UI waitlist y código de invitación. |
+| #19 | beta/privacy | [[../issues/CACH-B0006|CACH-B0006]] | Media | Eventos de uso con consentimiento explícito. |
+| #20 | issue | [[../issues/CACH-B0007|CACH-B0007]] | Media | Modal/resumen al pulsar calendario. |
+| #21 | tooling interno | [[../issues/CACH-B0010|CACH-B0010]] | Baja | Skill autobrowse. |
+| #22 | tooling interno | [[../issues/CACH-B0010|CACH-B0010]] | Media | Crear issue desde notas/ideas. |
+| #23 | spike tooling | [[../issues/CACH-B0010|CACH-B0010]] | Media | LLM local 8B para desarrollo. |
+| #24 | spike tooling | [[../issues/CACH-B0010|CACH-B0010]] | Baja | Casos de uso del LLM local. |
+| #25 | spike tooling | [[../issues/CACH-B0010|CACH-B0010]] | Media | Routing inteligente entre modelos. |
+| #26 | issue crítica | [[../issues/CACH-B0005|CACH-B0005]] | Alta | Backup y exportación de datos. |
+| #27 | issue beta/UX | [[../issues/CACH-B0006|CACH-B0006]] | Alta | Onboarding corto hacia primer aha moment. |
+| #28 | issue Pro | [[../issues/CACH-B0009|CACH-B0009]] | Baja | Salud financiera por proyecto. |
+| #29 | issue Pro | [[../issues/CACH-B0009|CACH-B0009]] | Baja | Flujo de caja mensual. |
+| #30 | issue | [[../issues/CACH-B0003|CACH-B0003]] | Media | Recordatorio de cobro pendiente. |
+| #31 | infraestructura base | [[../issues/CACH-B0008|CACH-B0008]] | Media | Sistema de notificaciones. |
+| #32 | issue GTM | [[../issues/CACH-B0012|CACH-B0012]] | Baja | Perfil público y calendario compartible. |
+| #33 | spike UX | [[../issues/CACH-B0001|CACH-B0001]] | Baja | Plantillas de proyecto. |
+| #34 | spike estratégico | [[../issues/CACH-B0004|CACH-B0004]] | Baja | Cooperativa/colaborativo: decidir individual vs colaborativo. |
+| #35 | infraestructura | [[../issues/CACH-B0008|CACH-B0008]] | Media | Convertir Cachés en PWA. |
+| #36 | issue | [[../issues/CACH-B0007|CACH-B0007]] | Baja | Disponibilidad en calendario. |
+| #37 | issue Pro | [[../issues/CACH-B0009|CACH-B0009]] | Media | Objetivos de ingresos. |
+| #38 | issue post-MVP | [[../issues/CACH-B0013|CACH-B0013]] | Baja | Documentos por proyecto/evento. |
+| #39 | spike taxonomía | [[../issues/CACH-B0011|CACH-B0011]] | Media | Repensar categorías y etiquetas. |
+| #40 | infraestructura | [[../issues/CACH-B0006|CACH-B0006]] | Baja | i18n post-MVP. |
+| #41 | issue | [[../issues/CACH-B0008|CACH-B0008]] | Media | Recordatorio de eventos próximos. |
+| #42 | infraestructura | [[../issues/CACH-B0008|CACH-B0008]] | Media | Offline básico. |
+| #43 | spike GTM | [[../issues/CACH-B0012|CACH-B0012]] | Baja | Referidos para monetización. |
+| #44 | issue beta/GTM | [[../issues/CACH-B0008|CACH-B0008]] | Media | Resumen semanal automático. |
+| #45 | spike infra/coste | [[../issues/CACH-B0008|CACH-B0008]] | Baja | Periodicidad configurable de resúmenes. |
+| #46 | issue crítica de flujo | [[../issues/CACH-B0003|CACH-B0003]] | Alta | Marcar ingresos como cobrados rápido. |
+| #47 | issue Pro | [[../issues/CACH-B0009|CACH-B0009]] | Baja | Presupuestos por categoría de gasto. |
+| #48 | issue con decisión financiera | [[../issues/CACH-B0004|CACH-B0004]] | Alta | Liquidación neta de proyecto/evento. |
+| #49 | issue Pro | [[../issues/CACH-B0009|CACH-B0009]] | Media | Simulación de escenarios. |
+| #50 | issue Pro | [[../issues/CACH-B0009|CACH-B0009]] | Baja | Rentabilidad/hora al cerrar proyecto. |
+| #51 | spike datos/producto | [[../issues/CACH-B0004|CACH-B0004]] | Media | CRM ligero de contratación. |
+| #52 | issue crítica | [[../issues/CACH-B0005|CACH-B0005]] | Alta | Migración/importación de datos. |
 
 ## Duplicados y absorciones
 
-- "Rediseñar listado Trabajos", "Badge Confirmado" y "Enlace Proyecto X" quedan absorbidos por [[../issues/CACH-B001|CACH-B001]].
-- La idea capturada de marcar un evento como cobrado rápido queda absorbida por [[../issues/CACH-B003|CACH-B003]].
-- #16 depende de #39 y no debe implementarse antes de [[../issues/CACH-B011|CACH-B011]].
+- "Rediseñar listado Trabajos", "Badge Confirmado" y "Enlace Proyecto X" quedan absorbidos por [[../issues/CACH-B0001|CACH-B0001]].
+- La idea capturada de marcar un evento como cobrado rápido queda absorbida por [[../issues/CACH-B0003|CACH-B0003]].
+- #16 depende de #39 y no debe implementarse antes de [[../issues/CACH-B0011|CACH-B0011]].
 - #30 y #46 forman un solo flujo de cobro pendiente.
 - #31, #35, #41, #42, #44 y #45 forman la columna de PWA/notificaciones/offline.
 - #26 y #52 son el bloque de portabilidad de datos previo a beta.
 
 ## Entradas Añadidas Desde Barrido Técnico
 
-- [[../issues/CACH-B014|CACH-B014]] recoge los hallazgos de [[../knowledge/PB-ZK-20260504-technical-audit|PB-ZK-20260504-TECH-AUDIT]] que afectan a confianza del MVP antes de beta.
+- [[../issues/CACH-B0014|CACH-B0014]] recoge los hallazgos de [[../knowledge/PB-ZK-20260504-technical-audit|PB-ZK-20260504-TECH-AUDIT]] que afectan a confianza del MVP antes de beta.
 
 ## Priorización sugerida
 
-1. Confianza del MVP: [[../issues/CACH-B014|CACH-B014]], [[../issues/CACH-B005|CACH-B005]] y [[../issues/CACH-B006|CACH-B006]].
-2. UX core: [[../issues/CACH-B001|CACH-B001]], [[../issues/CACH-B002|CACH-B002]] y [[../issues/CACH-B007|CACH-B007]].
-3. Cobro y datos financieros reales: [[../issues/CACH-B003|CACH-B003]] y [[../issues/CACH-B004|CACH-B004]].
-4. Infra de experiencia móvil: [[../issues/CACH-B008|CACH-B008]].
-5. Pro/GTM: [[../issues/CACH-B009|CACH-B009]] y [[../issues/CACH-B012|CACH-B012]].
+1. Confianza del MVP: [[../issues/CACH-B0014|CACH-B0014]], [[../issues/CACH-B0005|CACH-B0005]] y [[../issues/CACH-B0006|CACH-B0006]].
+2. UX core: [[../issues/CACH-B0001|CACH-B0001]], [[../issues/CACH-B0002|CACH-B0002]] y [[../issues/CACH-B0007|CACH-B0007]].
+3. Cobro y datos financieros reales: [[../issues/CACH-B0003|CACH-B0003]] y [[../issues/CACH-B0004|CACH-B0004]].
+4. Infra de experiencia móvil: [[../issues/CACH-B0008|CACH-B0008]].
+5. Pro/GTM: [[../issues/CACH-B0009|CACH-B0009]] y [[../issues/CACH-B0012|CACH-B0012]].

--- a/docs/project/releases/RELEASE-0.1-beta.md
+++ b/docs/project/releases/RELEASE-0.1-beta.md
@@ -24,13 +24,13 @@ La beta no busca parecer completa. Busca que Cachés sea fiable para probar con 
 
 ## Scope
 
-- [[../issues/CACH-B014]] — Endurecer agenda, cobros y captura del MVP
-- [[../issues/CACH-B005]] — Importacion, exportacion y portabilidad de datos
-- [[../issues/CACH-B006]] — Onboarding y acceso beta
-- [[../issues/CACH-B002]] — Simplificar experiencia mobile financiera
-- [[../issues/CACH-B003]] — Cobro rapido y gestion de pendientes
-- [[../issues/CACH-B001]] — Rediseñar Trabajos y jerarquia proyecto-evento
-- [[../issues/CACH-B007]] — Calendario unificado e interaccion rapida
+- [[../issues/CACH-B0014]] — Endurecer agenda, cobros y captura del MVP
+- [[../issues/CACH-B0005]] — Importacion, exportacion y portabilidad de datos
+- [[../issues/CACH-B0006]] — Onboarding y acceso beta
+- [[../issues/CACH-B0002]] — Simplificar experiencia mobile financiera
+- [[../issues/CACH-B0003]] — Cobro rapido y gestion de pendientes
+- [[../issues/CACH-B0001]] — Rediseñar Trabajos y jerarquia proyecto-evento
+- [[../issues/CACH-B0007]] — Calendario unificado e interaccion rapida
 
 ## Out Of Scope
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "agents:parallel": "node .opencode/scripts/run-parallel-agents.mjs",
     "pb:init": "node scripts/product-brain-sync.mjs init",
     "pb:status": "node scripts/product-brain-sync.mjs status",
+    "pb:check": "node scripts/product-brain-check.mjs",
     "pb:pull": "node scripts/product-brain-sync.mjs pull",
     "pb:push": "node scripts/product-brain-sync.mjs push",
     "pb:capture": "node scripts/product-brain-capture.mjs",

--- a/scripts/product-brain-check.mjs
+++ b/scripts/product-brain-check.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { dirname, join, normalize, relative, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)))
+const brainRoot = process.env.PRODUCT_BRAIN_REPO_PATH
+  ? resolve(process.env.PRODUCT_BRAIN_REPO_PATH)
+  : join(repoRoot, 'docs', 'project')
+
+const indexChecks = [
+  ['indexes/issues.index.md', 'issues'],
+  ['indexes/decisions.index.md', 'decisions'],
+  ['indexes/knowledge.index.md', 'knowledge'],
+  ['indexes/releases.index.md', 'releases'],
+]
+
+const errors = []
+const warnings = []
+
+function toPosix(value) {
+  return value.split(sep).join('/')
+}
+
+function listMarkdownFiles(dir) {
+  const files = []
+
+  function walk(current) {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const fullPath = join(current, entry.name)
+      if (entry.isDirectory()) {
+        walk(fullPath)
+      } else if (entry.name.endsWith('.md')) {
+        files.push(fullPath)
+      }
+    }
+  }
+
+  walk(dir)
+  return files.sort()
+}
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---/)
+  if (!match) {
+    return null
+  }
+
+  const result = { aliases: [] }
+  const lines = match[1].split('\n')
+  let activeList = null
+
+  for (const line of lines) {
+    const listItem = line.match(/^\s+-\s*(.+?)\s*$/)
+    if (activeList && listItem) {
+      result[activeList].push(listItem[1])
+      continue
+    }
+
+    const keyValue = line.match(/^([a-zA-Z0-9_-]+):\s*(.*?)\s*$/)
+    if (!keyValue) {
+      activeList = null
+      continue
+    }
+
+    const [, key, value] = keyValue
+    if (!value) {
+      if (key === 'aliases') {
+        activeList = 'aliases'
+      } else {
+        activeList = null
+      }
+      continue
+    }
+
+    result[key] = value
+    activeList = null
+  }
+
+  return result
+}
+
+function stripCodeFences(content) {
+  return content.replace(/```[\s\S]*?```/g, '')
+}
+
+function normalizeTarget(fromRel, target) {
+  const withoutHash = target.split('#')[0].trim()
+  if (!withoutHash || withoutHash.includes('://')) {
+    return null
+  }
+
+  if (
+    withoutHash.includes('...') ||
+    withoutHash.includes('XXXX') ||
+    withoutHash.includes('YYYY')
+  ) {
+    return null
+  }
+
+  if (withoutHash.includes('/') || withoutHash.startsWith('.')) {
+    const relDir = dirname(fromRel)
+    return toPosix(normalize(join(relDir, withoutHash))).replace(/\.md$/, '')
+  }
+
+  return withoutHash
+}
+
+function addLookup(map, key, rel) {
+  if (!key) return
+  if (!map.has(key)) {
+    map.set(key, [])
+  }
+  map.get(key).push(rel)
+}
+
+function wikilinkTargets(content) {
+  const links = []
+  const safeContent = stripCodeFences(content)
+
+  for (const match of safeContent.matchAll(/\[\[([^\]]+)\]\]/g)) {
+    const target = match[1].split('|')[0].trim()
+    links.push(target)
+  }
+
+  return links
+}
+
+function bulletTargets(content, indexRel) {
+  const targets = new Set()
+
+  for (const line of content.split('\n')) {
+    const bullet = line.match(/^\s*-\s+\[\[([^\]]+)\]\]/)
+    if (!bullet) continue
+
+    const normalized = normalizeTarget(indexRel, bullet[1].split('|')[0])
+    if (normalized) {
+      targets.add(normalized)
+    }
+  }
+
+  return targets
+}
+
+if (!existsSync(brainRoot)) {
+  errors.push(`No existe Product Brain: ${brainRoot}`)
+} else {
+  const files = listMarkdownFiles(brainRoot)
+  const docs = new Map()
+  const byBasename = new Map()
+  const byId = new Map()
+  const byAlias = new Map()
+
+  for (const file of files) {
+    const rel = toPosix(relative(brainRoot, file))
+    const key = rel.replace(/\.md$/, '')
+    const basename = key.split('/').at(-1)
+    const content = readFileSync(file, 'utf8')
+    const frontmatter = parseFrontmatter(content)
+
+    docs.set(key, { rel, key, basename, content, frontmatter })
+    addLookup(byBasename, basename, key)
+
+    if (!rel.startsWith('templates/') && !frontmatter) {
+      errors.push(`${rel}: falta frontmatter`)
+    }
+
+    if (frontmatter?.id) {
+      addLookup(byId, frontmatter.id, key)
+    }
+
+    for (const alias of frontmatter?.aliases ?? []) {
+      addLookup(byAlias, alias, key)
+    }
+
+    if (rel.startsWith('issues/') && rel !== 'issues/README.md') {
+      if (frontmatter?.id !== basename) {
+        errors.push(`${rel}: id '${frontmatter?.id ?? '(sin id)'}' no coincide con filename '${basename}'`)
+      }
+
+      const h1 = content.match(/^#\s+(.+)$/m)?.[1]
+      if (!h1?.startsWith(`${basename} `) && h1 !== basename) {
+        errors.push(`${rel}: H1 debe empezar por '${basename}'`)
+      }
+    }
+  }
+
+  for (const [id, locations] of byId.entries()) {
+    if (locations.length > 1) {
+      errors.push(`id duplicado '${id}': ${locations.join(', ')}`)
+    }
+  }
+
+  for (const [alias, locations] of byAlias.entries()) {
+    if (locations.length > 1) {
+      warnings.push(`alias duplicado '${alias}': ${locations.join(', ')}`)
+    }
+  }
+
+  for (const doc of docs.values()) {
+    for (const rawTarget of wikilinkTargets(doc.content)) {
+      const target = normalizeTarget(doc.rel, rawTarget)
+      if (!target) continue
+
+      const matches = target.includes('/') || target.startsWith('.')
+        ? docs.has(target) ? [target] : []
+        : [
+            ...(byBasename.get(target) ?? []),
+            ...(byId.get(target) ?? []),
+            ...(byAlias.get(target) ?? []),
+          ]
+
+      if (matches.length === 0) {
+        errors.push(`${doc.rel}: wikilink roto -> ${rawTarget}`)
+      }
+    }
+  }
+
+  for (const [indexRel, folder] of indexChecks) {
+    const indexKey = indexRel.replace(/\.md$/, '')
+    const indexDoc = docs.get(indexKey)
+    if (!indexDoc) {
+      errors.push(`${indexRel}: índice obligatorio no encontrado`)
+      continue
+    }
+
+    const expected = new Set(
+      [...docs.keys()].filter((key) => key.startsWith(`${folder}/`) && key !== `${folder}/README`),
+    )
+    const actual = bulletTargets(indexDoc.content, indexRel)
+
+    for (const target of expected) {
+      if (!actual.has(target)) {
+        errors.push(`${indexRel}: falta entrada para ${target}`)
+      }
+    }
+
+    for (const target of actual) {
+      if (!expected.has(target)) {
+        errors.push(`${indexRel}: entrada sobrante o rota ${target}`)
+      }
+    }
+  }
+}
+
+for (const warning of warnings) {
+  console.warn(`[pb:check] warning: ${warning}`)
+}
+
+if (errors.length > 0) {
+  for (const error of errors) {
+    console.error(`[pb:check] error: ${error}`)
+  }
+  console.error(`[pb:check] ${errors.length} error(es), ${warnings.length} warning(s)`)
+  process.exitCode = 1
+} else {
+  console.log(`[pb:check] OK: Product Brain consistente (${warnings.length} warning(s))`)
+}


### PR DESCRIPTION
## Resumen

- Añade `npm run pb:check` para validar frontmatter, índices y wikilinks de `docs/project/`.
- Normaliza los wikilinks restantes al ID canónico completo (`CACH-0026`, `CACH-B0001`, etc.).
- Documenta la ruta mínima de lectura para agentes en `START_HERE.md`.
- Añade una nota ZK sobre Product Brain legible por IA y actualiza `.memory/feedback_product_brain.md`.

## Issues enlazadas

Closes #50

## Verificacion

- [x] `npm run pb:check`
- [x] `npm run lint`
- [x] `npm run build` (mantiene warning conocido de chunk > 500 kB)
- [x] `npm run pb:status` tras `npm run pb:push`: repo y vault sincronizados

## Cierre de issues

La issue enlazada debe permanecer abierta mientras esta PR este abierta. Se cerrara automaticamente al merge por `Closes #50`.

## Rama, merge y produccion

- [x] La rama parte de `main` actualizado.
- [x] Esta PR apunta a `main`.
- [x] Cambio de docs/tooling; no requiere verificacion visual de app.
- [x] Tras merge correcto contra `main`, se elimino la rama remota y se borro la rama local desde `main` actualizado.

## Memoria

- [x] He revisado issue/contexto, diff y commits de la rama contra la base.
- [x] He actualizado `.memory/`.
- [x] No se han guardado secretos ni datos sensibles.

Estado de memoria: actualizada en `.memory/feedback_product_brain.md`

## Notas

- Product Brain sincronizado al vault de Obsidian con `npm run pb:push`.
