### PR TITLE
feat(agents): add visibility to agents command

### DIFF
--- a/.opencode/scripts/run-agent.mjs
+++ b/.opencode/scripts/run-agent.mjs
@@ -2,8 +2,13 @@
 import { spawn } from "node:child_process"
 import { resolve } from "node:path"
 import { fileURLToPath } from "node:url"
+import { mkdir, writeFile } from "node:fs/promises"
+import { dirname } from "node:path"
 
 const repoRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)))
+
+// Intervalo de checkpoint en ms (30 segundos)
+const CHECKPOINT_INTERVAL = 30000
 
 function usage() {
   console.log(`Uso:
@@ -70,6 +75,9 @@ function parseArgs(argv) {
   return options
 }
 
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const RUNS_DIR = resolve(__dirname, "../.opencode/runs")
+
 function buildContract(options) {
   return [
     "DIRECTRIZ ESTANDAR PARA CULTURAAPP",
@@ -113,14 +121,74 @@ async function main() {
   }
 
   const prompt = buildContract(options)
+
+  // Crear directorio de ejecución con timestamp
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
+  const runDir = resolve(RUNS_DIR, timestamp)
+  await mkdir(runDir, { recursive: true })
+  const outputPath = resolve(runDir, "output.txt")
+
+  console.log(`[${timestamp}] Starting: ${options.title}`)
+  console.log(`[${timestamp}] Output: ${outputPath}`)
+
   const child = spawn(
     "opencode",
     ["run", "--agent", options.agent, "--title", options.title, "--dir", repoRoot, "--dangerously-skip-permissions", prompt],
-    { cwd: repoRoot, stdio: "inherit" },
+    { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
   )
 
-  child.on("close", (code) => {
+  let stdout = ""
+  let stderr = ""
+  let checkpointCount = 0
+  let lastSize = 0
+
+  // Escribir output en tiempo real
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk.toString()
+    // Mostrar tail cada checkpoint
+    if (stdout.length - lastSize > 5000) {
+      lastSize = stdout.length
+      checkpointCount += 1
+      const lines = stdout.split("\n")
+      const tail = lines.slice(-10).join("\n")
+      console.log(`\n--- Checkpoint #${checkpointCount} ---`)
+      console.log(tail)
+      console.log(`-----------------------\n`)
+    }
+  })
+
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString()
+  })
+
+  // Checkpoint periódico como backup
+  const checkpointInterval = setInterval(() => {
+    if (!child.killed) {
+      checkpointCount += 1
+      const lines = stdout.split("\n")
+      const tail = lines.slice(-15).join("\n")
+      console.log(`\n[${new Date().toLocaleTimeString()}] Checkpoint #${checkpointCount} (tail):`)
+      console.log(tail)
+      console.log("-----------------------\n")
+    }
+  }, CHECKPOINT_INTERVAL)
+
+  child.on("close", async (code) => {
+    clearInterval(checkpointInterval)
+
+    // Escribir output final
+    await writeFile(outputPath, stdout, "utf-8")
+
+    console.log(`\n[${new Date().toLocaleTimeString()}] Finished with code: ${code}`)
+
     process.exitCode = code ?? 1
+  })
+
+  child.on("error", async (error) => {
+    clearInterval(checkpointInterval)
+    await writeFile(outputPath, `Error: ${error.message}\n${stderr}`, "utf-8")
+    console.error(`Error: ${error.message}`)
+    process.exitCode = 1
   })
 }
 

