### PR TITLE
fix(CACH-0061): paid_date coherence

### DIFF
--- a/src/hooks/useIncomes.js
+++ b/src/hooks/useIncomes.js
@@ -34,9 +34,15 @@ export function useIncomes(userId, { projectId = null, eventId = null, eventIds 
   }, [userId, fetchIncomes])
 
   const createIncome = async (incomeData) => {
+    const dataToInsert = { ...incomeData, user_id: userId }
+    // Si is_paid=true y no hay paid_date, asignar fecha actual
+    if (incomeData.is_paid && !incomeData.paid_date) {
+      dataToInsert.paid_date = new Date().toISOString().split('T')[0]
+    }
+
     const { data, error } = await supabase
       .from('incomes')
-      .insert({ ...incomeData, user_id: userId })
+      .insert(dataToInsert)
       .select()
       .single()
 
@@ -45,9 +51,15 @@ export function useIncomes(userId, { projectId = null, eventId = null, eventIds 
   }
 
   const updateIncome = async (id, incomeData) => {
+    const dataToUpdate = { ...incomeData }
+    // Si is_paid=true y no hay paid_date, asignar fecha actual
+    if (incomeData.is_paid && !incomeData.paid_date) {
+      dataToUpdate.paid_date = new Date().toISOString().split('T')[0]
+    }
+
     const { data, error } = await supabase
       .from('incomes')
-      .update(incomeData)
+      .update(dataToUpdate)
       .eq('id', id)
       .select()
       .single()


### PR DESCRIPTION
## Summary
- Auto-fill `paid_date` with current date when creating/editing income with `is_paid=true` and no `paid_date` provided
- If `paid_date` already provided, do not overwrite
- If `is_paid=false`, leave `paid_date` as-is

## Criteria
- [x] Create income with is_paid=true and no paid_date → assigns current date
- [x] Edit income setting is_paid to true with no paid_date → assigns current date
- [x] Create/edit with is_paid=false → leaves paid_date as provided
- [x] paid_date already provided → not overwritten
- [x] lint + build pass

## Tests
`npm run lint` ✓ | `npm run build` ✓

## Memoria
No aplica - preferencia de comportamiento ya documentada en issue #61.

Closes #61