### PR TITLE
fix(CACH-0031): ajustes UX móvil

### DIFF
--- a/docs/project/issues/CACH-0031.md
+++ b/docs/project/issues/CACH-0031.md
@@ -1,0 +1,83 @@
+---
+id: CACH-0031
+title: Corregir ajustes UX movil detectados en exploracion
+type: bug
+status: in-progress
+cycle: beta-1
+release: null
+priority: p1
+estimate: m
+area: frontend
+created_at: 2026-05-05
+updated_at: 2026-05-05
+aliases:
+  - CACH-0031
+tags:
+  - product-brain
+  - issue
+  - ux
+  - mobile
+related:
+  - CACH-0030
+---
+
+# CACH-0031 — Corregir ajustes UX movil detectados en exploracion
+
+## Contexto
+
+La exploracion UX movil de 2026-05-05 detecto varios problemas de render y ergonomia tactil en viewports de 360px y 390px.
+
+Informe de referencia: [[../explorations/UX-movil-exploration-2026-05-05|Exploracion UX Movil — CulturaApp]].
+
+## Problema
+
+Hay ajustes pequenos pero acumulativos que hacen la app menos comoda en movil:
+
+- Botones de navegacion de mes del dashboard demasiado pequenos.
+- Dropdown de `Select` y popup de calendario con riesgo de corte o desbordamiento.
+- Filtros de eventos ocupan demasiado alto en movil.
+- Calendarios con altura fija de 560px que puede ser excesiva en pantalla pequena.
+- Nombre de proyecto truncado en el panel movil del calendario de eventos.
+
+## Objetivo
+
+Aplicar los ajustes moviles de mayor impacto sin redisenar la navegacion ni reabrir decisiones ya aceptadas de calendario.
+
+## Alcance
+
+### Incluido
+
+- `Dashboard.jsx`: mejorar targets tactiles de navegacion de mes.
+- `Input.jsx`: ajustar altura/ancho de `Select` y `DateInput` popup para viewports pequenos.
+- `EventList.jsx`: reducir impacto vertical de filtros en movil manteniendo filtros existentes.
+- `CalendarEvents.jsx` y `CalendarProjects.jsx`: ajustar altura movil sin volver al bug de React Big Calendar.
+- `CalendarEvents.jsx`: mejorar truncado del nombre de proyecto en panel movil.
+
+### Fuera de alcance
+
+- Redisenar por completo los calendarios.
+- Reintroducir vista semana movil si ya estaba descartada.
+- Cambios de datos, Supabase, RLS o finanzas.
+- Cambios visuales amplios fuera de los hallazgos.
+
+## Criterios de aceptacion
+
+- [ ] En viewport 360px y 390px, los botones de mes del dashboard tienen target tactil minimo razonable.
+- [ ] Los dropdowns de `Select` y popup de calendario no generan overflow horizontal evidente ni quedan inutilizables cerca del borde inferior.
+- [ ] Los filtros de eventos ocupan menos espacio vertical en movil o quedan colapsables sin perder funcionalidad.
+- [ ] Los calendarios de eventos y proyectos mantienen filas visibles de React Big Calendar en movil y desktop.
+- [ ] El panel movil del calendario de eventos permite reconocer el proyecto asociado aunque el nombre sea largo.
+- [ ] No se introduce `<select>` nativo ni `input type="date"`/`datetime-local` directo en paginas.
+- [ ] `npm run lint`, `npm run build` y `npm run pb:check` pasan.
+
+## Verificacion visual
+
+- Ruta `/dashboard`, viewport 360x740 y 390x844.
+- Ruta `/events`, viewport 360x740 y 390x844.
+- Ruta `/calendar/events`, viewport 360x740 y 390x844.
+- Ruta `/calendar/projects`, viewport 360x740 y 390x844.
+- Confirmar visualmente que las semanas del mes son visibles en React Big Calendar.
+
+## Notas
+
+Mantener UI en espanol de Espana y tuteo. Si se toca Product Brain, ejecutar `npm run pb:check`.