--- a/.opencode/scripts/run-status.mjs
+++ b/.opencode/scripts/run-status.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * agents:status — Muestra el estado de agentes en ejecución y permite ver sus logs.
+ * 
+ * Uso:
+ *   npm run agents:status              Muestra agentes activos y último output
+ *   npm run agents:status --logs       Muestra logs recientes de la última ejecución
+ *   npm run agents:status --watch   Modo watch (actualiza cada 5s)
+ *   npm run agents:status --clear  Limpia ejecuciones antiguas
+ */
+import { readdir, stat, readFile, unlink } from "node:fs/promises"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, "../..")
+const RUNS_DIR = resolve(repoRoot, ".opencode/runs")
+
+function usage() {
+  console.log(`Uso:
+  npm run agents:status              Muestra agentes activos y último output
+  npm run agents:status --logs       Muestra logs recientes de la última ejecución
+  npm run agents:status --watch     Modo watch (actualiza cada 5s)
+  npm run agents:status --clear    Limpia ejecuciones antiguas
+
+Ejemplos:
+  npm run agents:status
+  npm run agents:status --logs
+  npm run agents:status --watch
+`)
+}
+
+function parseArgs(argv) {
+  const options = {
+    logs: false,
+    watch: false,
+    clear: false,
+  }
+
+  for (const arg of argv) {
+    if (arg === "--help" || arg === "-h") {
+      options.help = true
+    } else if (arg === "--logs") {
+      options.logs = true
+    } else if (arg === "--watch") {
+      options.watch = true
+    } else if (arg === "--clear") {
+      options.clear = true
+    }
+  }
+
+  return options
+}
+
+async function listRuns() {
+  try {
+    const dirs = await readdir(RUNS_DIR)
+    const runs = []
+
+    for (const dir of dirs) {
+      const dirPath = join(RUNS_DIR, dir)
+      const dirStat = await stat(dirPath)
+
+      if (dirStat.isDirectory()) {
+        const files = await readdir(dirPath)
+        runs.push({
+          id: dir,
+          created: dirStat.birthtime,
+          agents: files.filter(f => f.endsWith(".md")).map(f => f.replace(".md", "")),
+          hasOutput: files.some(f => f === "output.txt"),
+        })
+      }
+    }
+
+    // Ordenar por fecha descendente
+    runs.sort((a, b) => b.created - a.created)
+    return runs
+  } catch {
+    return []
+  }
+}
+
+async function getActiveRuns() {
+  const runs = await listRuns()
+  const now = new Date()
+  const activeRuns = []
+
+  for (const run of runs) {
+    // Una ejecución está activa si tiene menos de 30 minutos
+    const age = (now - run.created) / 1000 / 60
+    if (age < 30) {
+      activeRuns.push(run)
+    }
+  }
+
+  return activeRuns
+}
+
+async function showStatus(options) {
+  const runs = await listRuns()
+
+  if (runs.length === 0) {
+    console.log("No hay ejecuciones registradas.")
+    return
+  }
+
+  const activeRuns = await getActiveRuns()
+
+  console.log("=== Estado de Agentes ===\n")
+  console.log(`Total de ejecuciones: ${runs.length}`)
+  console.log(`Activas (< 30 min): ${activeRuns.length}`)
+
+  if (activeRuns.length > 0) {
+    console.log("\n--- Ejecuciones Activas ---")
+    for (const run of activeRuns) {
+      const time = new Date(run.created).toLocaleString("es-ES", {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      })
+      console.log(`- ${run.id} (${time}) → [${run.agents.join(", ")}]`)
+    }
+  }
+
+  // Mostrar última ejecución si hay y no hay activos
+  if (activeRuns.length === 0 && runs.length > 0) {
+    const lastRun = runs[0]
+    console.log("\n--- Última Ejecución ---")
+    console.log(`- ${lastRun.id} → [${lastRun.agents.join(", ")}]`)
+  }
+
+  // Si pide logs, mostrar output de la última
+  if (options.logs && runs.length > 0) {
+    const lastRun = runs[0]
+    console.log(`\n--- Output: ${lastRun.id} ---`)
+
+    const outputDir = join(RUNS_DIR, lastRun.id)
+
+    for (const agent of lastRun.agents) {
+      const outputPath = join(outputDir, `${agent}.md`)
+      try {
+        const content = await readFile(outputPath, "utf-8")
+        // Mostrar primeras 30 líneas
+        const lines = content.split("\n").slice(0, 30).join("\n")
+        console.log(`\n## ${agent}`)
+        console.log(lines)
+        if (content.split("\n").length > 30) {
+          console.log("\n... (truncado)")
+        }
+      } catch {
+        // Ignorar
+      }
+    }
+  }
+}
+
+async function clearOldRuns() {
+  const runs = await listRuns()
+  const now = new Date()
+  let removed = 0
+
+  for (const run of runs) {
+    const age = (now - run.created) / 1000 / 60
+    if (age > 24 * 60) { // Más de 24 horas
+      const dirPath = join(RUNS_DIR, run.id)
+      try {
+        await unlink(dirPath)
+        removed += 1
+      } catch {
+        // Ignorar errores
+      }
+    }
+  }
+
+  console.log(`Eliminadas ${removed} ejecuciones antiguas.`)
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+
+  if (options.help) {
+    usage()
+    return
+  }
+
+  if (options.clear) {
+    await clearOldRuns()
+    return
+  }
+
+  if (options.watch) {
+    // Modo watch: actualizar cada 5s
+    console.log("Modo watch (Ctrl+C para salir)...\n")
+    let watching = true
+
+    process.on("SIGINT", () => {
+      watching = false
+    })
+
+    while (watching) {
+      await showStatus({ logs: false })
+      await new Promise((resolve) => setTimeout(resolve, 5000))
+      console.clear()
+    }
+  } else {
+    await showStatus(options)
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message)
+  process.exitCode = 1
+})

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint .",
     "agents:plan": "node .opencode/scripts/run-planner.mjs",
     "agents:run": "node .opencode/scripts/run-agent.mjs",
+    "agents:status": "node .opencode/scripts/run-status.mjs",
+    "agents:logs": "node .opencode/scripts/run-status.mjs --logs",
     "agents:parallel": "node .opencode/scripts/run-parallel-agents.mjs",
     "agents:verify": "node .opencode/scripts/run-agent.mjs --agent verification-agent",
     "pb:init": "node scripts/product-brain-sync.mjs init",


### PR DESCRIPTION
## Summary
- Añadir comandos `agents:status` y `agents:logs` para ver progreso sin buscar logs manualmente
- Añadir checkpoint/tail del transcript en stdout mientras el agente corre (cada 30s)
- Guardar output en `.opencode/runs/` para referencia futura

## Changes
- `.opencode/scripts/run-status.mjs` — nuevo script de status/logs
- `.opencode/scripts/run-agent.mjs` — modificado para mostrar checkpoints y escribir output
- `package.json` — nuevos comandos `agents:status` y `agents:logs`

## Memoria
No aplica — es una mejora operativa interna que no afecta preferencias de usuario ni decisiones de producto.

## Verification
- npm run lint ✓
- npm run build ✓

Closes #67