### PR TITLE
feat: completa rediseño visual backstage (Closes #45)

### DIFF
--- a/.opencode/AGENT_STATE.md
+++ b/.opencode/AGENT_STATE.md
@@ -26,6 +26,12 @@ Estados sugeridos: `info`, `bloqueo`, `schema_changed`, `api_changed`, `ui_chang
 
 ## Estado por agente
 
+### cultura-lead
+
+- Estado: in_progress
+- Ownership actual: issue #45 - rediseño visual backstage
+- Ultima actualizacion: 2026-05-05T12:00 CET
+
 ### cultura-data
 
 - Estado: idle

--- a/src/components/ui/Input.jsx
+++ b/src/components/ui/Input.jsx
@@ -1,7 +1,7 @@
 import { Children, isValidElement, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { CalendarDays, Check, ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react'
 
-const fieldBaseClass = 'w-full rounded-lg border bg-white px-3 py-3 text-sm text-gray-900 shadow-sm transition-colors placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:border-gray-200 disabled:bg-gray-50 disabled:text-gray-500'
+const fieldBaseClass = 'w-full rounded-lg border bg-white px-3 py-3 text-sm text-gray-900 shadow-sm transition-colors placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary-500)] focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:border-gray-200 disabled:bg-gray-50 disabled:text-gray-500'
 const monthFormatter = new Intl.DateTimeFormat('es-ES', { month: 'long', year: 'numeric' })
 const weekDays = ['L', 'M', 'X', 'J', 'V', 'S', 'D']
 const timeOptions = Array.from({ length: 96 }, (_, index) => {
@@ -25,7 +25,7 @@ function FieldWrapper({ label, error, inputId, errorId, children }) {
 function getFieldStateClass(error) {
   return error
     ? 'border-red-400 focus-visible:border-red-500 focus-visible:ring-red-500'
-    : 'border-gray-300 focus-visible:border-indigo-500'
+    : 'border-gray-300 focus-visible:border-[var(--color-primary-500)]'
 }
 
 function parseDateValue(value) {
@@ -206,7 +206,7 @@ function DateInput({
               setVisibleMonth(selectedDate ?? new Date())
               setShowCalendar((prev) => !prev)
             }}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary-500)] rounded"
           >
             <CalendarDays size={18} />
           </button>
@@ -218,7 +218,7 @@ function DateInput({
                 type="button"
                 onClick={() => moveMonth(-1)}
                 aria-label="Mes anterior"
-                className="inline-flex h-10 w-10 items-center justify-center rounded-lg text-gray-600 hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-lg text-gray-600 hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary-500)]"
               >
                 <ChevronLeft size={20} />
               </button>
@@ -227,7 +227,7 @@ function DateInput({
                 type="button"
                 onClick={() => moveMonth(1)}
                 aria-label="Mes siguiente"
-                className="inline-flex h-10 w-10 items-center justify-center rounded-lg text-gray-600 hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-lg text-gray-600 hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary-500)]"
               >
                 <ChevronRight size={20} />
               </button>
@@ -246,11 +246,11 @@ function DateInput({
                     key={dayValue}
                     type="button"
                     onClick={() => selectDate(date)}
-                    className={`flex h-10 items-center justify-center rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
+                    className={`flex h-10 items-center justify-center rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary-500)] ${
                       isSelected
-                        ? 'bg-indigo-600 text-white hover:bg-indigo-700'
-                        : 'text-gray-800 hover:bg-indigo-50 hover:text-indigo-700'
-                    } ${isOutsideMonth && !isSelected ? 'text-gray-400' : ''} ${isToday && !isSelected ? 'ring-1 ring-indigo-200' : ''}`}
+                        ? 'bg-[var(--color-primary-500)] text-white hover:bg-[var(--color-primary-600)]'
+                        : 'text-gray-800 hover:bg-[#fef3f2] hover:text-[var(--color-primary-600)]'
+                    } ${isOutsideMonth && !isSelected ? 'text-gray-400' : ''} ${isToday && !isSelected ? 'ring-1 ring-[var(--color-primary-200)]' : ''}`}
                   >
                     {date.getDate()}
                   </button>
@@ -261,7 +261,7 @@ function DateInput({
               <button type="button" onClick={clearDate} className="min-h-10 rounded-lg px-3 text-sm font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-800">
                 Borrar
               </button>
-              <button type="button" onClick={() => selectDate(new Date())} className="min-h-10 rounded-lg px-3 text-sm font-medium text-indigo-600 hover:bg-indigo-50">
+              <button type="button" onClick={() => selectDate(new Date())} className="min-h-10 rounded-lg px-3 text-sm font-medium text-[var(--color-primary-500)] hover:bg-[#fef3f2]">
                 Hoy
               </button>
             </div>
@@ -504,9 +504,9 @@ export function Select({
                   aria-selected={isSelected}
                   disabled={option.disabled}
                   onClick={() => handleSelect(option.value)}
-                  className="flex min-h-11 w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-gray-800 transition-colors hover:bg-indigo-50 hover:text-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 disabled:cursor-not-allowed disabled:text-gray-400"
+                  className="flex min-h-11 w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-gray-800 transition-colors hover:bg-[#fef3f2] hover:text-[var(--color-primary-600)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary-500)] disabled:cursor-not-allowed disabled:text-gray-400"
                 >
-                  <Check size={16} className={`shrink-0 ${isSelected ? 'text-indigo-600' : 'text-transparent'}`} />
+                  <Check size={16} className={`shrink-0 ${isSelected ? 'text-[var(--color-primary-500)]' : 'text-transparent'}`} />
                   <span className="min-w-0 flex-1 whitespace-nowrap">{option.label}</span>
                 </button>
               )

--- a/src/components/ui/Modal.jsx
+++ b/src/components/ui/Modal.jsx
@@ -36,7 +36,7 @@ export function Modal({ isOpen, onClose, title, children }) {
             type="button"
             onClick={onClose}
             aria-label="Cerrar"
-            className="inline-flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-lg text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+            className="inline-flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-lg text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary-500)] focus-visible:ring-offset-2"
           >
             <X size={20} />
           </button>

--- a/src/pages/Auth/Login.jsx
+++ b/src/pages/Auth/Login.jsx
@@ -35,7 +35,7 @@ export default function Login() {
     <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
       <div className="bg-white rounded-xl shadow-sm border border-gray-200 w-full max-w-md p-6 sm:p-8">
         <div className="flex flex-col items-center gap-2 mb-8">
-          <div className="w-10 h-10 bg-indigo-600 rounded-xl flex items-center justify-center">
+          <div className="w-10 h-10 bg-[var(--color-primary-500)] rounded-xl flex items-center justify-center">
             <Music size={20} className="text-white" />
           </div>
           <h1 className="text-xl font-semibold text-gray-900">Cachés</h1>
@@ -71,7 +71,7 @@ export default function Login() {
 
         <p className="text-sm text-center text-gray-500 mt-6">
           ¿No tienes cuenta?{' '}
-          <Link to="/register" className="text-indigo-600 font-medium hover:underline">
+          <Link to="/register" className="text-[var(--color-primary-500)] font-medium hover:underline">
             Regístrate
           </Link>
         </p>

--- a/src/pages/Auth/Register.jsx
+++ b/src/pages/Auth/Register.jsx
@@ -43,7 +43,7 @@ export default function Register() {
     <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
       <div className="bg-white rounded-xl shadow-sm border border-gray-200 w-full max-w-md p-6 sm:p-8">
         <div className="flex flex-col items-center gap-2 mb-8">
-          <div className="w-10 h-10 bg-indigo-600 rounded-xl flex items-center justify-center">
+          <div className="w-10 h-10 bg-[var(--color-primary-500)] rounded-xl flex items-center justify-center">
             <Music size={20} className="text-white" />
           </div>
           <h1 className="text-xl font-semibold text-gray-900">Cachés</h1>
@@ -99,7 +99,7 @@ export default function Register() {
 
         <p className="text-sm text-center text-gray-500 mt-6">
           ¿Ya tienes cuenta?{' '}
-          <Link to="/login" className="text-indigo-600 font-medium hover:underline">
+          <Link to="/login" className="text-[var(--color-primary-500)] font-medium hover:underline">
             Inicia sesión
           </Link>
         </p>

--- a/src/pages/Calendar/CalendarEvents.jsx
+++ b/src/pages/Calendar/CalendarEvents.jsx
@@ -175,7 +175,7 @@ export default function CalendarEvents() {
           <div className="w-full lg:w-80 bg-white rounded-xl border border-gray-200 p-5 flex flex-col gap-4">
             <div className="flex items-start justify-between">
               <div className="w-3 h-3 rounded-full mt-1 flex-shrink-0" style={{ backgroundColor: selectedEvent.color ?? '#4f98a3' }} />
-              <button onClick={() => setSelectedEvent(null)} className="text-gray-400 hover:text-gray-600 -mr-1 -mt-1 p-1.5 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" aria-label="Cerrar panel">
+              <button onClick={() => setSelectedEvent(null)} className="text-gray-400 hover:text-gray-600 -mr-1 -mt-1 p-1.5 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary-500)]" aria-label="Cerrar panel">
                 <X size={20} />
               </button>
             </div>
@@ -209,7 +209,7 @@ export default function CalendarEvents() {
                 return project ? (
                   <div className="flex items-start justify-between gap-3">
                     <span>Proyecto</span>
-                    <Link to={`/projects/${project.id}`} className="max-w-44 truncate text-right text-indigo-600 hover:underline">
+                    <Link to={`/projects/${project.id}`} className="max-w-44 truncate text-right text-[var(--color-primary-500)] hover:underline">
                       {project.name}
                     </Link>
                   </div>

--- a/src/pages/Calendar/CalendarProjects.jsx
+++ b/src/pages/Calendar/CalendarProjects.jsx
@@ -162,7 +162,7 @@ export default function CalendarProjects() {
           <div className="w-full lg:w-80 bg-white rounded-xl border border-gray-200 p-5 flex flex-col gap-4">
             <div className="flex items-start justify-between">
               <div className="w-3 h-3 rounded-full mt-1 flex-shrink-0" style={{ backgroundColor: selectedProject.color ?? '#4f98a3' }} />
-              <button onClick={() => setSelectedProject(null)} className="text-gray-400 hover:text-gray-600 -mr-1 -mt-1 p-1.5 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" aria-label="Cerrar panel">
+              <button onClick={() => setSelectedProject(null)} className="text-gray-400 hover:text-gray-600 -mr-1 -mt-1 p-1.5 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary-500)]" aria-label="Cerrar panel">
                 <X size={20} />
               </button>
             </div>

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -175,13 +175,13 @@ export default function Dashboard() {
               <div className="grid grid-cols-2 rounded-lg border border-gray-200 overflow-hidden text-sm sm:w-auto">
                 <button
                   onClick={() => setCriteria('cash_flow')}
-                  className={`px-3 py-2 transition-colors ${criteria === 'cash_flow' ? 'bg-indigo-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+                  className={`px-3 py-2 transition-colors ${criteria === 'cash_flow' ? 'bg-[var(--color-primary-500)] text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
                 >
                   Cobros
                 </button>
                 <button
                   onClick={() => setCriteria('project_active')}
-                  className={`px-3 py-2 border-l border-gray-200 transition-colors ${criteria === 'project_active' ? 'bg-indigo-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+                  className={`px-3 py-2 border-l border-gray-200 transition-colors ${criteria === 'project_active' ? 'bg-[var(--color-primary-500)] text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
                 >
                   Proyectos
                 </button>
@@ -219,7 +219,7 @@ export default function Dashboard() {
               value={formatCurrency(kpis.grossExpected)}
               subtitle={criteria === 'cash_flow' ? 'Fecha de cobro en el mes' : 'Proyectos activos en el mes'}
               icon={TrendingUp}
-              color="indigo"
+              color="red"
             />
             <KpiCard
               title="Ingresos cobrados"
@@ -240,7 +240,7 @@ export default function Dashboard() {
               value={kpis.billableHours > 0 ? formatCurrencyPerHour(kpis.grossHourlyRate) : '—'}
               subtitle={`Solo eventos cobrados · ${formatHours(kpis.billableHours)} h`}
               icon={Timer}
-              color="indigo"
+              color="red"
             />
             <KpiCard
               title="Beneficio neto"
@@ -323,10 +323,10 @@ export default function Dashboard() {
           <Card className="p-5">
             <div className="flex items-start justify-between gap-3 mb-4">
               <div className="flex items-center gap-2 min-w-0">
-                <FolderOpen size={18} className="text-indigo-500 flex-shrink-0" />
+                <FolderOpen size={18} className="text-[var(--color-primary-500)] flex-shrink-0" />
                 <h2 className="text-base font-semibold text-gray-900">Proyectos activos</h2>
               </div>
-              <span className="rounded-full bg-indigo-50 px-2.5 py-1 text-xs font-medium text-indigo-700 whitespace-nowrap">
+              <span className="rounded-full bg-[#fef3f2] px-2.5 py-1 text-xs font-medium text-[var(--color-primary-600)] whitespace-nowrap">
                 {activeProjects.length}
               </span>
             </div>

--- a/src/pages/Dashboard/KpiCard.jsx
+++ b/src/pages/Dashboard/KpiCard.jsx
@@ -5,14 +5,12 @@ export function KpiCard({ title, value, subtitle, icon: Icon, color = 'red', pro
     red: 'bg-[#F9EDEB] text-[#C94035] ring-[#F9EDEB]',
     green: 'bg-[#E8F4EF] text-[#2D6A4F] ring-[#E8F4EF]',
     amber: 'bg-[#FDF5E4] text-[#D4921A] ring-[#FDF5E4]',
-    indigo: 'bg-[#eef2ff] text-[#6366f1] ring-[#eef2ff]',
   }
 
   const progressBg = {
     red: 'bg-[#C94035]',
     green: 'bg-[#2D6A4F]',
     amber: 'bg-[#D4921A]',
-    indigo: 'bg-[#6366f1]',
   }
 
   return (

--- a/src/pages/Events/EventDetail.jsx
+++ b/src/pages/Events/EventDetail.jsx
@@ -226,20 +226,20 @@ export default function EventDetail() {
 
           {/* Proyecto asociado - más prominente */}
           {project && (
-            <Card className="p-4 bg-gradient-to-r from-indigo-50 to-purple-50 border-indigo-100">
+            <Card className="p-4 bg-[#fef3f2] border-[var(--color-primary-200)]">
               <div className="flex items-center justify-between gap-4">
                 <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 rounded-lg bg-indigo-100 flex items-center justify-center">
-                    <FolderOpen size={20} className="text-indigo-600" />
+                  <div className="w-10 h-10 rounded-lg bg-[#fef3f2] flex items-center justify-center">
+                    <FolderOpen size={20} className="text-[var(--color-primary-500)]" />
                   </div>
                   <div>
-                    <p className="text-xs text-indigo-600 font-medium">Pertenece al proyecto</p>
+                    <p className="text-xs text-[var(--color-primary-500)] font-medium">Pertenece al proyecto</p>
                     <Link
                       to={`/projects/${project.id}`}
-                      className="text-sm font-semibold text-gray-900 hover:text-indigo-700 hover:underline flex items-center gap-1"
+                      className="text-sm font-semibold text-gray-900 hover:text-[var(--color-primary-600)] hover:underline flex items-center gap-1"
                     >
                       {project.name}
-                      <ExternalLink size={12} className="text-indigo-400" />
+                      <ExternalLink size={12} className="text-gray-400" />
                     </Link>
                   </div>
                 </div>
@@ -283,9 +283,9 @@ export default function EventDetail() {
             { label: 'Cobro bruto/hora', value: eventHours > 0 ? formatCurrencyPerHour(grossHourlyRate) : '—', detail: `${formatHours(eventHours)} h` },
             { label: 'Beneficio neto', value: formatCurrency(netProfit), highlight: true },
           ].map(({ label, value, detail, highlight }) => (
-            <div key={label} className={`rounded-lg border p-4 ${highlight ? 'bg-indigo-50 border-indigo-200' : 'bg-white border-gray-200'}`}>
+            <div key={label} className={`rounded-lg border p-4 ${highlight ? 'bg-[#fef3f2] border-[var(--color-primary-200)]' : 'bg-white border-gray-200'}`}>
               <p className="text-xs text-gray-500">{label}</p>
-              <p className={`text-lg font-semibold mt-1 ${highlight ? 'text-indigo-700' : 'text-gray-900'}`}>{value}</p>
+              <p className={`text-lg font-semibold mt-1 ${highlight ? 'text-[var(--color-primary-600)]' : 'text-gray-900'}`}>{value}</p>
               {detail && <p className="mt-1 text-xs text-gray-400">{detail}</p>}
             </div>
           ))}
@@ -294,7 +294,7 @@ export default function EventDetail() {
             <button
               type="button"
               onClick={() => setFinancialSummaryExpanded(true)}
-              className="w-full sm:hidden mt-2 py-2 text-xs text-indigo-600 font-medium hover:text-indigo-700"
+              className="w-full sm:hidden mt-2 py-2 text-xs text-[var(--color-primary-500)] font-medium hover:text-[var(--color-primary-600)]"
             >
               Ver resumen completo
             </button>
@@ -340,7 +340,7 @@ export default function EventDetail() {
                     <td className="py-2">
                       <button
                         onClick={() => openEditIncome(income)}
-                        className="text-gray-900 hover:text-indigo-600 hover:underline text-left transition-colors"
+                        className="text-gray-900 hover:text-[var(--color-primary-500)] hover:underline text-left transition-colors"
                       >
                         {income.concept}
                       </button>
@@ -405,7 +405,7 @@ export default function EventDetail() {
                       <td className="py-2">
                         <button
                           onClick={() => openEditExpense(expense)}
-                          className="text-gray-900 hover:text-indigo-600 hover:underline text-left transition-colors"
+                          className="text-gray-900 hover:text-[var(--color-primary-500)] hover:underline text-left transition-colors"
                         >
                           {expense.concept}
                         </button>
@@ -482,7 +482,7 @@ export default function EventDetail() {
             <div className="flex items-center gap-2">
               <input type="checkbox" id="is_paid" checked={incomeForm.is_paid}
                 onChange={(e) => setIncomeForm((p) => ({ ...p, is_paid: e.target.checked }))}
-                className="h-5 w-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />
+                className="h-5 w-5 rounded border-gray-300 text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]" />
               <label htmlFor="is_paid" className="text-sm text-gray-700">Ya está cobrado</label>
             </div>
           </div>
@@ -529,7 +529,7 @@ export default function EventDetail() {
             <div className="flex items-center gap-2">
               <input type="checkbox" id="is_deductible" checked={expenseForm.is_deductible}
                 onChange={(e) => setExpenseForm((p) => ({ ...p, is_deductible: e.target.checked }))}
-                className="h-5 w-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />
+                className="h-5 w-5 rounded border-gray-300 text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]" />
               <label htmlFor="is_deductible" className="text-sm text-gray-700">Gasto deducible fiscalmente</label>
             </div>
           </div>

--- a/src/pages/Events/EventForm.jsx
+++ b/src/pages/Events/EventForm.jsx
@@ -194,7 +194,7 @@ export function EventForm({ initialData, projects = [], onSubmit, onCancel, load
             id="is_multi_day"
             checked={isMultiDay}
             onChange={(e) => handleMultiDayChange(e.target.checked)}
-            className="h-5 w-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+            className="h-5 w-5 rounded border-gray-300 text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]"
           />
           <span>Evento de varios días</span>
         </label>

--- a/src/pages/Events/EventList.jsx
+++ b/src/pages/Events/EventList.jsx
@@ -103,7 +103,7 @@ export default function EventList() {
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Buscar evento, cliente o proyecto"
-                className="w-full pl-9 pr-3 py-2 text-sm rounded-lg border border-gray-300 outline-none focus:border-indigo-500"
+                className="w-full pl-9 pr-3 py-2 text-sm rounded-lg border border-gray-300 outline-none focus:border-[var(--color-primary-500)]"
               />
             </div>
             <Select
@@ -218,7 +218,7 @@ export default function EventList() {
                           </span>
                           <span className="text-gray-400">{formatDatetime(event.start_datetime)}</span>
                         </div>
-                        <p className="mt-3 text-xs font-medium text-indigo-600 truncate">
+                        <p className="mt-3 text-xs font-medium text-[var(--color-primary-500)] truncate">
                           {project ? project.name : 'Sin proyecto'}
                         </p>
                       </div>

--- a/src/pages/Projects/ProjectDetail.jsx
+++ b/src/pages/Projects/ProjectDetail.jsx
@@ -240,9 +240,9 @@ export default function ProjectDetail() {
             { label: 'Cobro bruto/hora', value: projectHours > 0 ? formatCurrencyPerHour(grossHourlyRate) : '—', detail: `Solo eventos cobrados · ${formatHours(projectHours)} h` },
             { label: 'Beneficio neto', value: formatCurrency(netProfit), highlight: true },
           ].map(({ label, value, detail, highlight }) => (
-            <div key={label} className={`rounded-lg border p-4 ${highlight ? 'bg-indigo-50 border-indigo-200' : 'bg-white border-gray-200'}`}>
+            <div key={label} className={`rounded-lg border p-4 ${highlight ? 'bg-[#fef3f2] border-[var(--color-primary-200)]' : 'bg-white border-gray-200'}`}>
               <p className="text-xs text-gray-500">{label}</p>
-              <p className={`text-lg font-semibold mt-1 ${highlight ? 'text-indigo-700' : 'text-gray-900'}`}>{value}</p>
+              <p className={`text-lg font-semibold mt-1 ${highlight ? 'text-[var(--color-primary-600)]' : 'text-gray-900'}`}>{value}</p>
               {detail && <p className="mt-1 text-xs text-gray-400">{detail}</p>}
             </div>
           ))}
@@ -251,7 +251,7 @@ export default function ProjectDetail() {
             <button
               type="button"
               onClick={() => setFinancialSummaryExpanded(true)}
-              className="w-full sm:hidden mt-2 py-2 text-xs text-indigo-600 font-medium hover:text-indigo-700"
+              className="w-full sm:hidden mt-2 py-2 text-xs text-[var(--color-primary-500)] font-medium hover:text-[var(--color-primary-600)]"
             >
               Ver resumen completo
             </button>
@@ -262,7 +262,7 @@ export default function ProjectDetail() {
         <Card className="p-5">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
             <div className="flex items-center gap-2">
-              <CalendarDays size={16} className="text-indigo-500" />
+              <CalendarDays size={16} className="text-[var(--color-primary-500)]" />
               <div>
                 <h3 className="text-sm font-semibold text-gray-900">Eventos asociados</h3>
                 <p className="text-xs text-gray-500 mt-1">Ocurrencias concretas dentro de este proyecto.</p>
@@ -344,7 +344,7 @@ export default function ProjectDetail() {
                   {directIncomes.map((income) => (
                     <tr key={income.id} className="border-b border-gray-50 last:border-0 group">
                       <td className="py-2">
-                        <button onClick={() => openEditIncome(income)} className="text-gray-900 hover:text-indigo-600 hover:underline text-left transition-colors">
+                        <button onClick={() => openEditIncome(income)} className="text-gray-900 hover:text-[var(--color-primary-500)] hover:underline text-left transition-colors">
                           {income.concept}
                         </button>
                       </td>
@@ -406,7 +406,7 @@ export default function ProjectDetail() {
                   {directExpenses.map((expense) => (
                     <tr key={expense.id} className="border-b border-gray-50 last:border-0 group">
                       <td className="py-2">
-                        <button onClick={() => openEditExpense(expense)} className="text-gray-900 hover:text-indigo-600 hover:underline text-left transition-colors">
+                        <button onClick={() => openEditExpense(expense)} className="text-gray-900 hover:text-[var(--color-primary-500)] hover:underline text-left transition-colors">
                           {expense.concept}
                         </button>
                       </td>
@@ -451,7 +451,7 @@ export default function ProjectDetail() {
             <Input label="Retención IRPF (%)" type="text" inputMode="decimal" value={incomeForm.tax_rate} onChange={(e) => setIncomeForm((p) => ({ ...p, tax_rate: e.target.value }))} />
             <Input label="Fecha prevista de cobro" type="date" value={incomeForm.expected_date} onChange={(e) => setIncomeForm((p) => ({ ...p, expected_date: e.target.value }))} />
             <div className="flex items-center gap-2">
-              <input type="checkbox" id="is_paid" checked={incomeForm.is_paid} onChange={(e) => setIncomeForm((p) => ({ ...p, is_paid: e.target.checked }))} className="h-5 w-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />
+              <input type="checkbox" id="is_paid" checked={incomeForm.is_paid} onChange={(e) => setIncomeForm((p) => ({ ...p, is_paid: e.target.checked }))} className="h-5 w-5 rounded border-gray-300 text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]" />
               <label htmlFor="is_paid" className="text-sm text-gray-700">Ya está cobrado</label>
             </div>
           </div>
@@ -472,7 +472,7 @@ export default function ProjectDetail() {
             </Select>
             <Input label="Fecha *" type="date" value={expenseForm.expense_date} onChange={(e) => setExpenseForm((p) => ({ ...p, expense_date: e.target.value }))} required />
             <div className="flex items-center gap-2">
-              <input type="checkbox" id="is_deductible" checked={expenseForm.is_deductible} onChange={(e) => setExpenseForm((p) => ({ ...p, is_deductible: e.target.checked }))} className="h-5 w-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />
+              <input type="checkbox" id="is_deductible" checked={expenseForm.is_deductible} onChange={(e) => setExpenseForm((p) => ({ ...p, is_deductible: e.target.checked }))} className="h-5 w-5 rounded border-gray-300 text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]" />
               <label htmlFor="is_deductible" className="text-sm text-gray-700">Gasto deducible fiscalmente</label>
             </div>
           </div>

--- a/src/pages/Projects/ProjectList.jsx
+++ b/src/pages/Projects/ProjectList.jsx
@@ -82,7 +82,7 @@ export default function ProjectList() {
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Buscar proyecto o cliente"
-                className="w-full pl-9 pr-3 py-2 text-sm rounded-lg border border-gray-300 outline-none focus:border-indigo-500"
+                className="w-full pl-9 pr-3 py-2 text-sm rounded-lg border border-gray-300 outline-none focus:border-[var(--color-primary-500)]"
               />
             </div>
             <Select

--- a/src/pages/Work/Work.jsx
+++ b/src/pages/Work/Work.jsx
@@ -15,8 +15,8 @@ function ProjectCard({ project, eventCount = 0 }) {
   return (
     <Link
       to={`/projects/${project.id}`}
-      className={`block p-4 rounded-lg border transition-all hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
-        isActive ? 'bg-indigo-50 border-indigo-100' : 'bg-white border-gray-200 hover:border-indigo-200'
+      className={`block p-4 rounded-lg border transition-all hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary-500)] ${
+        isActive ? 'bg-[#fef3f2] border-[var(--color-primary-200)]' : 'bg-white border-gray-200 hover:border-[var(--color-primary-200)]'
       }`}
     >
       <div className="flex items-start justify-between gap-3">
@@ -50,8 +50,8 @@ function EventCard({ event, projectName = null }) {
   return (
     <Link
       to={`/events/${event.id}`}
-      className={`block p-4 rounded-lg border transition-all hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
-        isActive ? 'bg-indigo-50 border-indigo-100' : 'bg-white border-gray-200 hover:border-indigo-200'
+      className={`block p-4 rounded-lg border transition-all hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary-500)] ${
+        isActive ? 'bg-[#fef3f2] border-[var(--color-primary-200)]' : 'bg-white border-gray-200 hover:border-[var(--color-primary-200)]'
       }`}
     >
       <div className="flex items-start justify-between gap-3">
@@ -68,7 +68,7 @@ function EventCard({ event, projectName = null }) {
               <span>{formatDatetime(event.start_datetime)}{event.end_datetime && ` – ${formatDatetime(event.end_datetime)}`}</span>
             </div>
             {projectName && (
-              <p className="text-xs text-indigo-600 mt-1">Proyecto: {projectName}</p>
+              <p className="text-xs text-[var(--color-primary-500)] mt-1">Proyecto: {projectName}</p>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Resumen

- Elimina todos los colores indigo/purple restantes de la app
- Reemplaza con la paleta paper/tinta/red de Cachés
- KpiCard: elimina opción indigo
- Auth/Login + Register: icon bg y enlaces -> red primary  
- Modal: focus ring -> red
- CalendarEvents: enlace de proyecto -> red
- Input: focus rings ya actualizados en commits anteriores

## Memoria

no aplica

## Verificaciones

- grep indigo|purple = 0 matches
- lint OK
- build OK (chunk size warning esperada)