### PR TITLE
feat(CACH-0032): priorizar operativa diaria en dashboard móvil

### DIFF
--- a/.memory/MEMORY.md
+++ b/.memory/MEMORY.md
@@ -7,6 +7,7 @@ Mapa estructurado ampliado: [core.md](core.md)
 - [Memoria centralizada en .memory/](project_memory_centralization.md) — Memoria movida de ruta Claude a .memory/ en el repo (2026-05-03)
 - [Routing/deploy](projects/routing-deploy.md) — Vercel necesita fallback SPA para recargas de rutas protegidas; producción verificada en `culturapp-rho.vercel.app`
 - [Estado general](projects/culturaapp-status.md) — Estado implementado del MVP, `/work` y brechas pendientes
+- [Dashboard móvil](projects/dashboard-mobile.md) — En móvil, priorizar información operativa diaria sobre KPIs financieros
 
 ## Referencias
 

--- a/.memory/core.md
+++ b/.memory/core.md
@@ -9,6 +9,7 @@ Repository-local memory for CulturaApp agents. This file is a compact map; detai
 - Portable skills and memory protocol: see [topics/portable-skills.md](topics/portable-skills.md).
 - Form controls and mobile selector lessons: see [topics/forms.md](topics/forms.md).
 - Overall CulturaApp implementation timeline: see [projects/culturaapp-status.md](projects/culturaapp-status.md).
+- Mobile dashboard product priority: see [projects/dashboard-mobile.md](projects/dashboard-mobile.md).
 - Calendar layout and mobile week UX: see [projects/calendar.md](projects/calendar.md).
 - Dashboard finance calculations: see [projects/dashboard-finance.md](projects/dashboard-finance.md).
 - Routing/deploy caveats: see [projects/routing-deploy.md](projects/routing-deploy.md).

--- a/.memory/me.md
+++ b/.memory/me.md
@@ -11,6 +11,7 @@ Durable collaboration preferences and user-provided context for CulturaApp agent
 - Before committing, pushing, closing an issue, or wrapping a meaningful session, explicitly check whether new durable preferences, product decisions, or workflow lessons should be saved in `.memory/`.
 - Before opening a PR, whether working through OpenCode agents or directly as Codex/Claude Code, complete the memory checkpoint: update `.memory/` with durable context or explicitly state `Memoria: no aplica`.
 - Do not duplicate every issue, PR, or commit in `.memory/`; use GitHub issues, PRs, and commits as the operational history when reconstructing task context. Save only durable preferences, product decisions, recurring gotchas, or workflow lessons.
+- For frontend or visual changes, start the local app when feasible and inspect the result instead of relying only on code review, lint, or build output.
 
 ## Privacy Boundary
 

--- a/.memory/projects/dashboard-mobile.md
+++ b/.memory/projects/dashboard-mobile.md
@@ -1,0 +1,13 @@
+# Dashboard Mobile Memory
+
+Durable product decisions for the mobile dashboard experience in Cachés.
+
+## 2026-05-05 — Operative mobile priority
+
+The mobile dashboard should prioritize day-to-day operational awareness over financial reporting. On small screens, the first information should answer questions such as:
+
+- What do I have today or next?
+- Which pending payments need attention soon?
+- Which active projects are moving now?
+
+Financial KPIs remain useful, but should be secondary and compact on mobile instead of dominating the first screen with "how much did I earn" metrics.

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -68,7 +68,9 @@ Sin issues en progreso.
 
 ## Review
 
-Sin issues en review.
+| ID | Titulo | Tipo | Prioridad | Nota |
+|---|---|---|---|---|
+| [[../issues/CACH-0032|CACH-0032]] | Priorizar operativa diaria en dashboard movil | feature | p1 | PR pendiente. |
 
 ## Done
 

--- a/docs/project/indexes/issues.index.md
+++ b/docs/project/indexes/issues.index.md
@@ -17,6 +17,7 @@ tags:
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion
+- [[../issues/CACH-0032|CACH-0032]] — Priorizar operativa diaria en dashboard movil
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes

