### PR TITLE
docs: link RELEASE-0.1-beta to GitHub Release and Milestone

### DIFF
--- a/docs/project/releases/RELEASE-0.1-beta.md
+++ b/docs/project/releases/RELEASE-0.1-beta.md
@@ -3,7 +3,9 @@ id: RELEASE-0.1-beta
 type: release
 status: Planned
 created: 2026-05-04
-updated: 2026-05-04
+updated: 2026-05-05
+github_release: https://github.com/dignacioconde/culturApp/releases/tag/RELEASE-0.1-beta
+milestone: https://github.com/dignacioconde/culturApp/milestone/1
 aliases:
   - Primera beta privada
 tags:
@@ -52,3 +54,37 @@ La beta no busca parecer completa. Busca que Cachés sea fiable para probar con 
 
 - [[../context/beta-readiness-risk-map-20260504]]
 - [[../decisions/ADR-0002-beta-trust-before-pro]]
+
+## Sync
+
+Las releases del Product Brain se vinculan a GitHub Release y Milestone.
+
+### Flujo actual (manual)
+
+1. Crear GitHub Release con `gh release create <tag> --title "..." --notes "..."`.
+2. Crear Milestone con `gh api repos/<owner>/<repo>/milestones --method POST -f title="..."`.
+3. Vincular issues al milestone desde GitHub UI o API.
+4. Actualizar documento del Product Brain con `github_release` y `milestone` en el frontmatter.
+5. Commitear y pushear cambios.
+
+### Mejora futura (automatica)
+
+Propuesta: crear script `scripts/github-release-sync.mjs` que:
+- Acepte tag de release como argumento
+- Cree GitHub Release automaticamente desde el tag de git
+- Cree Milestone si no existe
+- Pida issues a vincular (seleccion multiple)
+- Actualice el documento del Product Brain con los enlaces
+
+### Comandos utiles
+
+```bash
+# Listar releases
+gh release list
+
+# Ver milestone
+gh api repos/dignacioconde/culturApp/milestones
+
+# Vincular issue a milestone
+gh issue edit <num> --milestone "RELEASE-0.1-beta"
+```


### PR DESCRIPTION
## Summary

- Create GitHub Release `RELEASE-0.1-beta` linked to Product Brain documentation
- Create GitHub Milestone #1 for the release scope
- Update `docs/project/releases/RELEASE-0.1-beta.md` with `github_release` and `milestone` links
- Document sync workflow (manual + future automation proposal)

## Criteria verification

- [x] RELEASE-0.1-beta GitHub Release created with description linked to Product Brain
- [x] Milestone RELEASE-0.1-beta created in GitHub
- [x] RELEASE-0.1-beta.md updated with references
- [x] Sync system documented

## Memoria

actualizada en `.memory/` — no aplica. Es documentación operativa de sincronización Product Brain/GitHub.

## Related

Closes #53