### PR TITLE
fix(CACH-B0001): rework trabajos navigation

### DIFF
--- a/.memory/projects/culturaapp-status.md
+++ b/.memory/projects/culturaapp-status.md
@@ -23,3 +23,9 @@
 - Context: GitHub issue `#9` implemented the proposal from `#8` for grouping projects and events.
 - Durable memory: the app now has `/work` as an incremental unified "Trabajos" entry point for projects and events. Existing routes `/projects`, `/events`, `/calendar/events`, and `/calendar/projects` remain valid. `EventDetail` makes the associated project more prominent.
 - Source: commit `8b2d1a4` plus follow-up fix for `/work` links.
+
+## 2026-05-05 - Work Navigation Must Own Project/Event Details
+
+- Context: User feedback showed the previous `/work` iteration was not usable enough: after opening a project from "Trabajos", the detail pushed the user into `/projects` and forced browser-back navigation to return to the projects tab.
+- Durable memory: `/work` should be treated as the primary "Trabajos" workflow. Project and event detail pages must breadcrumb and return to `/work?view=projects` or `/work?view=events` when reached from this flow; tabs in `Trabajos` should be URL-addressable so navigation is recoverable on mobile and desktop.
+- Source: CACH-B0001 feedback and fix branch `fix/CACH-B0001-work-navigation-prod`.

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,17 +1,26 @@
-import { NavLink } from 'react-router-dom'
+import { NavLink, useLocation } from 'react-router-dom'
 import { Drama, LayoutDashboard, CalendarDays, CalendarRange, Briefcase, Settings } from 'lucide-react'
 
 const navItems = [
+  { to: '/work', icon: Briefcase, label: 'Trabajos', activePaths: ['/work', '/projects', '/events'] },
   { to: '/dashboard', icon: LayoutDashboard, label: 'Dashboard' },
   { to: '/calendar/events', icon: CalendarDays, label: 'Cal. eventos' },
   { to: '/calendar/projects', icon: CalendarRange, label: 'Cal. proyectos' },
-  { to: '/work', icon: Briefcase, label: 'Trabajos' },
   { to: '/settings', icon: Settings, label: 'Ajustes' },
 ]
 
 export function Sidebar({ onNavigate, isDrawer = false }) {
+  const location = useLocation()
   const handleNavClick = () => {
     if (onNavigate) onNavigate()
+  }
+
+  const isItemActive = (item, navLinkActive) => {
+    if (navLinkActive) return true
+    return item.activePaths?.some((path) => {
+      if (location.pathname === path) return true
+      return location.pathname.startsWith(`${path}/`)
+    })
   }
 
   return (
@@ -39,22 +48,22 @@ export function Sidebar({ onNavigate, isDrawer = false }) {
           }
         `}
       >
-        {navItems.map(({ to, icon: Icon, label }) => (
+        {navItems.map((item) => (
           <NavLink
-            key={to}
-            to={to}
+            key={item.to}
+            to={item.to}
             onClick={handleNavClick}
             className={({ isActive }) =>
               `flex min-h-10 shrink-0 items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2 lg:shrink
-              ${isActive
+              ${isItemActive(item, isActive)
                 ? 'bg-[#C94035] text-[#F5EFE0]'
                 : 'text-[rgba(245,239,224,.75)] hover:bg-[rgba(245,239,224,.08)] hover:text-[#F5EFE0]'
               }`
             }
-            title={label}
+            title={item.label}
           >
-            <Icon size={18} className="shrink-0" />
-            <span className="whitespace-nowrap">{label}</span>
+            <item.icon size={18} className="shrink-0" />
+            <span className="whitespace-nowrap">{item.label}</span>
           </NavLink>
         ))}
       </nav>

--- a/src/pages/Events/EventDetail.jsx
+++ b/src/pages/Events/EventDetail.jsx
@@ -21,11 +21,19 @@ import { isPaid, markPaid, markUnpaid } from '../../lib/payment'
 import { EXPENSE_CATEGORIES } from '../../lib/constants'
 
 const EMPTY_EXPENSE = { concept: '', amount: '', category: 'otros', expense_date: '', is_deductible: true }
+const compactSecondaryAction = 'inline-flex min-h-9 items-center justify-center gap-2 rounded-lg border border-[#E2D9C2] bg-[#F5EFE0] px-3 py-1.5 text-sm font-medium leading-none text-[#211C18] shadow-sm transition-colors hover:bg-[#EBE3CE] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2'
+const compactPrimaryAction = 'inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-[#C94035] px-3 py-1.5 text-sm font-medium leading-none text-white shadow-sm transition-colors hover:bg-[#A8342B] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2'
+const compactDangerAction = 'inline-flex min-h-9 items-center justify-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium leading-none text-[#C94035] transition-colors hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2'
 
 const getEventHours = (event) => {
   if (!event.end_datetime) return 0
   const minutes = (new Date(event.end_datetime).getTime() - new Date(event.start_datetime).getTime()) / 60000
   return minutes > 0 ? minutes / 60 : 0
+}
+
+function QuietStatusBadge({ status }) {
+  if (!status || status === 'confirmed') return null
+  return <StatusBadge status={status} />
 }
 
 export default function EventDetail() {
@@ -198,22 +206,24 @@ export default function EventDetail() {
 
   return (
     <PageWrapper title={event.name}>
-      <div className="flex flex-col gap-6 max-w-4xl">
+      <div className="flex max-w-4xl flex-col gap-4 sm:gap-5">
         <nav className="flex items-center gap-1.5 text-xs text-gray-400 breadcrumbs">
-          <Link to="/events" className="hover:text-gray-600">Eventos</Link>
+          <Link to="/work" className="hover:text-gray-600">Trabajos</Link>
+          <span>/</span>
+          <Link to="/work?view=events" className="hover:text-gray-600">Eventos</Link>
           <span>/</span>
           <span className="text-gray-600">{event.name}</span>
         </nav>
-        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex items-center gap-3">
-            <Link to="/events" className="text-gray-400 hover:text-gray-700">
+            <Link to="/work?view=events" className="text-gray-400 hover:text-gray-700" aria-label="Volver a eventos en trabajos">
               <ArrowLeft size={20} />
             </Link>
             <div>
-              <div className="flex items-center gap-2">
-                <div className="w-3 h-3 rounded-full" style={{ backgroundColor: event.color ?? '#4f98a3' }} />
-                <h2 className="text-lg font-semibold text-gray-900">{event.name}</h2>
-                <StatusBadge status={event.status} />
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <div className="h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: event.color ?? '#4f98a3' }} />
+                <h2 className="min-w-0 text-lg font-semibold text-gray-900">{event.name}</h2>
+                <QuietStatusBadge status={event.status} />
               </div>
               {event.client && <p className="text-sm text-gray-500 mt-0.5">{event.client}</p>}
               <p className="text-xs text-gray-400 mt-1 capitalize">
@@ -242,24 +252,24 @@ export default function EventDetail() {
                     </Link>
                   </div>
                 </div>
-                <Link to={`/projects/${project.id}`}>
-                  <Button size="sm" variant="secondary">Ver proyecto</Button>
+                <Link to={`/projects/${project.id}`} className={compactSecondaryAction}>
+                  Ver proyecto
                 </Link>
               </div>
             </Card>
           )}
 
           <div className="flex flex-wrap gap-2 sm:justify-end">
-            <Button variant="secondary" size="sm" onClick={() => setEditModal(true)} className="min-h-11 min-w-[5.5rem]">
+            <button type="button" onClick={() => setEditModal(true)} className={compactSecondaryAction}>
               <Edit size={14} /> Editar
-            </Button>
-            <Button variant="danger" size="sm" onClick={handleDeleteEvent} className="min-h-11 min-w-[5.5rem]">
+            </button>
+            <button type="button" onClick={handleDeleteEvent} className={compactDangerAction}>
               <Trash2 size={14} /> Eliminar
-            </Button>
+            </button>
           </div>
         </div>
 
-        <Card className="p-5 bg-gray-50">
+        <Card className="bg-gray-50 p-4 sm:p-5">
           <button
             type="button"
             onClick={() => setFinancialSummaryExpanded((prev) => !prev)}
@@ -301,24 +311,21 @@ export default function EventDetail() {
         </Card>
 
         {/* Ingresos */}
-        <Card className="p-5">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        <Card className="p-4 sm:p-5">
+          <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <h3 className="text-sm font-semibold text-gray-900">Ingresos</h3>
               <p className="text-xs text-gray-500 mt-1">Pagos previstos o cobrados por este evento.</p>
             </div>
-            <Button size="sm" onClick={openNewIncome}>
+            <button type="button" onClick={openNewIncome} className={compactPrimaryAction}>
               <Plus size={14} /> Añadir ingreso
-            </Button>
+            </button>
           </div>
           {incomesLoading ? (
             <p className="text-sm text-gray-400">Cargando ingresos...</p>
           ) : incomes.length === 0 ? (
             <div className="rounded-lg border border-dashed border-gray-200 p-4 text-sm text-gray-500">
               <p>No hay ingresos registrados para este evento.</p>
-              <Button size="sm" className="mt-3" onClick={openNewIncome}>
-                <Plus size={14} /> Añadir primer ingreso
-              </Button>
             </div>
 ) : (
             <div className="md:relative md:overflow-x-auto">
@@ -405,24 +412,21 @@ export default function EventDetail() {
         </Card>
 
         {/* Gastos */}
-        <Card className="p-5">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        <Card className="p-4 sm:p-5">
+          <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <h3 className="text-sm font-semibold text-gray-900">Gastos</h3>
               <p className="text-xs text-gray-500 mt-1">Costes asociados directamente a este evento.</p>
             </div>
-            <Button size="sm" onClick={openNewExpense}>
+            <button type="button" onClick={openNewExpense} className={compactPrimaryAction}>
               <Plus size={14} /> Añadir gasto
-            </Button>
+            </button>
           </div>
           {expensesLoading ? (
             <p className="text-sm text-gray-400">Cargando gastos...</p>
           ) : expenses.length === 0 ? (
             <div className="rounded-lg border border-dashed border-gray-200 p-4 text-sm text-gray-500">
               <p>No hay gastos registrados para este evento.</p>
-              <Button size="sm" className="mt-3" onClick={openNewExpense}>
-                <Plus size={14} /> Añadir primer gasto
-              </Button>
             </div>
 ) : (
             <div className="md:relative md:overflow-x-auto">

--- a/src/pages/Projects/ProjectDetail.jsx
+++ b/src/pages/Projects/ProjectDetail.jsx
@@ -21,11 +21,19 @@ import { isPaid, markPaid, markUnpaid } from '../../lib/payment'
 import { EXPENSE_CATEGORIES } from '../../lib/constants'
 
 const EMPTY_EXPENSE = { concept: '', amount: '', category: 'otros', expense_date: '', is_deductible: true }
+const compactSecondaryAction = 'inline-flex min-h-9 items-center justify-center gap-2 rounded-lg border border-[#E2D9C2] bg-[#F5EFE0] px-3 py-1.5 text-sm font-medium leading-none text-[#211C18] shadow-sm transition-colors hover:bg-[#EBE3CE] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2'
+const compactPrimaryAction = 'inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-[#C94035] px-3 py-1.5 text-sm font-medium leading-none text-white shadow-sm transition-colors hover:bg-[#A8342B] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2'
+const compactDangerAction = 'inline-flex min-h-9 items-center justify-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium leading-none text-[#C94035] transition-colors hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2'
 
 const getEventHours = (event) => {
   if (!event.end_datetime) return 0
   const minutes = (new Date(event.end_datetime).getTime() - new Date(event.start_datetime).getTime()) / 60000
   return minutes > 0 ? minutes / 60 : 0
+}
+
+function QuietStatusBadge({ status }) {
+  if (!status || status === 'confirmed') return null
+  return <StatusBadge status={status} />
 }
 
 export default function ProjectDetail() {
@@ -189,22 +197,24 @@ export default function ProjectDetail() {
 
   return (
     <PageWrapper title={project.name}>
-      <div className="flex flex-col gap-6 max-w-4xl">
+      <div className="flex max-w-4xl flex-col gap-4 sm:gap-5">
         <nav className="flex items-center gap-1.5 text-xs text-gray-400 breadcrumbs">
-          <Link to="/projects" className="hover:text-gray-600">Proyectos</Link>
+          <Link to="/work" className="hover:text-gray-600">Trabajos</Link>
+          <span>/</span>
+          <Link to="/work?view=projects" className="hover:text-gray-600">Proyectos</Link>
           <span>/</span>
           <span className="text-gray-600">{project.name}</span>
         </nav>
-        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex items-center gap-3">
-            <Link to="/projects" className="text-gray-400 hover:text-gray-700">
+            <Link to="/work?view=projects" className="text-gray-400 hover:text-gray-700" aria-label="Volver a proyectos en trabajos">
               <ArrowLeft size={20} />
             </Link>
             <div>
-              <div className="flex items-center gap-2">
-                <div className="w-3 h-3 rounded-full" style={{ backgroundColor: project.color ?? '#4f98a3' }} />
-                <h2 className="text-lg font-semibold text-gray-900">{project.name}</h2>
-                <StatusBadge status={project.status} />
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <div className="h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: project.color ?? '#4f98a3' }} />
+                <h2 className="min-w-0 text-lg font-semibold text-gray-900">{project.name}</h2>
+                <QuietStatusBadge status={project.status} />
               </div>
               {project.client && <p className="text-sm text-gray-500 mt-0.5">{project.client}</p>}
               <p className="text-xs text-gray-400 mt-1 capitalize">
@@ -213,16 +223,16 @@ export default function ProjectDetail() {
             </div>
           </div>
           <div className="flex flex-wrap gap-2 sm:justify-end">
-            <Button variant="secondary" size="sm" onClick={() => setEditModal(true)} className="min-h-11 min-w-[5.5rem]">
+            <button type="button" onClick={() => setEditModal(true)} className={compactSecondaryAction}>
               <Edit size={14} /> Editar
-            </Button>
-            <Button variant="danger" size="sm" onClick={handleDeleteProject} className="min-h-11 min-w-[5.5rem]">
+            </button>
+            <button type="button" onClick={handleDeleteProject} className={compactDangerAction}>
               <Trash2 size={14} /> Eliminar
-            </Button>
+            </button>
           </div>
         </div>
 
-        <Card className="p-5 bg-gray-50">
+        <Card className="bg-gray-50 p-4 sm:p-5">
           <button
             type="button"
             onClick={() => setFinancialSummaryExpanded((prev) => !prev)}
@@ -264,8 +274,8 @@ export default function ProjectDetail() {
         </Card>
 
         {/* Eventos asociados */}
-        <Card className="p-5">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        <Card className="p-4 sm:p-5">
+          <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center gap-2">
               <CalendarDays size={16} className="text-[var(--color-primary-500)]" />
               <div>
@@ -273,10 +283,8 @@ export default function ProjectDetail() {
                 <p className="text-xs text-gray-500 mt-1">Ocurrencias concretas dentro de este proyecto.</p>
               </div>
             </div>
-            <Link to={`/events?project=${id}`}>
-              <Button size="sm" variant="secondary">
-                <Plus size={14} /> Nuevo evento
-              </Button>
+            <Link to={`/events?project=${id}`} className={compactSecondaryAction}>
+              <Plus size={14} /> Nuevo evento
             </Link>
           </div>
           {eventsLoading ? (
@@ -284,10 +292,8 @@ export default function ProjectDetail() {
           ) : events.length === 0 ? (
             <div className="rounded-lg border border-dashed border-gray-200 p-4 text-sm text-gray-500">
               <p>No hay eventos asociados a este proyecto todavía.</p>
-              <Link to={`/events?project=${id}`} className="inline-flex mt-3">
-                <Button size="sm" variant="secondary">
-                  <Plus size={14} /> Crear primer evento
-                </Button>
+              <Link to={`/events?project=${id}`} className={`${compactSecondaryAction} mt-3`}>
+                <Plus size={14} /> Crear evento
               </Link>
             </div>
           ) : (
@@ -296,16 +302,16 @@ export default function ProjectDetail() {
                 <Link
                   key={event.id}
                   to={`/events/${event.id}`}
-                  className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0 hover:bg-gray-50 -mx-2 px-2 rounded-lg transition-colors"
+                  className="-mx-2 flex min-w-0 items-center justify-between gap-3 rounded-lg border-b border-gray-100 px-2 py-2 transition-colors last:border-0 hover:bg-gray-50"
                 >
-                  <div className="flex items-center gap-2">
+                  <div className="flex min-w-0 items-center gap-2">
                     <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: event.color ?? '#4f98a3' }} />
-                    <div>
-                      <p className="text-sm font-medium text-gray-900">{event.name}</p>
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium text-gray-900">{event.name}</p>
                       <p className="text-xs text-gray-400">{formatDatetime(event.start_datetime)}</p>
                     </div>
                   </div>
-                  <StatusBadge status={event.status} />
+                  <QuietStatusBadge status={event.status} />
                 </Link>
               ))}
             </div>
@@ -313,24 +319,21 @@ export default function ProjectDetail() {
         </Card>
 
         {/* Ingresos directos del proyecto */}
-        <Card className="p-5">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        <Card className="p-4 sm:p-5">
+          <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <h3 className="text-sm font-semibold text-gray-900">Ingresos del proyecto</h3>
               <p className="text-xs text-gray-400 mt-0.5">No atribuibles a un evento concreto</p>
             </div>
-            <Button size="sm" onClick={openNewIncome}>
+            <button type="button" onClick={openNewIncome} className={compactPrimaryAction}>
               <Plus size={14} /> Añadir ingreso
-            </Button>
+            </button>
           </div>
           {incomesLoading ? (
             <p className="text-sm text-gray-400">Cargando ingresos...</p>
           ) : directIncomes.length === 0 ? (
             <div className="rounded-lg border border-dashed border-gray-200 p-4 text-sm text-gray-500">
               <p>No hay ingresos directos del proyecto registrados.</p>
-              <Button size="sm" className="mt-3" onClick={openNewIncome}>
-                <Plus size={14} /> Añadir primer ingreso
-              </Button>
             </div>
 ) : (
             <div className="md:relative md:overflow-x-auto">
@@ -396,24 +399,21 @@ export default function ProjectDetail() {
         </Card>
 
         {/* Gastos directos del proyecto */}
-        <Card className="p-5">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        <Card className="p-4 sm:p-5">
+          <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <h3 className="text-sm font-semibold text-gray-900">Gastos del proyecto</h3>
               <p className="text-xs text-gray-400 mt-0.5">No atribuibles a un evento concreto</p>
             </div>
-            <Button size="sm" onClick={openNewExpense}>
+            <button type="button" onClick={openNewExpense} className={compactPrimaryAction}>
               <Plus size={14} /> Añadir gasto
-            </Button>
+            </button>
           </div>
           {expensesLoading ? (
             <p className="text-sm text-gray-400">Cargando gastos...</p>
           ) : directExpenses.length === 0 ? (
             <div className="rounded-lg border border-dashed border-gray-200 p-4 text-sm text-gray-500">
               <p>No hay gastos directos del proyecto registrados.</p>
-              <Button size="sm" className="mt-3" onClick={openNewExpense}>
-                <Plus size={14} /> Añadir primer gasto
-              </Button>
             </div>
 ) : (
             <div className="md:relative md:overflow-x-auto">

--- a/src/pages/Work/Work.jsx
+++ b/src/pages/Work/Work.jsx
@@ -1,140 +1,264 @@
-import { useState, useMemo } from 'react'
-import { Link } from 'react-router-dom'
-import { FolderOpen, Ticket } from 'lucide-react'
+import { useMemo } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { Briefcase, CalendarDays, ChevronRight, FolderOpen, Plus, Ticket } from 'lucide-react'
 import { PageWrapper } from '../../components/layout/PageWrapper'
 import { Card } from '../../components/ui/Card'
-import { Button } from '../../components/ui/Button'
 import { StatusBadge } from '../../components/ui/Badge'
 import { useAuth } from '../../hooks/useAuth'
 import { useProjects } from '../../hooks/useProjects'
 import { useEvents } from '../../hooks/useEvents'
-import { formatDatetime } from '../../lib/formatters'
+import { formatDateRange, formatDatetime } from '../../lib/formatters'
 
-function ProjectCard({ project }) {
+const views = [
+  { value: 'all', label: 'Todo' },
+  { value: 'projects', label: 'Proyectos' },
+  { value: 'events', label: 'Eventos' },
+]
+
+const linkButtonClass = 'inline-flex min-h-10 items-center justify-center gap-2 rounded-lg bg-[#C94035] px-4 py-2 text-sm font-medium leading-none text-white shadow-sm transition-colors hover:bg-[#A8342B] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2'
+const secondaryLinkButtonClass = 'inline-flex min-h-10 items-center justify-center gap-2 rounded-lg border border-[#E2D9C2] bg-[#F5EFE0] px-4 py-2 text-sm font-medium leading-none text-[#211C18] shadow-sm transition-colors hover:bg-[#EBE3CE] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2'
+
+function QuietStatusBadge({ status }) {
+  if (!status || status === 'confirmed') return null
+  return <StatusBadge status={status} />
+}
+
+function EventRow({ event, compact = false }) {
   return (
     <Link
-      to={`/projects/${project.id}`}
-      className="block p-3 rounded-lg border border-gray-100 bg-white hover:border-gray-300 transition-colors"
+      to={`/events/${event.id}`}
+      className={`group flex min-w-0 items-center gap-3 rounded-lg border border-[#E2D9C2] bg-[#FDFBF6] px-3 py-3 transition-colors hover:border-[#C94035]/40 hover:bg-white ${compact ? '' : 'sm:px-4'}`}
     >
-      <div className="flex items-center gap-2">
-        <div className="w-2 h-2 rounded-full" style={{ backgroundColor: project.color ?? '#4f98a3' }} />
-        <span className="text-sm font-medium text-gray-900 truncate flex-1">{project.name}</span>
-        <StatusBadge status={project.status} size="sm" />
-      </div>
-      {project.client && <p className="text-xs text-gray-400 mt-1 pl-4 truncate">{project.client}</p>}
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[#EBE3CE] text-[#5C5149]">
+        <Ticket size={16} />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-sm font-medium text-[#211C18]">{event.name}</span>
+          <QuietStatusBadge status={event.status} />
+        </span>
+        <span className="mt-0.5 block truncate text-xs text-[#5C5149]">
+          {formatDatetime(event.start_datetime)}
+          {event.client ? ` · ${event.client}` : ''}
+        </span>
+      </span>
+      <ChevronRight size={16} className="shrink-0 text-[#8A7A6D] transition-transform group-hover:translate-x-0.5" />
     </Link>
   )
 }
 
-function EventCard({ event }) {
+function ProjectBlock({ project, events }) {
   return (
-    <Link
-      to={`/events/${event.id}`}
-      className="block p-3 rounded-lg border border-gray-100 bg-white hover:border-gray-300 transition-colors"
-    >
-      <div className="flex items-center gap-2">
-        <div className="w-2 h-2 rounded-full" style={{ backgroundColor: event.color ?? '#4f98a3' }} />
-        <span className="text-sm font-medium text-gray-900 truncate flex-1">{event.name}</span>
-        <StatusBadge status={event.status} size="sm" />
+    <Card className="overflow-hidden">
+      <div className="flex flex-col gap-4 p-4 sm:p-5">
+        <div className="flex items-start gap-3">
+          <span
+            className="mt-1 h-3 w-3 shrink-0 rounded-full"
+            style={{ backgroundColor: project.color ?? '#4f98a3' }}
+            aria-hidden="true"
+          />
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <Link
+                to={`/projects/${project.id}`}
+                className="min-w-0 truncate text-base font-semibold text-[#211C18] hover:text-[#C94035] hover:underline"
+              >
+                {project.name}
+              </Link>
+              <QuietStatusBadge status={project.status} />
+            </div>
+            <p className="mt-1 truncate text-sm text-[#5C5149]">
+              {project.client ? `${project.client} · ` : ''}
+              {formatDateRange(project.start_date, project.end_date)}
+            </p>
+          </div>
+          <Link
+            to={`/projects/${project.id}`}
+            className="inline-flex h-9 shrink-0 items-center justify-center rounded-lg px-2 text-[#5C5149] hover:bg-[#EBE3CE] hover:text-[#211C18] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035]"
+            aria-label={`Abrir proyecto ${project.name}`}
+          >
+            <ChevronRight size={18} />
+          </Link>
+        </div>
+
+        {events.length > 0 ? (
+          <div className="grid gap-2">
+            {events.map((event) => (
+              <EventRow key={event.id} event={event} compact />
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed border-[#E2D9C2] bg-[#FDFBF6] px-3 py-3 text-sm text-[#8A7A6D]">
+            Sin eventos asociados todavía.
+          </div>
+        )}
       </div>
-      <p className="text-xs text-gray-400 mt-1 pl-4 truncate">{formatDatetime(event.start_datetime)}</p>
-    </Link>
+    </Card>
   )
 }
 
 export default function Work() {
   const { user } = useAuth()
-  const { projects, loading: projectsLoading } = useProjects(user?.id)
-  const { events, loading: eventsLoading } = useEvents(user?.id)
-  const [tab, setTab] = useState('projects')
+  const { projects, loading: projectsLoading, error: projectsError } = useProjects(user?.id)
+  const { events, loading: eventsLoading, error: eventsError } = useEvents(user?.id)
+  const [searchParams, setSearchParams] = useSearchParams()
 
-  // Forzar renderizado consistente del tab activo
-  const activeTab = useMemo(() => tab, [tab])
+  const currentView = views.some((view) => view.value === searchParams.get('view'))
+    ? searchParams.get('view')
+    : 'all'
+
+  const eventsByProject = useMemo(() => {
+    const grouped = new Map()
+    events.forEach((event) => {
+      if (!event.project_id) return
+      const projectEvents = grouped.get(event.project_id) ?? []
+      projectEvents.push(event)
+      grouped.set(event.project_id, projectEvents)
+    })
+    return grouped
+  }, [events])
+
+  const projectIds = useMemo(() => new Set(projects.map((project) => project.id)), [projects])
+  const standaloneEvents = useMemo(
+    () => events.filter((event) => !event.project_id || !projectIds.has(event.project_id)),
+    [events, projectIds]
+  )
+
+  const loading = projectsLoading || eventsLoading
+  const error = projectsError || eventsError
+  const showProjects = currentView === 'all' || currentView === 'projects'
+  const showEvents = currentView === 'all' || currentView === 'events'
+  const visibleProjectCount = showProjects ? projects.length : 0
+  const visibleStandaloneCount = showEvents ? standaloneEvents.length : 0
+  const hasAnyWork = projects.length > 0 || events.length > 0
+
+  const setView = (view) => {
+    const nextParams = new URLSearchParams(searchParams)
+    if (view === 'all') nextParams.delete('view')
+    else nextParams.set('view', view)
+    setSearchParams(nextParams, { replace: true })
+  }
 
   return (
     <PageWrapper title="Trabajos">
-      {/* Tabs simplificados */}
-      <div className="flex gap-1 p-1 bg-gray-100 rounded-lg w-fit mb-4" role="tablist" aria-label="Ver proyectos o eventos">
-        <button
-          role="tab"
-          aria-selected={activeTab === 'projects'}
-          onClick={() => setTab('projects')}
-          className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors min-w-[80px] ${
-            activeTab === 'projects' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'
-          }`}
-        >
-          Proyectos
-        </button>
-        <button
-          role="tab"
-          aria-selected={activeTab === 'events'}
-          onClick={() => setTab('events')}
-          className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors min-w-[80px] ${
-            activeTab === 'events' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'
-          }`}
-        >
-          Eventos
-        </button>
-      </div>
-
-      {/* Proyectos */}
-      {activeTab === 'projects' && (
-        <div className="flex flex-col gap-3">
-          {projectsLoading ? (
-            <p className="text-sm text-gray-400">Cargando...</p>
-          ) : projects.length === 0 ? (
-            <Card className="p-6 text-center">
-              <p className="text-sm text-gray-500 mb-3">Sin proyectos</p>
-              <Link to="/projects">
-                <Button size="sm">Crear proyecto</Button>
-              </Link>
-            </Card>
-          ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              {projects.map(project => (
-                <ProjectCard key={project.id} project={project} />
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Eventos */}
-      {activeTab === 'events' && (
-        <div className="flex flex-col gap-3">
-          {eventsLoading ? (
-            <p className="text-sm text-gray-400">Cargando...</p>
-          ) : events.length === 0 ? (
-            <Card className="p-6 text-center">
-              <p className="text-sm text-gray-500 mb-3">Sin eventos</p>
-              <Link to="/events">
-                <Button size="sm">Crear evento</Button>
-              </Link>
-            </Card>
-          ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              {events.map(event => (
-                <EventCard key={event.id} event={event} />
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Estado vacío general */}
-      {!projectsLoading && !eventsLoading && projects.length === 0 && events.length === 0 && (
-        <Card className="p-6 text-center">
-          <p className="text-sm text-gray-500 mb-3">No tienes ningún trabajo registrado.</p>
-          <div className="flex justify-center gap-2">
-            <Link to="/projects">
-              <Button size="sm"><FolderOpen size={14} /> Proyecto</Button>
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0">
+            <p className="text-sm text-[#5C5149]">
+              {projects.length} proyectos · {events.length} eventos
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Link to="/projects" className={secondaryLinkButtonClass}>
+              <Plus size={16} />
+              Proyecto
             </Link>
-            <Link to="/events">
-              <Button size="sm" variant="secondary"><Ticket size={14} /> Evento</Button>
+            <Link to="/events" className={linkButtonClass}>
+              <Plus size={16} />
+              Evento
             </Link>
           </div>
-        </Card>
-      )}
+        </div>
+
+        <div className="flex w-full gap-1 rounded-lg bg-[#EBE3CE] p-1 sm:w-fit" role="tablist" aria-label="Filtrar trabajos">
+          {views.map((view) => (
+            <button
+              key={view.value}
+              type="button"
+              role="tab"
+              aria-selected={currentView === view.value}
+              onClick={() => setView(view.value)}
+              className={`min-h-10 flex-1 rounded-md px-3 text-sm font-medium transition-colors sm:flex-none sm:min-w-24 ${
+                currentView === view.value
+                  ? 'bg-white text-[#211C18] shadow-sm'
+                  : 'text-[#5C5149] hover:text-[#211C18]'
+              }`}
+            >
+              {view.label}
+            </button>
+          ))}
+        </div>
+
+        {error && (
+          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            No hemos podido cargar todos los trabajos. Revisa la conexión y vuelve a intentarlo.
+          </div>
+        )}
+
+        {loading ? (
+          <div className="grid gap-3">
+            {[1, 2, 3].map((item) => (
+              <Card key={item} className="p-5">
+                <div className="h-4 w-2/3 rounded bg-[#EBE3CE]" />
+                <div className="mt-3 h-3 w-1/2 rounded bg-[#EBE3CE]" />
+                <div className="mt-5 h-10 rounded bg-[#F5EFE0]" />
+              </Card>
+            ))}
+          </div>
+        ) : !hasAnyWork ? (
+          <Card className="p-6 text-center">
+            <Briefcase size={36} className="mx-auto text-[#8A7A6D]" />
+            <p className="mt-3 text-sm font-medium text-[#211C18]">No tienes ningún trabajo registrado.</p>
+            <p className="mx-auto mt-1 max-w-md text-sm text-[#5C5149]">
+              Crea un proyecto si quieres agrupar varias fechas o un evento si es una cita concreta.
+            </p>
+            <div className="mt-4 flex flex-col justify-center gap-2 sm:flex-row">
+              <Link to="/projects" className={secondaryLinkButtonClass}>
+                <FolderOpen size={16} />
+                Crear proyecto
+              </Link>
+              <Link to="/events" className={linkButtonClass}>
+                <Ticket size={16} />
+                Crear evento
+              </Link>
+            </div>
+          </Card>
+        ) : visibleProjectCount === 0 && visibleStandaloneCount === 0 ? (
+          <Card className="p-6 text-center">
+            <CalendarDays size={32} className="mx-auto text-[#8A7A6D]" />
+            <p className="mt-3 text-sm font-medium text-[#211C18]">No hay trabajos en esta vista.</p>
+            <button
+              type="button"
+              onClick={() => setView('all')}
+              className="mt-4 text-sm font-medium text-[#C94035] hover:underline"
+            >
+              Ver todo
+            </button>
+          </Card>
+        ) : (
+          <div className="grid gap-5">
+            {showProjects && projects.length > 0 && (
+              <section className="grid gap-3" aria-labelledby="work-projects-heading">
+                <h2 id="work-projects-heading" className="text-sm font-semibold text-[#211C18]">
+                  Proyectos
+                </h2>
+                <div className="grid gap-3 xl:grid-cols-2">
+                  {projects.map((project) => (
+                    <ProjectBlock
+                      key={project.id}
+                      project={project}
+                      events={eventsByProject.get(project.id) ?? []}
+                    />
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {showEvents && standaloneEvents.length > 0 && (
+              <section className="grid gap-3" aria-labelledby="work-events-heading">
+                <h2 id="work-events-heading" className="text-sm font-semibold text-[#211C18]">
+                  Eventos sin proyecto
+                </h2>
+                <div className="grid gap-2 xl:grid-cols-2">
+                  {standaloneEvents.map((event) => (
+                    <EventRow key={event.id} event={event} />
+                  ))}
+                </div>
+              </section>
+            )}
+          </div>
+        )}
+      </div>
     </PageWrapper>
   )
 }


### PR DESCRIPTION
## Resumen

- Replantea `Trabajos` como flujo principal con tabs navegables por URL.
- Agrupa eventos bajo proyectos y evita duplicados confusos en `/work`.
- Hace que los detalles de proyecto y evento vuelvan a `Trabajos` en la pestaña correcta.
- Compacta CTAs y reduce ruido visual de badges `Confirmado` en detalles.

## Validación

- `npm run lint`
- `npm run build`

## Memoria

actualizada en `.memory/projects/culturaapp-status.md` con la regla durable de navegación de `Trabajos`.