### PR TITLE
fix(CACH-0029): integra helpers de decimal datetime y cobros

### DIFF
--- a/.memory/topics/forms.md
+++ b/.memory/topics/forms.md
@@ -27,5 +27,11 @@
 ## 2026-05-03 - Decimal Inputs Should Accept Comma And Dot
 
 - Context: Issue `#11` found that IRPF values with decimals are real user inputs and native numeric controls can block comma decimals depending on browser/locale.
-- Durable memory: for decimal finance percentages such as `tax_rate`, prefer text inputs with `inputMode="decimal"` plus `parseDecimal()` from `src/lib/formatters.js`, accepting both `15,5` and `15.5`; validate IRPF in the `0-100` range before saving.
+- Durable memory: for decimal finance fields, including `tax_rate`, income amounts, and expense amounts, prefer text inputs with `inputMode="decimal"` plus the shared decimal parser, accepting comma and dot forms such as `15,5`, `12,50`, and `12.50`; validate IRPF in the `0-100` range and amounts as positive values before saving.
 - Source: issue `#11`; commit `ce89ea3`; `src/lib/formatters.js`; `src/pages/Settings/Settings.jsx`; income forms in event/project detail.
+
+## 2026-05-05 - Finance Form Payloads Use Shared Normalizers
+
+- Context: CACH-0029 integrated the CACH-B0016 helpers into real event/project income and expense forms.
+- Durable memory: when adding or changing financial forms, normalize payloads through shared helpers instead of ad hoc `Number(...)`, native `type="number"`, or manual `is_paid`/`paid_date` toggles. `paid_date` remains a date field, so compatibility payloads should send both `is_paid` and `paid_date` coherently.
+- Source: CACH-0029; ADR-0012; `src/lib/financeForms.ts`; `src/lib/payment.ts`; `src/pages/Events/EventDetail.jsx`; `src/pages/Projects/ProjectDetail.jsx`.

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -66,7 +66,9 @@ Sin issues en progreso.
 
 ## Review
 
-Sin issues en review.
+| ID | Titulo | Tipo | Prioridad | Nota |
+|---|---|---|---|---|
+| [[../issues/CACH-0029|CACH-0029]] | Integrar helpers CACH-B0016 en flujos reales | bug | p1 | Validacion completa; e2e/db con skips explicitos. |
 
 ## Done
 

--- a/docs/project/inbox/README.md
+++ b/docs/project/inbox/README.md
@@ -15,6 +15,40 @@ tags:
 
 Capturas rápidas pendientes de curar. Desde móvil, si la idea está verde, entra aquí antes de convertirse en ZK, issue, ADR o contexto estable.
 
-## Regla
+## Captura rapida
+
+Crear una nota simple:
+
+```bash
+npm run pb:capture -- "texto de la idea o feedback"
+```
+
+Crear una nota con titulo y tags:
+
+```bash
+npm run pb:capture -- --title "Feedback beta cobros" --tag beta,feedback "La usuaria no entiende si el cache esta cobrado"
+```
+
+El comando crea un Markdown en `docs/project/inbox/` con timestamp de segundos y slug. Si coinciden dos capturas en el mismo segundo, anade sufijo incremental para no pisar archivos.
+
+## Que entra aqui
+
+- Ideas verdes sin problema ni usuario claro.
+- Feedback cualitativo sin clasificar.
+- Notas rapidas desde movil o durante una sesion.
+- Preguntas que necesitan triage antes de ser backlog.
+
+## Que no entra aqui
+
+- Issues listas para implementar: crear `docs/project/issues/CACH-XXXX.md`.
+- Decisiones duraderas: crear ADR.
+- Contexto estable del producto: mover a `context/` o `knowledge/`.
+- Historial operativo de una tarea actual: actualizar la issue relacionada.
+
+## Weekly review
 
 No usar como backlog permanente. En modo `PB ironman`, revisar, clasificar y mover.
+
+1. Revisar capturas recientes.
+2. Clasificar cada una como `issue`, `ZK`, `ADR`, `contexto`, `duplicado`, `rechazado` o dejarla en inbox con motivo.
+3. Enlazar la pieza resultante y borrar o archivar la captura solo cuando el contenido quede curado.

--- a/docs/project/indexes/by-area.md
+++ b/docs/project/indexes/by-area.md
@@ -21,6 +21,7 @@ tags:
 
 ## frontend
 
