### PR TITLE
fix(logo): reemplazar SVG custom por icono Drama de lucide-react

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,12 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
-  <!-- Máscara de comedia (sonriente) - color crema -->
-  <circle cx="10" cy="16" r="8" fill="#F5EFE0"/>
-  <!-- Ojo izquierdo -->
-  <circle cx="7.5" cy="14" r="1.5" fill="#211C18"/>
-  <!-- Ojo derecho -->
-  <circle cx="12.5" cy="14" r="1.5" fill="#211C18"/>
-  <!-- Boca sonriente -->
-  <path d="M6 18 Q10 23 14 18" stroke="#211C18" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <!-- Ceja -->
-  <path d="M6 11 Q10 9 14 11" stroke="#211C18" stroke-width="1" fill="none" stroke-linecap="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#C94035" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M13.192 9h6.616a2 2 0 0 1 1.992 2.183l-.567 6.182a4 4 0 0 1 -3.983 3.635h-1.5a4 4 0 0 1 -3.983 -3.635l-.567 -6.182a2 2 0 0 1 1.992 -2.183"/>
+  <path d="M15 13h.01"/>
+  <path d="M18 13h.01"/>
+  <path d="M15 16.5c1 .667 2 .667 3 0"/>
+  <path d="M8.632 15.982a4.037 4.037 0 0 1 -.382 .018h-1.5a4 4 0 0 1 -3.983 -3.635l-.567 -6.182a2 2 0 0 1 1.992 -2.183h6.616a2 2 0 0 1 2 2"/>
+  <path d="M6 8h.01"/>
+  <path d="M9 8h.01"/>
+  <path d="M6 12c.764 -.51 1.528 -.63 2.291 -.36"/>
 </svg>

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,39 +1,5 @@
 import { NavLink } from 'react-router-dom'