--- a/src/components/ui/Input.jsx
+++ b/src/components/ui/Input.jsx
@@ -212,7 +212,7 @@ function DateInput({
           </button>
         </div>
         {showCalendar && (
-          <div className="absolute left-0 top-[calc(100%+0.375rem)] z-[90] w-full min-w-[20rem] max-w-[calc(100vw-2rem)] rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-surface)] p-3 text-sm shadow-xl ring-1 ring-[var(--color-ink)]/5">
+          <div className="absolute right-0 top-[calc(100%+0.375rem)] z-[90] w-full min-w-[280px] max-w-[calc(100vw-2rem)] rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-surface)] p-3 text-sm shadow-xl ring-1 ring-[var(--color-ink)]/5">
             <div className="mb-3 flex items-center justify-between gap-2">
               <button
                 type="button"
@@ -491,7 +491,7 @@ export function Select({
             id={listboxId}
             role="listbox"
             aria-labelledby={inputId}
-            className="absolute right-0 top-[calc(100%+0.375rem)] z-[80] max-h-72 min-w-full w-max max-w-[calc(100vw-2rem)] overflow-y-auto rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-surface)] p-1.5 text-base shadow-xl ring-1 ring-[var(--color-ink)]/5"
+            className="absolute right-0 top-[calc(100%+0.375rem)] z-[80] max-h-[60vh] min-w-full w-max max-w-[calc(100vw-2rem)] overflow-y-auto rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-surface)] p-1.5 text-base shadow-xl ring-1 ring-[var(--color-ink)]/5"
           >
             {options.map((option) => {
               const isSelected = option.value === String(value ?? '')

--- a/src/pages/Calendar/CalendarEvents.jsx
+++ b/src/pages/Calendar/CalendarEvents.jsx
@@ -156,7 +156,7 @@ export default function CalendarEvents() {
             </div>
           ) : (
             <div className="flex flex-1 flex-col">
-              <div className="h-[560px] min-h-[560px] overflow-x-auto overflow-y-hidden sm:h-[640px] sm:min-h-[640px] lg:h-full lg:min-h-0">
+              <div className="h-[480px] min-h-[480px] overflow-x-auto overflow-y-hidden sm:h-[560px] sm:min-h-[560px] lg:h-full lg:min-h-0">
                 <div className={`h-full ${timeGridMinWidth}`}>
                   <Calendar
                     localizer={localizer}
@@ -241,7 +241,7 @@ export default function CalendarEvents() {
                 return project ? (
                   <div className="flex items-start justify-between gap-3">
                     <span>Proyecto</span>
-                    <Link to={`/projects/${project.id}`} className="max-w-44 truncate text-right text-[var(--color-primary-500)] hover:underline">
+                    <Link to={`/projects/${project.id}`} className="max-w-52 truncate text-right text-[var(--color-primary-500)] hover:underline">
                       {project.name}
                     </Link>
                   </div>

--- a/src/pages/Calendar/CalendarProjects.jsx
+++ b/src/pages/Calendar/CalendarProjects.jsx
@@ -144,7 +144,7 @@ export default function CalendarProjects() {
             </div>
           ) : (
             <div className="flex flex-1 flex-col">
-              <div className="h-[560px] min-h-[560px] overflow-x-auto overflow-y-hidden sm:h-[640px] sm:min-h-[640px] lg:h-full lg:min-h-0">
+              <div className="h-[480px] min-h-[480px] overflow-x-auto overflow-y-hidden sm:h-[560px] sm:min-h-[560px] lg:h-full lg:min-h-0">
                 <div className={`h-full ${calendarMinWidth}`}>
                   <Calendar
                     localizer={localizer}

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -137,13 +137,13 @@ export default function Dashboard() {
             {/* Selector de mes simplificado */}
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
               <div className="flex items-center gap-1">
-                <button onClick={prevMonth} className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-500" aria-label="Mes anterior">
+                <button onClick={prevMonth} className="p-2.5 min-h-10 rounded-lg hover:bg-gray-100 text-gray-500" aria-label="Mes anterior">
                   <ChevronLeft size={18} />
                 </button>
                 <span className="text-sm font-medium text-gray-900 min-w-[100px] text-center capitalize">
                   {selectedDate.format('MMMM')}
                 </span>
-                <button onClick={nextMonth} className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-500" aria-label="Mes siguiente">
+                <button onClick={nextMonth} className="p-2.5 min-h-10 rounded-lg hover:bg-gray-100 text-gray-500" aria-label="Mes siguiente">
                   <ChevronRight size={18} />
                 </button>
                 <Select

--- a/src/pages/Events/EventList.jsx
+++ b/src/pages/Events/EventList.jsx
@@ -106,47 +106,95 @@ export default function EventList() {
                 className="w-full pl-9 pr-3 py-2 text-sm rounded-lg border border-gray-300 outline-none focus:border-[var(--color-primary-500)]"
               />
             </div>
-            <Select
-              value={filterStatus}
-              onChange={(e) => setFilterStatus(e.target.value)}
-            >
-              <option value="">Todos los estados</option>
-              {EVENT_STATUSES.map((s) => (
-                <option key={s.value} value={s.value}>{s.label}</option>
-              ))}
-            </Select>
-            <Select
-              value={filterCategory}
-              onChange={(e) => setFilterCategory(e.target.value)}
-            >
-              <option value="">Todas las categorías</option>
-              {EVENT_CATEGORIES.map((c) => (
-                <option key={c.value} value={c.value}>{c.label}</option>
-              ))}
-            </Select>
-            <Select
-              value={effectiveFilterProject}
-              onChange={(e) => {
-                setFilterProject(e.target.value)
-                if (searchParams.get('project')) {
-                  const newParams = new URLSearchParams(searchParams)
-                  newParams.delete('project')
-                  setSearchParams(newParams)
-                }
-              }}
-            >
-              <option value="">Todos los proyectos</option>
-              <option value="__none__">Sin proyecto</option>
-              {projects.map((p) => (
-                <option key={p.id} value={p.id}>{p.name}</option>
-              ))}
-            </Select>
-            {hasFilters && (
-              <Button variant="ghost" onClick={clearFilters} className="justify-center whitespace-nowrap">
-                <FilterX size={16} />
-                Limpiar
-              </Button>
-            )}
+            <details className="lg:hidden">
+              <summary className="cursor-pointer text-sm font-medium text-gray-600 list-none">Filtros ↓</summary>
+              <div className="mt-2 grid grid-cols-2 gap-3">
+                <Select
+                  value={filterStatus}
+                  onChange={(e) => setFilterStatus(e.target.value)}
+                >
+                  <option value="">Todos los estados</option>
+                  {EVENT_STATUSES.map((s) => (
+                    <option key={s.value} value={s.value}>{s.label}</option>
+                  ))}
+                </Select>
+                <Select
+                  value={filterCategory}
+                  onChange={(e) => setFilterCategory(e.target.value)}
+                >
+                  <option value="">Todas las categorías</option>
+                  {EVENT_CATEGORIES.map((c) => (
+                    <option key={c.value} value={c.value}>{c.label}</option>
+                  ))}
+                </Select>
+                <Select
+                  value={effectiveFilterProject}
+                  onChange={(e) => {
+                    setFilterProject(e.target.value)
+                    if (searchParams.get('project')) {
+                      const newParams = new URLSearchParams(searchParams)
+                      newParams.delete('project')
+                      setSearchParams(newParams)
+                    }
+                  }}
+                >
+                  <option value="">Todos los proyectos</option>
+                  <option value="__none__">Sin proyecto</option>
+                  {projects.map((p) => (
+                    <option key={p.id} value={p.id}>{p.name}</option>
+                  ))}
+                </Select>
+                {hasFilters && (
+                  <Button variant="ghost" onClick={clearFilters} className="justify-center whitespace-nowrap">
+                    <FilterX size={16} />
+                    Limpiar
+                  </Button>
+                )}
+              </div>
+            </details>
+            <div className="hidden lg:contents">
+              <Select
+                value={filterStatus}
+                onChange={(e) => setFilterStatus(e.target.value)}
+              >
+                <option value="">Todos los estados</option>
+                {EVENT_STATUSES.map((s) => (
+                  <option key={s.value} value={s.value}>{s.label}</option>
+                ))}
+              </Select>
+              <Select
+                value={filterCategory}
+                onChange={(e) => setFilterCategory(e.target.value)}
+              >
+                <option value="">Todas las categorías</option>
+                {EVENT_CATEGORIES.map((c) => (
+                  <option key={c.value} value={c.value}>{c.label}</option>
+                ))}
+              </Select>
+              <Select
+                value={effectiveFilterProject}
+                onChange={(e) => {
+                  setFilterProject(e.target.value)
+                  if (searchParams.get('project')) {
+                    const newParams = new URLSearchParams(searchParams)
+                    newParams.delete('project')
+                    setSearchParams(newParams)
+                  }
+                }}
+              >
+                <option value="">Todos los proyectos</option>
+                <option value="__none__">Sin proyecto</option>
+                {projects.map((p) => (
+                  <option key={p.id} value={p.id}>{p.name}</option>
+                ))}
+              </Select>
+              {hasFilters && (
+                <Button variant="ghost" onClick={clearFilters} className="justify-center whitespace-nowrap">
+                  <FilterX size={16} />
+                  Limpiar
+                </Button>
+              )}
+            </div>
           </div>
         </Card>
 


### PR DESCRIPTION
## Resumen

Ajustes UX móvil detectados en la exploración de 2026-05-05.

## Cambios

| Archivo | Ajuste |
|---------|--------|
| `Dashboard.jsx` | Botones de mes: `p-1.5` → `p-2.5 min-h-10` (target táctil 40px+) |
| `Input.jsx` | Popup calendario: `min-w-[20rem]` → `min-w-[280px]` + `right-0` |
| `Input.jsx` | Dropdown Select: `max-h-72` → `max-h-[60vh]` + `overflow-y-auto` |
| `EventList.jsx` | Filtros colapsables en móvil (`<details>` + grid 2x2) |
| `CalendarEvents.jsx` | Altura móvil: 560px → 480px, sm: 640px → 560px |
| `CalendarProjects.jsx` | Altura móvil: 560px → 480px, sm: 640px → 560px |
| `CalendarEvents.jsx` | Panel proyecto: `max-w-44` → `max-w-52` |

## Verificación

- `npm run lint` ✓
- `npm run build` ✓
- `npm run pb:check` ✓

## Memoria

No aplica — ajustes UX móviles menores sin persistencia de preferencias.

Closes #CACH-0031