### PR TITLE
docs(agent-state): limpia eventos y senales obsoletas, documenta regla de limpieza

### DIFF
--- a/.opencode/AGENT_STATE.md
+++ b/.opencode/AGENT_STATE.md
@@ -10,8 +10,11 @@ Pizarra operativa para que los agentes de CulturaApp se coordinen sin esperar si
 - No guardes secretos, datos personales reales ni valores de `.env.local`.
 - Usa esto para senales de coordinacion, no como sustituto de `AGENTS.md`, Git o los tests.
 - Si hay conflicto entre este archivo y el codigo, gana el codigo; si hay conflicto con `AGENTS.md`, gana `AGENTS.md`.
+- **Regla de limpieza**: Las secciones `Senales activas` y `Eventos` deben quedar vacias tras cada tarea completada. El historial permanente vive en git y en GitHub (commits, PRs, issues). Este archivo es solo una pizarra operativa transitoria.
 
 ## Senales activas
+
+*(vacío — el historial vive en git y GitHub)*
 
 Formato recomendado:
 
@@ -20,9 +23,6 @@ Formato recomendado:
 ```
 
 Estados sugeridos: `info`, `bloqueo`, `schema_changed`, `api_changed`, `ui_changed`, `needs_review`, `verified`, `done`.
-
-- [verified] lead -> all: Rediseño paper/tinta #43 mergeado. Build OK. PR #44 cerrada.
-- [verified] lead -> all: Issue #48 implementada. Flag --delete añadido a pb:push. PR #49 mergeada. Sync limpio verificado.
 
 ## Estado por agente
 
@@ -91,16 +91,10 @@ Estados sugeridos: `info`, `bloqueo`, `schema_changed`, `api_changed`, `ui_chang
 
 ## Eventos
 
+*(vacío — el historial vive en git y GitHub)*
+
 Formato:
 
 ```text
 - YYYY-MM-DD HH:mm CET - agente - estado - mensaje.
 ```
-
-- 2026-05-05 12:15 CET - lead - verified - Issue #45: rediseño visual backstage completado. PR #56 mergeada. Rama borrada. Producción verificada.
-
-- 2026-05-05 10:00 CET - lead - verified - Issue #53: RELEASE-0.1-beta GitHub Release + Milestone creados. RELEASE-0.1-beta.md actualizado con sync workflow. PR #54 mergeada. Rama borrada.
-
-- 2026-05-04 19:15 CET - lead - info - Issue #30: comando pb:capture creado. Script: scripts/product-brain-capture.mjs. Prefijos: inbox, idea, issue, decisión, contexto. Documentación: docs/project/prompts/product-brain-capture.md. Verificado: lint OK, agents:plan OK, agents:run OK.
-
-- 2026-05-04 18:30 CET - lead - info - Regla cierre de issues documentada inicialmente; corregida despues para exigir enlace permanente issue->PR/commit y no cerrar issues con PR abierta antes del merge.


### PR DESCRIPTION
## Resumen
- Limpiadas secciones `Senales activas` y `Eventos` de AGENT_STATE.md (entradas obsoletas de PRs ya mergeadas)
- Añadida regla de limpieza al protocolo: estas secciones deben quedar vacías tras cada tarea completada — el historial permanente vive en git y GitHub

## Memoria
actualizada en `.memory/MEMORY.md` (regla documentada)