-import { LayoutDashboard, CalendarDays, CalendarRange, Briefcase, Settings } from 'lucide-react'
-
-function TheaterMasksLogo({ className }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 36 24"
-      className={className}
-      fill="none"
-    >
-      {/* Máscara tragedia (izquierda) - roja */}
-      <g transform="translate(0, 0)">
-        <ellipse cx="9" cy="12" rx="7" ry="9" fill="#C94035"/>
-        {/* Ojos tragedia */}
-        <circle cx="6.5" cy="10" r="1.5" fill="#F5EFE0"/>
-        <circle cx="11.5" cy="10" r="1.5" fill="#F5EFE0"/>
-        {/* Ceja tragedia */}
-        <path d="M4 7 L7 8 L10 7" stroke="#211C18" stroke-width="1.2" fill="none" stroke-linecap="round"/>
-        {/* Boca tragedia */}
-        <path d="M5 15 Q9 13 13 15" stroke="#211C18" stroke-width="1.2" fill="none" stroke-linecap="round"/>
-      </g>
-      {/* Máscara comedia (derecha) - púrpura */}
-      <g transform="translate(18, 0)">
-        <ellipse cx="9" cy="12" rx="7" ry="9" fill="#863bff"/>
-        {/* Ojos comedia */}
-        <circle cx="6.5" cy="10" r="1.5" fill="#F5EFE0"/>
-        <circle cx="11.5" cy="10" r="1.5" fill="#F5EFE0"/>
-        {/* Ceja comedia */}
-        <path d="M5 8 Q9 10 13 8" stroke="#211C18" stroke-width="1.2" fill="none" stroke-linecap="round"/>
-        {/* Boca comedia sonriente */}
-        <path d="M5 15 Q9 19 13 15" stroke="#211C18" stroke-width="1.2" fill="none" stroke-linecap="round"/>
-      </g>
-    </svg>
-  )
-}
+import { Drama, LayoutDashboard, CalendarDays, CalendarRange, Briefcase, Settings } from 'lucide-react'
 
 const navItems = [
   { to: '/dashboard', icon: LayoutDashboard, label: 'Dashboard' },
@@ -48,7 +14,7 @@ export function Sidebar() {
     <aside className="w-full shrink-0 border-b border-[rgba(245,239,224,.08)] bg-[#2C2420] lg:sticky lg:top-0 lg:h-screen lg:w-60 lg:border-r lg:border-b-0">
       <div className="flex items-center gap-2 border-b border-[rgba(245,239,224,.08)] px-4 py-4 lg:px-5">
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[#211C18] shadow-sm">
-          <TheaterMasksLogo className="h-6 w-auto" />
+          <Drama size={24} strokeWidth={1.5} className="text-[#C94035]" />
         </div>
         <span className="truncate text-sm font-semibold text-[#F5EFE0]">Cachés</span>
       </div>

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -1,33 +1,5 @@
 import { useAuth } from '../../hooks/useAuth'
-import { LogOut, User } from 'lucide-react'
-
-function TheaterMasksLogo({ className }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 36 24"
-      className={className}
-      fill="none"
-    >
-      {/* Máscara tragedia (izquierda) - roja */}
-      <g transform="translate(0, 0)">
-        <ellipse cx="9" cy="12" rx="7" ry="9" fill="#C94035"/>
-        <circle cx="6.5" cy="10" r="1.5" fill="#F5EFE0"/>
-        <circle cx="11.5" cy="10" r="1.5" fill="#F5EFE0"/>
-        <path d="M4 7 L7 8 L10 7" stroke="#211C18" stroke-width="1.2" fill="none" stroke-linecap="round"/>
-        <path d="M5 15 Q9 13 13 15" stroke="#211C18" stroke-width="1.2" fill="none" stroke-linecap="round"/>
-      </g>
-      {/* Máscara comedia (derecha) - púrpura */}
-      <g transform="translate(18, 0)">
-        <ellipse cx="9" cy="12" rx="7" ry="9" fill="#863bff"/>
-        <circle cx="6.5" cy="10" r="1.5" fill="#F5EFE0"/>
-        <circle cx="11.5" cy="10" r="1.5" fill="#F5EFE0"/>
-        <path d="M5 8 Q9 10 13 8" stroke="#211C18" stroke-width="1.2" fill="none" stroke-linecap="round"/>
-        <path d="M5 15 Q9 19 13 15" stroke="#211C18" stroke-width="1.2" fill="none" stroke-linecap="round"/>
-      </g>
-    </svg>
-  )
-}
+import { Drama, LogOut, User } from 'lucide-react'
 
 export function TopBar({ title }) {
   const { user, signOut } = useAuth()
@@ -35,7 +7,7 @@ export function TopBar({ title }) {
   return (
     <header className="flex min-h-16 items-center justify-between gap-4 border-b border-[#E2D9C2] bg-[#F5EFE0] px-4 py-3 sm:px-6">
       <div className="flex min-w-0 items-center gap-2">
-        <TheaterMasksLogo className="hidden h-6 w-auto sm:block" />
+        <Drama size={28} strokeWidth={1.5} className="hidden sm:block text-[#C94035]" />
         <h1 className="min-w-0 truncate text-lg font-semibold leading-7 text-[#211C18] font-['DM_Serif_Display']">{title}</h1>
       </div>
       <div className="flex min-w-0 shrink-0 items-center gap-2 sm:gap-3">


### PR DESCRIPTION
## Summary
- **TopBar**: elimina `TheaterMasksLogo` inline, sustituye por `<Drama />` de lucide-react (MIT, mismo estilo que LogOut/User)
- **favicon.svg**: reemplaza SVG básico por paths de Tabler Icons `masks-theater` (MIT), stroke `#C94035`

## Why
El SVG anterior fue generado automáticamente sin calidad. Lucide/Tabler tienen paths profesionales y son consistentes con el design system.

## Verification
- `npm run lint` ✓  `npm run build` ✓

## Memoria: no aplica

Closes #64