--- a/docs/project/issues/CACH-0032.md
+++ b/docs/project/issues/CACH-0032.md
@@ -1,0 +1,69 @@
+---
+id: CACH-0032
+title: Priorizar operativa diaria en dashboard movil
+type: feature
+status: review
+cycle: unassigned
+release: null
+priority: p1
+estimate: s
+area: frontend
+created_at: 2026-05-05
+updated_at: 2026-05-05
+aliases:
+  - CACH-0032
+tags:
+  - product-brain
+  - issue
+  - mobile
+  - dashboard
+related:
+  - CACH-B0002
+---
+
+# CACH-0032 — Priorizar operativa diaria en dashboard movil
+
+## Objetivo
+
+Hacer que el Dashboard en movil priorice informacion operativa del dia a dia antes que KPIs financieros completos.
+
+## Alcance
+
+Incluido:
+
+- Reordenar la jerarquia mobile del Dashboard para que el primer bloque responda que hay hoy/proximamente.
+- Mostrar cobros urgentes o vencidos de forma compacta.
+- Mantener una lectura financiera minima, sin ocupar la primera pantalla con cinco KPIs.
+- Conservar la experiencia desktop actual.
+
+Fuera de alcance:
+
+- Redisenar formularios financieros.
+- Sustituir tablas financieras en evento/proyecto.
+- Cambiar calculos financieros o hooks de Supabase.
+- Cerrar la issue paraguas `CACH-B0002`, que sigue cubriendo mas superficies mobile.
+
+## Criterios de aceptacion
+
+- [x] En mobile, el primer bloque del Dashboard muestra informacion operativa: eventos de hoy/proximos, cobros urgentes y proyectos activos.
+- [x] Los KPIs financieros completos no dominan la primera pantalla mobile.
+- [x] En desktop se mantienen las tarjetas KPI existentes.
+- [x] Los importes y fechas usan formatters/patrones existentes.
+- [x] No hay llamadas directas a Supabase desde el componente.
+- [x] `npm run lint` y `npm run build` pasan.
+
+## Validacion
+
+- [x] `npm run lint` — OK.
+- [x] `npm run build` — OK.
+- [x] Servidor local Vite arrancado en `http://127.0.0.1:5173/`.
+- [x] Memoria actualizada con prioridad de producto para Dashboard movil.
+
+## Resultado
+
+Implementado en rama `feature/CACH-0032-mobile-dashboard-operativo`.
+
+- Nuevo bloque mobile `Ahora` con acceso rapido a calendario, proximo evento, cobros urgentes/vencidos y proyectos activos.
+- KPIs financieros completos ocultos en mobile y mantenidos desde `md`.
+- Resumen financiero mobile reducido a cobrado, gastos y neto.
+- Decision durable guardada en `.memory/projects/dashboard-mobile.md`.

--- a/docs/project/issues/CACH-B0002.md
+++ b/docs/project/issues/CACH-B0002.md
@@ -57,3 +57,4 @@ El Dashboard móvil debe sentirse tan compacto y escaneable como Events y Projec
 - [[../plans/backlog-mayo-2026]]
 - [[../context/ux-mobile-guardrails-20260504|ux-mobile-guardrails-20260504]]
 - [[../context/ui-direction-v3-20260504|ui-direction-v3-20260504]]
+- [[CACH-0032|CACH-0032]] — Slice implementado para priorizar operativa diaria en Dashboard movil.

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import dayjs from 'dayjs'
-import { TrendingUp, Wallet, Receipt, PiggyBank, Clock, FolderOpen, ChevronLeft, ChevronRight, AlertCircle, Timer } from 'lucide-react'
+import 'dayjs/locale/es'
+import { TrendingUp, Wallet, Receipt, PiggyBank, Clock, FolderOpen, ChevronLeft, ChevronRight, AlertCircle, Timer, CalendarDays } from 'lucide-react'
 import { PageWrapper } from '../../components/layout/PageWrapper'
 import { Card } from '../../components/ui/Card'
 import { StatusBadge } from '../../components/ui/Badge'
@@ -15,6 +16,8 @@ import { useExpenses } from '../../hooks/useExpenses'
 import { formatCurrency, formatCurrencyPerHour, formatDate, formatHours } from '../../lib/formatters'
 
 const YEARS = Array.from({ length: 6 }, (_, i) => dayjs().year() - 2 + i)