+- [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -33,6 +33,7 @@ tags:
 
 ## RELEASE-0.1.0-beta.1
 
+- [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain
 - [[../issues/CACH-B0016|CACH-B0016]] — Refundacion operativa del Product Brain y tests B0014
 

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -19,6 +19,10 @@ tags:
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain
 - [[../issues/CACH-B0016|CACH-B0016]] — Refundacion operativa del Product Brain y tests B0014
 
+## review
+
+- [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales
+
 ## backlog
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento

--- a/docs/project/indexes/issues.index.md
+++ b/docs/project/indexes/issues.index.md
@@ -14,6 +14,7 @@ tags:
 
 - [[../issues/CACH-0026|CACH-0026]] — Setup inicial Product Brain
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada
+- [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes

--- a/docs/project/issues/CACH-0029.md
+++ b/docs/project/issues/CACH-0029.md
@@ -1,0 +1,146 @@
+---
+id: CACH-0029
+title: Integrar helpers CACH-B0016 en flujos reales
+type: bug
+status: review
+cycle: beta-1
+release: RELEASE-0.1.0-beta.1
+priority: p1
+estimate: m
+area: frontend
+created_at: 2026-05-05
+updated_at: 2026-05-05
+aliases:
+  - CACH-0029
+tags:
+  - product-brain
+  - issue
+  - testing
+  - hardening
+adr:
+  - ADR-0011
+  - ADR-0012
+  - ADR-0013
+related:
+  - CACH-B0016
+  - CACH-B0014
+---
+
+# CACH-0029 — Integrar helpers CACH-B0016 en flujos reales
+
+## Rama sugerida
+
+`fix/CACH-0029-cerrar-huecos-b0016`
+
+Nota: `CURRENT_RELEASE.md` marca `release/0.1.0-beta.1` como rama activa, pero esa rama ya no existe en refs locales ni remotas tras `git fetch`. La rama de trabajo se crea desde `chore/cach-b0016-brain-refactor` porque CACH-0029 depende de los helpers introducidos por CACH-B0016.
+
+## Contexto
+
+CACH-B0016 dejo helpers y tests puros para decimales, datetime Madrid/UTC y cobros, pero varios flujos reales de la app aun no los usan.
+
+## Problema
+
+- Los formularios financieros aceptan importes con `type="number"` y validaciones con `Number(...)`.
+- `EventForm` envia valores `YYYY-MM-DDTHH:mm` locales a Supabase sin convertirlos explicitamente a UTC.
+- `EventDetail` y `ProjectDetail` alternan `is_paid` y `paid_date` manualmente.
+- Playwright y pgTAP siguen como humo/placeholder sin explicar claramente el bloqueo.
+- `docs/project/inbox/README.md` no documenta el uso nuevo de `pb:capture`.
+
+## Objetivo
+
+Integrar los helpers de CACH-B0016 en los flujos reales sin reabrir la refundacion del Product Brain.
+
+## Alcance
+
+### Incluido
+
+- Formularios de ingresos y gastos de evento/proyecto.
+- Payload de evento local Madrid a ISO UTC.
+- Coherencia `is_paid`/`paid_date` en altas, ediciones y toggles.
+- Tests unitarios de payloads reales.
+- Playwright smoke con `webServer` y skip honesto si no hay seed/auth.
+- Placeholder pgTAP documentado hasta tener migraciones versionadas de app.
+- Documentacion de `pb:capture` en inbox.
+
+### Fuera de alcance
+
+- Migraciones destructivas de datos existentes.
+- Seed/auth e2e real si no existe infraestructura lista.
+- Rehacer el modelo financiero o el dashboard completo.
+
+## Criterios de aceptacion
+
+- [x] Crear/editar evento convierte input local Madrid a ISO UTC antes de llamar a Supabase.
+- [x] Ingresos y gastos aceptan coma decimal en evento y proyecto.
+- [x] Los payloads de cobro nunca crean `is_paid=true` con `paid_date=null`.
+- [x] `npm run test` cubre payload de evento, decimal de ingreso/gasto y toggle de cobro.
+- [x] Playwright tiene `webServer` y documenta por que el smoke sigue skippeado si no hay seed/auth.
+- [x] pgTAP/RLS documenta claramente el bloqueo por falta de migraciones versionadas de tablas financieras.
+- [x] `docs/project/inbox/README.md` explica `pb:capture` y weekly review.
+
+## Riesgos
+
+- Drift horario en cambios de horario Europe/Madrid.
+- Formatos ambiguos `1,234.56` frente a coma decimal espanola.
+- Datos legacy con `is_paid` y `paid_date` incoherentes.
+- Confundir smoke skippeado con cobertura e2e real.
+
+## Dependencias
+
+- Helpers de CACH-B0016 en `src/lib/decimal.ts`, `src/lib/datetime.ts` y `src/lib/payment.ts`.
+- ADR-0011, ADR-0012 y ADR-0013.
+
+## Notas tecnicas
+
+- `paid_date` es `date` en el schema documentado actual. No se hara migracion destructiva; los helpers deben emitir fecha `YYYY-MM-DD` y mantener `is_paid` por compatibilidad.
+- TODO pgTAP: no hay migraciones versionadas de `profiles`, `projects`, `events`, `incomes` y `expenses`; hasta que existan, `supabase/tests/payment_rls.test.sql` no puede probar RLS financiero real de forma reproducible.
+
+## Plan de implementacion
+
+1. Integrar helpers de decimal, datetime y payment en los flujos reales.
+2. Extraer helpers puros pequenos si facilita tests.
+3. Actualizar tests unitarios y placeholders e2e/db.
+4. Actualizar inbox y Product Brain.
+5. Ejecutar validacion obligatoria.
+
+## Validacion
+
+- [x] `npm run pb:check` — OK.
+- [x] `npm run lint` — OK.
+- [x] `npm run test` — OK, 10 archivos y 44 tests.
+- [x] `npm run build` — OK; Vite mantiene warning de chunk >500 kB.
+- [x] `npm run test:e2e` — OK fuera del sandbox; 1 smoke skippeado por falta de seed/auth e2e. En sandbox fallo antes por `listen EPERM 127.0.0.1:5173`.
+- [x] `npm run test:db` — OK con skip explicito: Supabase CLI no esta instalado y faltan migraciones versionadas de tablas financieras.
+
+## Resultado
+
+Listo para revision. CACH-0029 integra los helpers de CACH-B0016 en flujos reales:
+
+- `EventForm` convierte input local Europe/Madrid a ISO UTC antes de persistir.
+- Los formularios de ingresos/gastos de evento y proyecto usan `type="text"`, `inputMode="decimal"` y normalizadores compartidos.
+- Los toggles y payloads de cobro usan `isPaid()`, `markPaid()` y `markUnpaid()` manteniendo `is_paid` y `paid_date` coherentes.
+- Los tests unitarios cubren payload de evento, importes con coma, gastos con coma y coherencia de cobros.
+- Playwright queda con `webServer` real, pero el smoke sigue skippeado hasta tener seed/auth.
+- pgTAP/RLS queda como placeholder honesto hasta versionar migraciones de tablas financieras.
+- Inbox documenta `pb:capture`, tags y weekly review.
+
+Memoria: actualizada en `.memory/topics/forms.md`.
+
+## Commits relacionados
+
+- `fix(CACH-0029): integra helpers de decimal datetime y cobros`
+
+## Pull/Merge relacionado
+
+- PR: https://github.com/dignacioconde/culturApp/pull/60
+- Rama: `fix/CACH-0029-cerrar-huecos-b0016`
+- Base prevista: `chore/cach-b0016-brain-refactor` (PR #59).
+
+## Relacionado
+
+- [[../releases/RELEASE-0.1.0-beta.1]]
+- [[CACH-B0016]]
+- [[CACH-B0014]]
+- [[../decisions/ADR-0011-timestamp-policy]]
+- [[../decisions/ADR-0012-decimal-input-policy]]
+- [[../decisions/ADR-0013-testing-strategy]]

--- a/docs/project/plans/CURRENT_PLAN.md
+++ b/docs/project/plans/CURRENT_PLAN.md
@@ -24,7 +24,7 @@ Cerrar [[../releases/RELEASE-0.1.0-beta.1|RELEASE-0.1.0-beta.1]] como primer cor
 
 ## Prioridades
 
-1. Mergear [[../releases/RELEASE-0.1.0-beta.1|RELEASE-0.1.0-beta.1]] a `main`.
+1. Cerrar [[../issues/CACH-0029|CACH-0029]] y mergear [[../releases/RELEASE-0.1.0-beta.1|RELEASE-0.1.0-beta.1]] a `main`.
 2. Abrir `RELEASE-0.1.0-beta.2` con scope pequeno, probablemente [[../issues/CACH-B0014|CACH-B0014]].
 3. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
 

--- a/docs/project/prompts/cach-0029-cerrar-huecos-b0016.md
+++ b/docs/project/prompts/cach-0029-cerrar-huecos-b0016.md
@@ -1,0 +1,183 @@
+---
+id: PB-PROMPT-CACH-0029
+type: prompt
+status: Active
+created: 2026-05-05
+updated: 2026-05-05
+aliases:
+  - CACH-0029 cerrar huecos B0016
+  - Prompt CACH-0029
+tags:
+  - product-brain
+  - prompt
+  - testing
+  - hardening
+---
+
+# CACH-0029 — Cerrar huecos reales de CACH-B0016
+
+```markdown
+# CACH-0029 — Cerrar huecos reales de CACH-B0016: integrar helpers en la app y endurecer tests
+
+Eres Claude Code/Codex trabajando en el repo `culturApp` / Cachés.
+
+## Objetivo
+
+La PR `#59` / CACH-B0016 dejó bien montado el Product Brain y añadió helpers/tests puros, pero quedaron huecos reales:
+
+1. `decimal.ts` existe, pero varios formularios siguen usando `type="number"` o `Number(...)`.
+2. `datetime.ts` existe, pero `EventForm` sigue enviando `YYYY-MM-DDTHH:mm` local sin convertirlo a instante UTC.
+3. `payment.ts` existe, pero `EventDetail` y `ProjectDetail` siguen alternando `is_paid` y `paid_date` manualmente.
+4. Playwright smoke está `skip`.
+5. pgTAP/RLS está como placeholder.
+6. `inbox/README.md` no explica bien el nuevo `pb:capture`.
+
+Tu trabajo es cerrar esos huecos sin reabrir la refundación completa del Product Brain.
+
+## Respuesta inicial obligatoria
+
+Antes de tocar archivos, responde en español:
+
+1. **Issue**: CACH-0029 — Integrar helpers CACH-B0016 en flujos reales.
+2. **Release**: usar la release activa que indiquen `CURRENT_RELEASE.md` y `CURRENT_PLAN.md`.
+3. **Rama**: crea rama desde la rama de release activa si existe; si no, desde `main`.
+4. **Ficheros previstos**.
+5. **Riesgos**.
+6. **Validación esperada**.
+7. **Memoria**: confirmar que harás checkpoint pre-PR.
+
+Luego ejecuta.
+
+## Contexto obligatorio
+
+Lee antes de editar:
+
+- `AGENTS.md`
+- `.memory/MEMORY.md`
+- `docs/project/START_HERE.md`
+- `docs/project/releases/CURRENT_RELEASE.md`
+- `docs/project/plans/CURRENT_PLAN.md`
+- `docs/project/backlog/BACKLOG.md`
+- `docs/project/issues/CACH-B0016.md`
+- `docs/project/issues/CACH-B0014.md`
+- `docs/project/decisions/ADR-0009-id-policy.md`
+- `docs/project/decisions/ADR-0011-timestamp-policy.md`
+- `docs/project/decisions/ADR-0012-decimal-input-policy.md`
+- `docs/project/decisions/ADR-0013-testing-strategy.md`
+
+Si no existe issue `CACH-0029`, créala en `docs/project/issues/CACH-0029.md` con frontmatter nuevo sin prefijo `B`.
+
+## Cambios a hacer
+
+### 1. Decimales reales en UI
+
+Actualizar formularios de ingresos/gastos para no depender de `type="number"`:
+
+- `src/pages/Events/EventDetail.jsx`
+- `src/pages/Projects/ProjectDetail.jsx`
+
+Reglas:
+
+- Importes: `type="text"`, `inputMode="decimal"`.
+- Usar `parseDecimal()` para ingresos, gastos y retención IRPF.
+- No usar `Number(expenseForm.amount)` para validar gastos.
+- Aceptar `1.234,56`, `1234,56`, `1234.56`, `,5`, `-1,5` donde aplique.
+- Mantener UI en español de España y tuteo.
+
+### 2. Datetime real en eventos
+
+Actualizar `EventForm` y/o el punto de submit para convertir correctamente:
+
+- Input local `YYYY-MM-DDTHH:mm` -> `fromLocalInputValue(..., 'Europe/Madrid')` -> `toIsoUtc()`.
+- Al editar evento existente, seguir usando `toDatetimeLocal()`.
+- No mandar naive datetime local directo a Supabase.
+
+Archivos probables:
+
+- `src/pages/Events/EventForm.jsx`
+- `src/pages/Calendar/CalendarEvents.jsx`
+- hooks/callers que reciban payload de eventos, si aplica.
+
+### 3. Coherencia `paid_date` <-> cobrado
+
+Actualizar cobros para usar `payment.ts`:
+
+- `markPaid()`
+- `markUnpaid()`
+- `isPaid()`
+
+Reglas:
+
+- No crear estados donde `is_paid=true` y `paid_date=null`.
+- Si la BD todavía tiene `is_paid`, mantener compatibilidad enviando ambos campos coherentes.
+- Si `paid_date` es `date` en el schema actual, documentar la limitación y no hacer migración destructiva salvo que ya existan migraciones claras.
+
+### 4. Tests de integración mínima
+
+Añadir/actualizar tests para cubrir los flujos reales, no sólo helpers:
+
+- test de transformación de payload de evento local Madrid -> ISO UTC.
+- test de payload de ingreso/gasto con coma decimal.
+- test de toggle de cobro que deja `is_paid` y `paid_date` coherentes.
+
+Si extraer helpers pequeños facilita testear sin montar componentes enormes, hazlo.
+
+### 5. Playwright
+
+Mejorar `e2e/smoke.spec.ts`:
+
+- Si existe auth/seed viable, des-skippear y ejecutar humo real.
+- Si no existe, mantener `.skip`, pero añadir `webServer` en `playwright.config.ts` y dejar TODO claro con issue link.
+- No fingir cobertura e2e si no hay seed/auth.
+
+### 6. pgTAP / test db
+
+Mejorar `supabase/tests/payment_rls.test.sql`:
+
+- Si hay migrations reales para tablas financieras, escribir pgTAP real.
+- Si no las hay, mantener placeholder, pero abrir TODO en la issue CACH-0029 explicando que no hay migrations versionadas para testear RLS todavía.
+- `npm run test:db` puede seguir skippeando si falta Supabase CLI, pero debe decirlo explícitamente.
+
+### 7. Inbox
+
+Actualizar `docs/project/inbox/README.md` para explicar:
+
+- `npm run pb:capture -- "texto"`
+- `npm run pb:capture -- --title "..." --tag beta,feedback "texto"`
+- weekly review
+- qué va a inbox y qué no.
+
+## Validación obligatoria
+
+Ejecuta:
+
+```bash
+npm run pb:check
+npm run lint
+npm run test
+npm run build
+npm run test:e2e
+npm run test:db
+```
+
+Si algún comando queda skippeado, explícalo con motivo exacto.
+
+## Cierre
+
+Antes de PR:
+
+1. Actualiza `docs/project/issues/CACH-0029.md` con resultado y validación.
+2. Actualiza backlog/release/plan si cambia estado.
+3. Haz checkpoint de memoria:
+   - si hay memoria durable, actualiza `.memory/`;
+   - si no, declara `Memoria: no aplica`.
+4. Commit con formato:
+   `fix(CACH-0029): integra helpers de decimal datetime y cobros`
+5. Push.
+6. PR en español con:
+   - resumen;
+   - qué huecos de CACH-B0016 se cerraron;
+   - qué sigue skippeado y por qué;
+   - validación;
+   - sección `Memoria`.
+```

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -28,7 +28,7 @@ Active
 
 ## Ultimo corte
 
-Pendiente de cierre tras CACH-B0016.
+Pendiente de cierre tras CACH-0029.
 
 ## Siguiente corte esperado
 

--- a/docs/project/releases/RELEASE-0.1.0-beta.1.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.1.md
@@ -37,6 +37,7 @@ El primer corte `0.1.0-beta.1` no entrega funcionalidad de usuario final; entreg
 
 - [[../issues/CACH-B0015]] — Operativizar backlog, releases y ramas en Product Brain
 - [[../issues/CACH-B0016]] — Refundacion operativa del Product Brain y tests B0014
+- [[../issues/CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales
 
 ## Issues incluidas
 
@@ -44,6 +45,7 @@ El primer corte `0.1.0-beta.1` no entrega funcionalidad de usuario final; entreg
 |---|---|---|---|
 | [[../issues/CACH-B0015|CACH-B0015]] | Operativizar backlog, releases y ramas en Product Brain | done | `release/0.1.0-beta.1` |
 | [[../issues/CACH-B0016|CACH-B0016]] | Refundacion operativa del Product Brain y tests B0014 | done | `chore/cach-b0016-brain-refactor` |
+| [[../issues/CACH-0029|CACH-0029]] | Integrar helpers CACH-B0016 en flujos reales | review | `fix/CACH-0029-cerrar-huecos-b0016` |
 
 ## Out Of Scope
 
@@ -82,7 +84,7 @@ El primer corte `0.1.0-beta.1` no entrega funcionalidad de usuario final; entreg
 
 ## Checklist de desarrollo
 
-- [x] Todas las issues del corte estan cerradas o Ready for Release.
+- [ ] Todas las issues del corte estan cerradas o Ready for Release.
 - [x] Commits integrados en rama release.
 - [x] No hay cambios sueltos fuera de release.
 - [x] No hay issues sin estado.
@@ -91,9 +93,12 @@ El primer corte `0.1.0-beta.1` no entrega funcionalidad de usuario final; entreg
 ## Checklist de estabilizacion
 
 - [x] `npm run lint`.
-- [x] `npm run build` no aplica; no toca app React/runtime.
+- [x] `npm run build`.
 - [x] `npm run pb:check`.
 - [x] `npm run pb:status`.
+- [x] `npm run test`.
+- [x] `npm run test:e2e` con smoke skippeado por falta de seed/auth.
+- [x] `npm run test:db` con skip explicito por falta de Supabase CLI y migraciones financieras versionadas.
 - [x] Revision de documentacion.
 
 ## Checklist de salida
@@ -126,6 +131,8 @@ El primer corte `0.1.0-beta.1` no entrega funcionalidad de usuario final; entreg
 
 - Se evita que la release branch sea una rama larga indefinida.
 - Se eliminan strings libres de release en issues (`Unassigned`, `Beta`, `Internal`, `Pro`, `Growth`, `Post-MVP`, `0.1-cycle`).
+- CACH-0029 integra los helpers de decimales, datetime y cobros en los formularios reales de eventos/proyectos.
+- Los payloads de cobro mantienen `is_paid` y `paid_date` coherentes sin migracion destructiva.
 
 ### Eliminado
 
@@ -136,6 +143,8 @@ El primer corte `0.1.0-beta.1` no entrega funcionalidad de usuario final; entreg
 - ADR-0008 documenta release branching gobernado por Product Brain.
 - `scripts/product-brain-sync.mjs` conoce las carpetas `backlog/` y `process/`.
 - ADR-0009 a ADR-0014 documentan IDs, frontmatter, timestamps, decimales, testing y feedback beta.
+- Playwright tiene `webServer` configurado; el smoke sigue omitido hasta tener seed/auth e2e.
+- pgTAP/RLS documenta el bloqueo por falta de migraciones versionadas de tablas financieras.
 
 ## Resultado final
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,7 +1,8 @@
 import { test } from '@playwright/test'
 
 test.skip('crear cache con importe europeo, fecha Madrid y marcar como pagada', async ({ page }) => {
-  // Pendiente de seed/auth estable para e2e. Flujo objetivo:
+  // TODO CACH-0029: des-skippear cuando exista seed/auth estable para e2e.
+  // Flujo objetivo:
   // 1. Iniciar sesion con usuario seed de beta.
   // 2. Crear cache/evento con importe "1.234,56" y fecha "2026-05-16T22:00".
   // 3. Marcar ingreso como pagado.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,13 @@ import { defineConfig } from '@playwright/test'
 export default defineConfig({
   testDir: './e2e',
   reporter: process.env.CI ? [['html', { open: 'never' }], ['github']] : 'list',
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1',
+    url: 'http://127.0.0.1:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
   use: {
-    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173',
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:5173',
   },
 })

--- a/scripts/test-db.mjs
+++ b/scripts/test-db.mjs
@@ -5,7 +5,7 @@ const hasSupabase = spawnSync('supabase', ['--version'], { encoding: 'utf8' })
 
 if (hasSupabase.error?.code === 'ENOENT') {
   console.log('[test:db] skip: Supabase CLI no esta instalado en este entorno.')
-  console.log('[test:db] pendiente: ejecutar supabase test db cuando haya CLI y migraciones versionadas completas.')
+  console.log('[test:db] pendiente: ejecutar supabase test db cuando haya CLI y migraciones versionadas de tablas financieras.')
   process.exit(0)
 }
 

--- a/src/lib/eventPayload.test.ts
+++ b/src/lib/eventPayload.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { buildEventPayload } from './eventPayload'
+
+describe('buildEventPayload', () => {
+  it('convierte un input local Madrid a ISO UTC antes de persistir', () => {
+    const payload = buildEventPayload({
+      name: 'Cache nocturno',
+      start_datetime: '2026-05-16T22:00',
+      end_datetime: '2026-05-16T23:00',
+    }, 'Europe/Madrid')
+
+    expect(payload.start_datetime).toBe('2026-05-16T20:00:00.000Z')
+    expect(payload.end_datetime).toBe('2026-05-16T21:00:00.000Z')
+  })
+
+  it('mantiene end_datetime nulo si no hay fin', () => {
+    const payload = buildEventPayload({
+      name: 'Cache sin fin',
+      start_datetime: '2026-01-10T08:00',
+      end_datetime: null,
+    }, 'Europe/Madrid')
+
+    expect(payload.start_datetime).toBe('2026-01-10T07:00:00.000Z')
+    expect(payload.end_datetime).toBeNull()
+  })
+})

--- a/src/lib/eventPayload.ts
+++ b/src/lib/eventPayload.ts
@@ -1,0 +1,15 @@
+import { DEFAULT_TZ, fromLocalInputValue, toIsoUtc } from './datetime'
+
+type EventFormValues = {
+  start_datetime: string
+  end_datetime?: string | null
+  [key: string]: unknown
+}
+
+export function buildEventPayload<T extends EventFormValues>(form: T, tz = DEFAULT_TZ): T {
+  return {
+    ...form,
+    start_datetime: toIsoUtc(fromLocalInputValue(form.start_datetime, tz)),
+    end_datetime: form.end_datetime ? toIsoUtc(fromLocalInputValue(form.end_datetime, tz)) : null,
+  }
+}

--- a/src/lib/financeForms.test.ts
+++ b/src/lib/financeForms.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeExpenseForm, normalizeIncomeForm } from './financeForms'
+
+describe('finance form payloads', () => {
+  it('normaliza ingreso con coma decimal y paid_date coherente', () => {
+    const { payload, error } = normalizeIncomeForm(
+      {
+        concept: 'Actuacion',
+        amount: '1.234,56',
+        tax_rate: '15,5',
+        expected_date: '2026-05-20',
+        is_paid: true,
+      },
+      { paidAt: new Date('2026-05-16T20:30:00Z') },
+    )
+
+    expect(error).toBeNull()
+    expect(payload).toMatchObject({
+      amount: 1234.56,
+      tax_rate: 15.5,
+      is_paid: true,
+      paid_date: '2026-05-16',
+    })
+  })
+
+  it('mantiene la fecha de cobro existente al editar un ingreso ya cobrado', () => {
+    const { payload } = normalizeIncomeForm(
+      {
+        concept: 'Actuacion',
+        amount: '900,00',
+        tax_rate: '15',
+        is_paid: true,
+      },
+      {
+        existingIncome: { is_paid: true, paid_date: '2026-05-10' },
+        paidAt: new Date('2026-05-16T20:30:00Z'),
+      },
+    )
+
+    expect(payload?.paid_date).toBe('2026-05-10')
+  })
+
+  it('limpia paid_date si el ingreso queda pendiente', () => {
+    const { payload } = normalizeIncomeForm(
+      {
+        concept: 'Actuacion',
+        amount: '900,00',
+        tax_rate: '',
+        is_paid: false,
+      },
+      {
+        defaultTaxRate: 21,
+        existingIncome: { is_paid: true, paid_date: '2026-05-10' },
+      },
+    )
+
+    expect(payload).toMatchObject({
+      tax_rate: 21,
+      is_paid: false,
+      paid_date: null,
+    })
+  })
+
+  it('normaliza gastos con coma decimal sin Number()', () => {
+    const { payload, error } = normalizeExpenseForm({
+      concept: 'Taxi',
+      amount: ',5',
+      category: 'transporte',
+    })
+
+    expect(error).toBeNull()
+    expect(payload?.amount).toBe(0.5)
+  })
+
+  it('rechaza importes no positivos', () => {
+    expect(normalizeIncomeForm({ amount: '-1,5', tax_rate: '15', is_paid: false }).error).toBe('amount')
+    expect(normalizeExpenseForm({ amount: '0' }).error).toBe('amount')
+  })
+})

--- a/src/lib/financeForms.ts
+++ b/src/lib/financeForms.ts
@@ -1,0 +1,70 @@
+import { parseDecimal } from './decimal'
+import { markPaid, markUnpaid, type PaymentState } from './payment'
+
+type FinanceForm = {
+  amount: unknown
+  [key: string]: unknown
+}
+
+type IncomeForm = FinanceForm & {
+  tax_rate?: unknown
+  is_paid?: boolean
+  paid_date?: string | null
+}
+
+type FinanceValidationError = 'amount' | 'tax_rate'
+
+type NormalizeResult<T> =
+  | { payload: T; error: null }
+  | { payload: null; error: FinanceValidationError }
+
+export function normalizeExpenseForm<T extends FinanceForm>(form: T): NormalizeResult<T & { amount: number }> {
+  const amount = parseDecimal(String(form.amount ?? ''))
+
+  if (amount === null || amount <= 0) {
+    return { payload: null, error: 'amount' }
+  }
+
+  return { payload: { ...form, amount }, error: null }
+}
+
+export function normalizeIncomeForm<T extends IncomeForm>(
+  form: T,
+  {
+    defaultTaxRate = 15,
+    existingIncome = null,
+    paidAt = new Date(),
+  }: {
+    defaultTaxRate?: number
+    existingIncome?: PaymentState | null
+    paidAt?: Date
+  } = {},
+): NormalizeResult<T & { amount: number; tax_rate: number; is_paid: boolean; paid_date: string | null }> {
+  const amount = parseDecimal(String(form.amount ?? ''))
+  const rawTaxRate = String(form.tax_rate ?? '').trim()
+  const taxRate = rawTaxRate === '' ? defaultTaxRate : parseDecimal(rawTaxRate)
+
+  if (amount === null || amount <= 0) {
+    return { payload: null, error: 'amount' }
+  }
+
+  if (taxRate === null || taxRate < 0 || taxRate > 100) {
+    return { payload: null, error: 'tax_rate' }
+  }
+
+  const paymentSource = {
+    is_paid: form.is_paid ?? existingIncome?.is_paid ?? false,
+    paid_date: form.paid_date ?? existingIncome?.paid_date ?? null,
+  }
+  const paymentState = form.is_paid ? markPaid(paymentSource, paidAt) : markUnpaid(paymentSource)
+
+  return {
+    payload: {
+      ...form,
+      amount,
+      tax_rate: taxRate,
+      ...paymentState,
+    },
+    error: null,
+  }
+}

--- a/src/lib/payment.test.ts
+++ b/src/lib/payment.test.ts
@@ -2,25 +2,27 @@ import { describe, expect, it } from 'vitest'
 import { isPaid, markPaid, markUnpaid, type PaymentState } from './payment'
 
 describe('payment state', () => {
-  it('deriva isPaid desde paid_date', () => {
-    expect(isPaid({ paid_date: null })).toBe(false)
-    expect(isPaid({ paid_date: '2026-05-16T10:00:00Z' })).toBe(true)
+  it('deriva isPaid desde paid_date y mantiene compatibilidad con is_paid legacy', () => {
+    expect(isPaid({ paid_date: null, is_paid: false })).toBe(false)
+    expect(isPaid({ paid_date: '2026-05-16', is_paid: false })).toBe(true)
+    expect(isPaid({ paid_date: null, is_paid: true })).toBe(true)
   })
 
-  it('marca como cobrado con paid_date coherente', () => {
-    expect(markPaid({ paid_date: null }, new Date('2026-05-16T10:00:00Z'))).toEqual({
-      paid_date: '2026-05-16T10:00:00.000Z',
+  it('marca como cobrado con is_paid y paid_date coherentes', () => {
+    expect(markPaid({ paid_date: null, is_paid: false }, new Date('2026-05-16T10:00:00Z'))).toEqual({
+      paid_date: '2026-05-16',
+      is_paid: true,
     })
   })
 
-  it('marca como pendiente limpiando paid_date', () => {
-    expect(markUnpaid({ paid_date: '2026-05-16T10:00:00.000Z' })).toEqual({ paid_date: null })
+  it('marca como pendiente limpiando paid_date e is_paid', () => {
+    expect(markUnpaid({ paid_date: '2026-05-16', is_paid: true })).toEqual({ paid_date: null, is_paid: false })
   })
 
   it('mantiene la propiedad derivada en cualquier estado base', () => {
     const states: PaymentState[] = [
-      { paid_date: null },
-      { paid_date: '2026-01-01T00:00:00.000Z' },
+      { paid_date: null, is_paid: false },
+      { paid_date: '2026-01-01', is_paid: true },
     ]
     const date = new Date('2026-05-16T10:00:00Z')
 

--- a/src/lib/payment.ts
+++ b/src/lib/payment.ts
@@ -1,13 +1,24 @@
-export type PaymentState = { paid_date: string | null }
+import { formatInTimeZone } from 'date-fns-tz'
+import { DEFAULT_TZ } from './datetime'
+
+export type PaymentState = { is_paid?: boolean | null; paid_date?: string | null }
 
 export function isPaid(s: PaymentState): boolean {
-  return Boolean(s.paid_date)
+  return Boolean(s.paid_date) || s.is_paid === true
 }
 
-export function markPaid(s: PaymentState, when: Date): PaymentState {
-  return { ...s, paid_date: when.toISOString() }
+export function paymentDate(when: Date, tz = DEFAULT_TZ): string {
+  return formatInTimeZone(when, tz, 'yyyy-MM-dd')
 }
 
-export function markUnpaid(s: PaymentState): PaymentState {
-  return { ...s, paid_date: null }
+export function markPaid<T extends PaymentState>(
+  s: T,
+  when = new Date(),
+  tz = DEFAULT_TZ,
+): T & { is_paid: true; paid_date: string } {
+  return { ...s, is_paid: true, paid_date: s.paid_date || paymentDate(when, tz) }
+}
+
+export function markUnpaid<T extends PaymentState>(s: T): T & { is_paid: false; paid_date: null } {
+  return { ...s, is_paid: false, paid_date: null }
 }

--- a/src/pages/Events/EventDetail.jsx
+++ b/src/pages/Events/EventDetail.jsx
@@ -7,7 +7,6 @@ import { Button } from '../../components/ui/Button'
 import { StatusBadge } from '../../components/ui/Badge'
 import { Modal } from '../../components/ui/Modal'
 import { Input, Select } from '../../components/ui/Input'
-import { parseDecimal } from '../../lib/formatters'
 import { useToast, ToastContainer } from '../../components/ui/Toast'
 import { EventForm } from './EventForm'
 import { useAuth } from '../../hooks/useAuth'
@@ -17,6 +16,8 @@ import { useProjects } from '../../hooks/useProjects'
 import { useIncomes } from '../../hooks/useIncomes'
 import { useExpenses } from '../../hooks/useExpenses'
 import { formatCurrency, formatCurrencyPerHour, formatDate, formatDatetime, formatHours } from '../../lib/formatters'
+import { normalizeExpenseForm, normalizeIncomeForm } from '../../lib/financeForms'
+import { isPaid, markPaid, markUnpaid } from '../../lib/payment'
 import { EXPENSE_CATEGORIES } from '../../lib/constants'
 
 const EMPTY_EXPENSE = { concept: '', amount: '', category: 'otros', expense_date: '', is_deductible: true }
@@ -85,7 +86,7 @@ export default function EventDetail() {
   }
 
   const totalGross = incomes.reduce((acc, i) => acc + Number(i.amount), 0)
-  const paidIncomes = incomes.filter((i) => i.is_paid)
+  const paidIncomes = incomes.filter((i) => isPaid(i))
   const totalPaid = paidIncomes.reduce((acc, i) => acc + Number(i.amount), 0)
   const pendingAmount = totalGross - totalPaid
   const totalRetentions = paidIncomes.reduce((acc, i) => acc + Number(i.amount) * (Number(i.tax_rate) / 100), 0)
@@ -107,7 +108,8 @@ export default function EventDetail() {
       amount: income.amount,
       tax_rate: income.tax_rate,
       expected_date: income.expected_date ?? '',
-      is_paid: income.is_paid,
+      is_paid: isPaid(income),
+      paid_date: income.paid_date ?? null,
     })
     setIncomeModal(true)
   }
@@ -148,21 +150,17 @@ export default function EventDetail() {
 
   const handleSubmitIncome = async (e) => {
     e.preventDefault()
-    const amount = parseDecimal(incomeForm.amount)
-    const rawTaxRate = String(incomeForm.tax_rate ?? '').trim()
-    const taxRate = rawTaxRate === '' ? defaultTaxRate : parseDecimal(rawTaxRate)
-    if (!incomeForm.concept.trim() || !amount || amount <= 0) {
+    const { payload, error: validationError } = normalizeIncomeForm(incomeForm, {
+      defaultTaxRate,
+      existingIncome: editingIncome,
+    })
+    if (!incomeForm.concept.trim() || validationError === 'amount') {
       addToast('Completa el concepto y un importe mayor que 0.', 'error')
       return
     }
-    if (taxRate === null || taxRate < 0 || taxRate > 100) {
+    if (validationError === 'tax_rate') {
       addToast('La retención IRPF debe estar entre 0 y 100.', 'error')
       return
-    }
-    const payload = {
-      ...incomeForm,
-      amount: amount,
-      tax_rate: taxRate,
     }
     setSavingIncome(true)
     const { error } = editingIncome
@@ -175,22 +173,23 @@ export default function EventDetail() {
   }
 
   const handleTogglePaid = async (income) => {
-    await updateIncome(income.id, {
-      is_paid: !income.is_paid,
-      paid_date: !income.is_paid ? new Date().toISOString().split('T')[0] : null,
-    })
+    const currentPayment = { is_paid: income.is_paid, paid_date: income.paid_date ?? null }
+    const paymentState = isPaid(income) ? markUnpaid(currentPayment) : markPaid(currentPayment)
+    const { error } = await updateIncome(income.id, paymentState)
+    if (error) addToast('Error al actualizar el cobro.', 'error')
   }
 
   const handleSubmitExpense = async (e) => {
     e.preventDefault()
-    if (!expenseForm.concept.trim() || Number(expenseForm.amount) <= 0) {
+    const { payload, error: validationError } = normalizeExpenseForm(expenseForm)
+    if (!expenseForm.concept.trim() || validationError === 'amount') {
       addToast('Completa el concepto y un importe mayor que 0.', 'error')
       return
     }
     setSavingExpense(true)
     const { error } = editingExpense
-      ? await updateExpense(editingExpense.id, expenseForm)
-      : await createExpense({ ...expenseForm, event_id: id })
+      ? await updateExpense(editingExpense.id, payload)
+      : await createExpense({ ...payload, event_id: id })
     setSavingExpense(false)
     if (error) { addToast('Error al guardar el gasto.', 'error'); return }
     addToast(editingExpense ? 'Gasto actualizado.' : 'Gasto añadido.')
@@ -350,7 +349,7 @@ export default function EventDetail() {
                     <td className="py-2 text-right text-gray-500">{formatDate(income.expected_date)}</td>
                     <td className="py-2 text-center">
                       <button onClick={() => handleTogglePaid(income)} className="text-gray-400 hover:text-green-600 transition-colors">
-                        {income.is_paid ? <CheckCircle size={16} className="text-green-500" /> : <Circle size={16} />}
+                        {isPaid(income) ? <CheckCircle size={16} className="text-green-500" /> : <Circle size={16} />}
                       </button>
                     </td>
                     <td className="py-2 text-right">
@@ -461,7 +460,8 @@ export default function EventDetail() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <Input
               label="Importe (€) *"
-              type="number" min="0" step="0.01"
+              type="text"
+              inputMode="decimal"
               value={incomeForm.amount}
               onChange={(e) => setIncomeForm((p) => ({ ...p, amount: e.target.value }))}
               required
@@ -507,7 +507,8 @@ export default function EventDetail() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <Input
               label="Importe (€) *"
-              type="number" min="0" step="0.01"
+              type="text"
+              inputMode="decimal"
               value={expenseForm.amount}
               onChange={(e) => setExpenseForm((p) => ({ ...p, amount: e.target.value }))}
               required

--- a/src/pages/Events/EventForm.jsx
+++ b/src/pages/Events/EventForm.jsx
@@ -3,6 +3,7 @@ import { Button } from '../../components/ui/Button'
 import { Input, Select, Textarea } from '../../components/ui/Input'
 import { EVENT_STATUSES, EVENT_CATEGORIES, DEFAULT_PROJECT_COLORS } from '../../lib/constants'
 import { toDatetimeLocal } from '../../lib/formatters'
+import { buildEventPayload } from '../../lib/eventPayload'
 
 const EMPTY_FORM = {
   name: '',
@@ -43,21 +44,23 @@ const getDefaultEndDatetime = (startDatetime, multiDay = false) => {
 }
 
 export function EventForm({ initialData, projects = [], onSubmit, onCancel, loading }) {
+  const initialStartDatetime = toDatetimeLocal(initialData?.start_datetime)
+  const initialEndDatetime = toDatetimeLocal(initialData?.end_datetime)
   const [form, setForm] = useState({
     ...EMPTY_FORM,
     ...initialData,
     name: initialData?.name ?? '',
     client: initialData?.client ?? '',
-    start_datetime: toDatetimeLocal(initialData?.start_datetime),
-    end_datetime: toDatetimeLocal(initialData?.end_datetime),
+    start_datetime: initialStartDatetime,
+    end_datetime: initialEndDatetime,
     project_id: initialData?.project_id ?? '',
     notes: initialData?.notes ?? '',
   })
   const [error, setError] = useState('')
   const [isMultiDay, setIsMultiDay] = useState(() => {
-    if (!initialData?.end_datetime) return false
-    const startDate = initialData.start_datetime?.split('T')[0]
-    const endDate = initialData.end_datetime?.split('T')[0]
+    if (!initialEndDatetime) return false
+    const startDate = initialStartDatetime.split('T')[0]
+    const endDate = initialEndDatetime.split('T')[0]
     return startDate !== endDate
   })
 
@@ -106,14 +109,14 @@ export function EventForm({ initialData, projects = [], onSubmit, onCancel, load
       setError('La fecha de fin no puede ser anterior al inicio.')
       return
     }
-    const payload = {
+    const payload = buildEventPayload({
       ...form,
       name: form.name.trim(),
       client: form.client.trim(),
       project_id: form.project_id || null,
       end_datetime: form.end_datetime || null,
       notes: form.notes.trim(),
-    }
+    })
     onSubmit(payload)
   }
 

--- a/src/pages/Projects/ProjectDetail.jsx
+++ b/src/pages/Projects/ProjectDetail.jsx
@@ -7,7 +7,6 @@ import { Button } from '../../components/ui/Button'
 import { StatusBadge } from '../../components/ui/Badge'
 import { Modal } from '../../components/ui/Modal'
 import { Input, Select } from '../../components/ui/Input'
-import { parseDecimal } from '../../lib/formatters'
 import { useToast, ToastContainer } from '../../components/ui/Toast'
 import { ProjectForm } from './ProjectForm'
 import { useAuth } from '../../hooks/useAuth'
@@ -17,6 +16,8 @@ import { useEvents } from '../../hooks/useEvents'
 import { useIncomes } from '../../hooks/useIncomes'
 import { useExpenses } from '../../hooks/useExpenses'
 import { formatCurrency, formatCurrencyPerHour, formatDate, formatDatetime, formatHours } from '../../lib/formatters'
+import { normalizeExpenseForm, normalizeIncomeForm } from '../../lib/financeForms'
+import { isPaid, markPaid, markUnpaid } from '../../lib/payment'
 import { EXPENSE_CATEGORIES } from '../../lib/constants'
 
 const EMPTY_EXPENSE = { concept: '', amount: '', category: 'otros', expense_date: '', is_deductible: true }
@@ -88,7 +89,7 @@ export default function ProjectDetail() {
   const directExpenses = expenses.filter((e) => e.project_id === id)
 
   const totalGross = incomes.reduce((acc, i) => acc + Number(i.amount), 0)
-  const paidIncomes = incomes.filter((i) => i.is_paid)
+  const paidIncomes = incomes.filter((i) => isPaid(i))
   const paidEventIncomes = paidIncomes.filter((i) => i.event_id)
   const paidEventIds = new Set(paidEventIncomes.map((i) => i.event_id))
   const totalPaid = paidIncomes.reduce((acc, i) => acc + Number(i.amount), 0)
@@ -105,7 +106,14 @@ export default function ProjectDetail() {
   const openNewIncome = () => { setEditingIncome(null); setIncomeForm(emptyIncomeForm); setIncomeModal(true) }
   const openEditIncome = (income) => {
     setEditingIncome(income)
-    setIncomeForm({ concept: income.concept, amount: income.amount, tax_rate: income.tax_rate, expected_date: income.expected_date ?? '', is_paid: income.is_paid })
+    setIncomeForm({
+      concept: income.concept,
+      amount: income.amount,
+      tax_rate: income.tax_rate,
+      expected_date: income.expected_date ?? '',
+      is_paid: isPaid(income),
+      paid_date: income.paid_date ?? null,
+    })
     setIncomeModal(true)
   }
   const openNewExpense = () => { setEditingExpense(null); setExpenseForm(EMPTY_EXPENSE); setExpenseModal(true) }
@@ -133,21 +141,17 @@ export default function ProjectDetail() {
 
   const handleSubmitIncome = async (e) => {
     e.preventDefault()
-    const amount = parseDecimal(incomeForm.amount)
-    const rawTaxRate = String(incomeForm.tax_rate ?? '').trim()
-    const taxRate = rawTaxRate === '' ? defaultTaxRate : parseDecimal(rawTaxRate)
-    if (!incomeForm.concept.trim() || !amount || amount <= 0) {
+    const { payload, error: validationError } = normalizeIncomeForm(incomeForm, {
+      defaultTaxRate,
+      existingIncome: editingIncome,
+    })
+    if (!incomeForm.concept.trim() || validationError === 'amount') {
       addToast('Completa el concepto y un importe mayor que 0.', 'error')
       return
     }
-    if (taxRate === null || taxRate < 0 || taxRate > 100) {
+    if (validationError === 'tax_rate') {
       addToast('La retención IRPF debe estar entre 0 y 100.', 'error')
       return
-    }
-    const payload = {
-      ...incomeForm,
-      amount: amount,
-      tax_rate: taxRate,
     }
     setSavingIncome(true)
     const { error } = editingIncome
@@ -160,22 +164,23 @@ export default function ProjectDetail() {
   }
 
   const handleTogglePaid = async (income) => {
-    await updateIncome(income.id, {
-      is_paid: !income.is_paid,
-      paid_date: !income.is_paid ? new Date().toISOString().split('T')[0] : null,
-    })
+    const currentPayment = { is_paid: income.is_paid, paid_date: income.paid_date ?? null }
+    const paymentState = isPaid(income) ? markUnpaid(currentPayment) : markPaid(currentPayment)
+    const { error } = await updateIncome(income.id, paymentState)
+    if (error) addToast('Error al actualizar el cobro.', 'error')
   }
 
   const handleSubmitExpense = async (e) => {
     e.preventDefault()
-    if (!expenseForm.concept.trim() || Number(expenseForm.amount) <= 0) {
+    const { payload, error: validationError } = normalizeExpenseForm(expenseForm)
+    if (!expenseForm.concept.trim() || validationError === 'amount') {
       addToast('Completa el concepto y un importe mayor que 0.', 'error')
       return
     }
     setSavingExpense(true)
     const { error } = editingExpense
-      ? await updateExpense(editingExpense.id, expenseForm)
-      : await createExpense({ ...expenseForm, project_id: id })
+      ? await updateExpense(editingExpense.id, payload)
+      : await createExpense({ ...payload, project_id: id })
     setSavingExpense(false)
     if (error) { addToast('Error al guardar el gasto.', 'error'); return }
     addToast(editingExpense ? 'Gasto actualizado.' : 'Gasto añadido.')
@@ -353,7 +358,7 @@ export default function ProjectDetail() {
                       <td className="py-2 text-right text-gray-500">{formatDate(income.expected_date)}</td>
                       <td className="py-2 text-center">
                         <button onClick={() => handleTogglePaid(income)} className="text-gray-400 hover:text-green-600 transition-colors">
-                          {income.is_paid ? <CheckCircle size={16} className="text-green-500" /> : <Circle size={16} />}
+                          {isPaid(income) ? <CheckCircle size={16} className="text-green-500" /> : <Circle size={16} />}
                         </button>
                       </td>
                       <td className="py-2 text-right">
@@ -447,7 +452,7 @@ export default function ProjectDetail() {
         <form onSubmit={handleSubmitIncome} className="flex flex-col gap-4">
           <Input label="Concepto *" value={incomeForm.concept} onChange={(e) => setIncomeForm((p) => ({ ...p, concept: e.target.value }))} placeholder="Producción general" required />
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <Input label="Importe (€) *" type="number" min="0" step="0.01" value={incomeForm.amount} onChange={(e) => setIncomeForm((p) => ({ ...p, amount: e.target.value }))} required />
+            <Input label="Importe (€) *" type="text" inputMode="decimal" value={incomeForm.amount} onChange={(e) => setIncomeForm((p) => ({ ...p, amount: e.target.value }))} required />
             <Input label="Retención IRPF (%)" type="text" inputMode="decimal" value={incomeForm.tax_rate} onChange={(e) => setIncomeForm((p) => ({ ...p, tax_rate: e.target.value }))} />
             <Input label="Fecha prevista de cobro" type="date" value={incomeForm.expected_date} onChange={(e) => setIncomeForm((p) => ({ ...p, expected_date: e.target.value }))} />
             <div className="flex items-center gap-2">
@@ -466,7 +471,7 @@ export default function ProjectDetail() {
         <form onSubmit={handleSubmitExpense} className="flex flex-col gap-4">
           <Input label="Concepto *" value={expenseForm.concept} onChange={(e) => setExpenseForm((p) => ({ ...p, concept: e.target.value }))} placeholder="Material de producción" required />
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <Input label="Importe (€) *" type="number" min="0" step="0.01" value={expenseForm.amount} onChange={(e) => setExpenseForm((p) => ({ ...p, amount: e.target.value }))} required />
+            <Input label="Importe (€) *" type="text" inputMode="decimal" value={expenseForm.amount} onChange={(e) => setExpenseForm((p) => ({ ...p, amount: e.target.value }))} required />
             <Select label="Categoría" value={expenseForm.category} onChange={(e) => setExpenseForm((p) => ({ ...p, category: e.target.value }))}>
               {EXPENSE_CATEGORIES.map((c) => <option key={c.value} value={c.value}>{c.label}</option>)}
             </Select>

--- a/supabase/tests/payment_rls.test.sql
+++ b/supabase/tests/payment_rls.test.sql
@@ -1,6 +1,7 @@
--- pgTAP placeholder for CACH-B0016.
+-- pgTAP placeholder for CACH-0029.
 -- skip: the current Supabase schema in this repo is documented in AGENTS.md,
--- but there are no versioned app migrations for payments/caches yet.
+-- but there are no versioned app migrations for profiles/projects/events/incomes/expenses yet.
+-- Without those migrations, RLS tests for payments cannot be reproduced from a clean db.
 --
 -- Target coverage once migrations are versioned:
 -- - tests.rls_enabled('public')


### PR DESCRIPTION
## Resumen

Cierra CACH-0029 encima de la rama de CACH-B0016 / PR #59, porque la rama `release/0.1.0-beta.1` ya no existe en local/remoto y este trabajo depende de los helpers introducidos en `chore/cach-b0016-brain-refactor`.

- Integra los helpers de datetime, decimal y payment en los flujos reales de evento/proyecto.
- Crea normalizadores puros para payloads financieros y de eventos, con tests unitarios.
- Actualiza Product Brain, inbox, Playwright y placeholder pgTAP sin fingir cobertura inexistente.

## Huecos de CACH-B0016 cerrados

- `EventForm` convierte `YYYY-MM-DDTHH:mm` local Europe/Madrid a ISO UTC antes de guardar en Supabase.
- Los importes de ingresos/gastos en `EventDetail` y `ProjectDetail` usan `type="text"`, `inputMode="decimal"` y aceptan coma/punto via helper.
- Los cobros usan `isPaid()`, `markPaid()` y `markUnpaid()`, manteniendo `is_paid` y `paid_date` coherentes.
- Los tests cubren payload de evento Madrid -> UTC, ingreso/gasto con coma decimal y coherencia de cobro.

## Sigue skippeado

- Playwright smoke sigue con `test.skip` porque no existe seed/auth e2e estable. Ahora `playwright.config.ts` tiene `webServer` real y el TODO enlaza CACH-0029.
- pgTAP/RLS sigue como placeholder porque no hay migraciones versionadas de `profiles`, `projects`, `events`, `incomes` y `expenses`; `test:db` lo reporta explicitamente si falta Supabase CLI.

## Validacion

- [x] `npm run pb:check`
- [x] `npm run pb:status`
- [x] `npm run lint`
- [x] `npm run test` — 10 archivos, 44 tests
- [x] `npm run build` — OK; Vite mantiene warning de chunk >500 kB
- [x] `npm run test:e2e` — OK fuera del sandbox; 1 skipped por falta de seed/auth. En sandbox fallo por `listen EPERM 127.0.0.1:5173`.
- [x] `npm run test:db` — OK con skip explicito: Supabase CLI no instalado y faltan migraciones financieras versionadas.

## Memoria

Memoria: actualizada en `.memory/topics/forms.md`.

## Relacionado

- Product Brain: `CACH-0029`
- Base: PR #59 / `CACH-B0016`
- Relacionada: `CACH-B0014`