+
+dayjs.locale('es')
 
 const getEventHours = (event) => {
   if (!event.end_datetime) return 0
@@ -38,6 +41,7 @@ export default function Dashboard() {
   const endOfMonth = selectedDate.endOf('month').format('YYYY-MM-DD')
   const today = dayjs().format('YYYY-MM-DD')
   const inPendingDays = dayjs().add(pendingDays, 'day').format('YYYY-MM-DD')
+  const inSevenDays = dayjs().add(7, 'day').format('YYYY-MM-DD')
 
   const prevMonth = () => setSelectedDate((d) => d.subtract(1, 'month'))
   const nextMonth = () => setSelectedDate((d) => d.add(1, 'month'))
@@ -116,6 +120,36 @@ export default function Dashboard() {
       .sort((a, b) => a.expected_date.localeCompare(b.expected_date))
   , [incomes, today, inPendingDays])
 
+  const urgentPendingIncomes = useMemo(() =>
+    incomes
+      .filter((i) => !i.is_paid && i.expected_date && i.expected_date <= inSevenDays)
+      .sort((a, b) => a.expected_date.localeCompare(b.expected_date))
+  , [incomes, inSevenDays])
+
+  const urgentPendingTotal = useMemo(() =>
+    urgentPendingIncomes.reduce((acc, income) => acc + Number(income.amount), 0)
+  , [urgentPendingIncomes])
+
+  const overdueIncomes = useMemo(() =>
+    urgentPendingIncomes.filter((income) => income.expected_date < today)
+  , [urgentPendingIncomes, today])
+
+  const upcomingEvents = useMemo(() =>
+    events
+      .filter((event) => {
+        if (event.status === 'cancelled') return false
+        const eventDate = dayjs(event.start_datetime)
+        return eventDate.isAfter(dayjs().subtract(1, 'hour')) && eventDate.format('YYYY-MM-DD') <= inSevenDays
+      })
+      .sort((a, b) => dayjs(a.start_datetime).valueOf() - dayjs(b.start_datetime).valueOf())
+  , [events, inSevenDays])
+
+  const todayEvents = useMemo(() =>
+    upcomingEvents.filter((event) => dayjs(event.start_datetime).format('YYYY-MM-DD') === today)
+  , [upcomingEvents, today])
+
+  const nextEvent = upcomingEvents[0]
+
   const activeProjects = useMemo(() =>
     projects.filter((p) => p.status === 'confirmed' || p.status === 'in_progress')
   , [projects])
@@ -182,7 +216,7 @@ export default function Dashboard() {
         )}
 
         {loading ? (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4">
+          <div className="hidden md:grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4">
             {Array.from({ length: 5 }).map((_, i) => (
               <div key={i} className="rounded-xl border border-gray-100 bg-white p-4 sm:p-5 animate-pulse">
                 <div className="flex items-start gap-3">
@@ -197,7 +231,7 @@ export default function Dashboard() {
             ))}
           </div>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4">
+          <div className="hidden md:grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4">
             <KpiCard
               title="Ingresos previstos"
               value={formatCurrency(kpis.grossExpected)}
@@ -235,6 +269,106 @@ export default function Dashboard() {
             />
           </div>
         )}
+
+        <Card className="p-3 md:hidden">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-semibold text-gray-900">Ahora</h2>
+              <p className="text-xs text-gray-500">{dayjs().format('dddd, D MMMM')}</p>
+            </div>
+            <button
+              onClick={() => navigate('/calendar/events')}
+              className="flex min-h-10 items-center gap-1.5 rounded-lg px-2 text-xs font-medium text-[var(--color-primary-600)] hover:bg-gray-50"
+            >
+              <CalendarDays size={15} />
+              Calendario
+            </button>
+          </div>
+
+          {loading ? (
+            <div className="grid grid-cols-1 gap-2 animate-pulse">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="h-[68px] rounded-lg bg-gray-100" />
+              ))}
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-2">
+              <button
+                onClick={() => nextEvent ? navigate(`/events/${nextEvent.id}`) : navigate('/calendar/events')}
+                className="flex min-h-[68px] items-center gap-3 rounded-lg border border-gray-100 px-3 py-2 text-left hover:bg-gray-50"
+              >
+                <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-[#F9EDEB] text-[#C94035]">
+                  <Clock size={19} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-semibold text-gray-900">
+                    {todayEvents.length > 0 ? `${todayEvents.length} evento${todayEvents.length === 1 ? '' : 's'} hoy` : nextEvent ? 'Próximo evento' : 'Sin eventos próximos'}
+                  </span>
+                  <span className="block truncate text-xs text-gray-500">
+                    {nextEvent
+                      ? `${dayjs(nextEvent.start_datetime).format('DD/MM HH:mm')} · ${nextEvent.name}`
+                      : 'Semana tranquila'}
+                  </span>
+                </span>
+              </button>
+
+              <button
+                onClick={() => urgentPendingIncomes[0] ? navigateToIncome(urgentPendingIncomes[0]) : undefined}
+                className="flex min-h-[68px] items-center gap-3 rounded-lg border border-gray-100 px-3 py-2 text-left hover:bg-gray-50"
+              >
+                <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-[#FDF5E4] text-[#D4921A]">
+                  <Wallet size={19} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-semibold text-gray-900">
+                    {urgentPendingIncomes.length > 0 ? `${urgentPendingIncomes.length} cobro${urgentPendingIncomes.length === 1 ? '' : 's'} urgente${urgentPendingIncomes.length === 1 ? '' : 's'}` : 'Sin cobros urgentes'}
+                  </span>
+                  <span className="block truncate text-xs text-gray-500">
+                    {urgentPendingIncomes.length > 0
+                      ? `${formatCurrency(urgentPendingTotal)} · ${overdueIncomes.length > 0 ? `${overdueIncomes.length} vencido${overdueIncomes.length === 1 ? '' : 's'}` : 'próximos 7 días'}`
+                      : 'Nada vence esta semana'}
+                  </span>
+                </span>
+              </button>
+
+              <button
+                onClick={() => navigate('/projects')}
+                className="flex min-h-[68px] items-center gap-3 rounded-lg border border-gray-100 px-3 py-2 text-left hover:bg-gray-50"
+              >
+                <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-[#E8F4EF] text-[#2D6A4F]">
+                  <FolderOpen size={19} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-semibold text-gray-900">
+                    {activeProjects.length} proyecto{activeProjects.length === 1 ? '' : 's'} activo{activeProjects.length === 1 ? '' : 's'}
+                  </span>
+                  <span className="block truncate text-xs text-gray-500">
+                    {activeProjects[0] ? activeProjects[0].name : 'Sin trabajo activo'}
+                  </span>
+                </span>
+              </button>
+            </div>
+          )}
+
+          {!loading && (
+            <div className="mt-3 grid grid-cols-3 gap-2 border-t border-gray-100 pt-3">
+              <div>
+                <p className="text-[11px] text-gray-500">Cobrado</p>
+                <p className="truncate text-sm font-semibold text-gray-900">{formatCurrency(kpis.grossPaid)}</p>
+              </div>
+              <div>
+                <p className="text-[11px] text-gray-500">Gastos</p>
+                <p className="truncate text-sm font-semibold text-gray-900">{formatCurrency(kpis.totalExpenses)}</p>
+              </div>
+              <div>
+                <p className="text-[11px] text-gray-500">Neto</p>
+                <p className={`truncate text-sm font-semibold ${kpis.netProfit >= 0 ? 'text-[#2D6A4F]' : 'text-[#C94035]'}`}>
+                  {formatCurrency(kpis.netProfit)}
+                </p>
+              </div>
+            </div>
+          )}
+        </Card>
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
           <Card className="p-4">


### PR DESCRIPTION
## Resumen

- Añade un bloque móvil `Ahora` en el Dashboard con próximos eventos, cobros urgentes/vencidos y proyectos activos.
- Mantiene los KPIs financieros completos en desktop y reduce la lectura financiera móvil a cobrado, gastos y neto.
- Crea la issue `CACH-0032` como slice concreto de `CACH-B0002` y actualiza Product Brain/backlog.

## Validación

- `npm run lint` — OK
- `npm run build` — OK
- `npm run pb:check` — OK
- Servidor local Vite arrancado en `http://127.0.0.1:5173/`

## Memoria

Actualizada en `.memory/projects/dashboard-mobile.md` y `.memory/me.md`.

## Notas

Hay cambios locales previos no incluidos en este commit/PR: `.memory/projects/culturaapp-status.md`, `docs/project/context/beta-readiness-risk-map-20260504.md`, `docs/project/context/product-snapshot-20260504.md` y `docs/project/issues/CACH-B0001.md`.