### PR TITLE
docs(CACH-B0001): consolidar lecciones de navegación de Trabajos

### DIFF
--- a/.memory/projects/culturaapp-status.md
+++ b/.memory/projects/culturaapp-status.md
@@ -27,5 +27,7 @@
 ## 2026-05-05 - Work Navigation Must Own Project/Event Details
 
 - Context: User feedback showed the previous `/work` iteration was not usable enough: after opening a project from "Trabajos", the detail pushed the user into `/projects` and forced browser-back navigation to return to the projects tab.
-- Durable memory: `/work` should be treated as the primary "Trabajos" workflow. Project and event detail pages must breadcrumb and return to `/work?view=projects` or `/work?view=events` when reached from this flow; tabs in `Trabajos` should be URL-addressable so navigation is recoverable on mobile and desktop.
-- Source: CACH-B0001 feedback and fix branch `fix/CACH-B0001-work-navigation-prod`.
+- Durable memory: `/work` should be treated as the primary "Trabajos" workflow, not a cosmetic shortcut to separate `/projects` and `/events` sections. Project and event detail pages must breadcrumb and return to `/work?view=projects` or `/work?view=events` when reached from this flow; tabs in `Trabajos` should be URL-addressable so navigation is recoverable on mobile and desktop.
+- Durable memory: for details reached from `Trabajos`, avoid large full-width CTAs and repeated empty-state buttons. Primary actions should be compact, aligned with the section header, and visually secondary to the work content unless they are the main task. Hide default `Confirmado` badges when they add noise rather than information.
+- Durable memory: future UI fixes should verify the whole navigation loop, not only the screen where the bug is reported: list/tab -> detail -> related detail -> return path.
+- Source: CACH-B0001 feedback, PR `#75`, merge commit `9715736`.

--- a/docs/project/context/beta-readiness-risk-map-20260504.md
+++ b/docs/project/context/beta-readiness-risk-map-20260504.md
@@ -3,7 +3,7 @@ id: PB-CTX-BETA-RISK-20260504
 type: context
 status: Active
 created: 2026-05-04
-updated: 2026-05-04
+updated: 2026-05-05
 aliases:
   - Mapa beta y riesgos 2026-05-04
 tags:
@@ -32,6 +32,7 @@ La beta debería priorizar confianza, comprensión rápida y reversibilidad de d
 ## Riesgos De Producto
 
 - Si proyecto y evento no se distinguen bien, la app se convierte en otra lista confusa de trabajos.
+- Si `Trabajos` no conserva el contexto al entrar y salir de detalles, el usuario pierde orientación y la app parece inservible aunque cada ruta funcione por separado.
 - Si los datos no se pueden exportar, el usuario beta tendrá miedo razonable a depender de Cachés.
 - Si la hora de un evento o la fecha real de cobro cambia silenciosamente, la confianza en la app se rompe aunque la UI parezca correcta.
 - Si los cobros pendientes no son accionables, la app registra dinero pero no ayuda a cobrarlo.
@@ -47,6 +48,7 @@ La beta debería priorizar confianza, comprensión rápida y reversibilidad de d
 ## Criterio De Salida Para Primera Beta
 
 - Un usuario nuevo entiende evento, proyecto y cobro en pocos minutos.
+- Puede navegar de `Trabajos` a un proyecto o evento y volver a la pestaña correcta sin depender del historial del navegador.
 - Puede crear un primer trabajo real desde móvil sin pelearse con fechas o selectores.
 - Puede registrar un ingreso, marcarlo como cobrado y ver el impacto económico.
 - Puede exportar sus datos.

--- a/docs/project/context/product-snapshot-20260504.md
+++ b/docs/project/context/product-snapshot-20260504.md
@@ -3,7 +3,7 @@ id: PB-CTX-PRODUCT-SNAPSHOT-20260504
 type: context
 status: Active
 created: 2026-05-04
-updated: 2026-05-04
+updated: 2026-05-05
 aliases:
   - Snapshot producto Cachés 2026-05-04
 tags:
@@ -49,13 +49,13 @@ La distinción proyecto/evento es el centro cognitivo del producto. Cualquier re
 - Calendario de eventos con hora exacta y panel lateral.
 - Calendario de proyectos por rango de fechas.
 - Listados y detalles de eventos/proyectos con formularios, ingresos y gastos.
-- Vista `/work` como primer intento de agrupar proyectos y eventos bajo “Trabajos”.
+- Vista `/work` como flujo principal de “Trabajos”, con proyectos y eventos agrupados de forma jerárquica.
 - Ajustes de perfil: nombre, profesión e IRPF habitual.
 - Product Brain repo-native en `docs/project/`, separado de `.memory/`.
 
 ## Tensiones De Producto Activas
 
-- `/work` existe, pero [[../issues/CACH-B0001|CACH-B0001]] sigue siendo el rediseño pendiente para jerarquía real y evitar duplicidades.
+- [[../issues/CACH-B0001|CACH-B0001]] sigue siendo la guía de rediseño de “Trabajos”: la iteración actual ya corrige navegación básica, tabs en URL, jerarquía proyecto-evento y ruido visual, pero debe seguir evaluándose con uso real.
 - Los calendarios separados funcionan, pero [[../issues/CACH-B0007|CACH-B0007]] apunta a una vista unificada con filtros e interacción rápida.
 - Finanzas funcionan para MVP, pero contratante, facturación, liquidación neta y CRM ligero viven en [[../issues/CACH-B0004|CACH-B0004]].
 - La app registra datos; el salto diferencial será convertirlos en decisiones económicas, cubierto por [[../issues/CACH-B0009|CACH-B0009]].

--- a/docs/project/issues/CACH-B0001.md
+++ b/docs/project/issues/CACH-B0001.md
@@ -9,7 +9,7 @@ priority: p1
 estimate: m
 area: frontend
 created_at: 2026-05-04
-updated_at: 2026-05-04
+updated_at: 2026-05-05
 aliases:
   - CACH-B0001
 tags:
@@ -43,10 +43,28 @@ La vista actual puede duplicar trabajos y dar el mismo peso visual a contenedore
 
 ## Acceptance Criteria
 
-- [ ] Un evento asociado a un proyecto no aparece duplicado como trabajo independiente en la vista principal.
-- [ ] Proyecto y evento tienen jerarquía visual distinta.
-- [ ] El badge "Confirmado" no añade ruido si es el estado normal.
+- [x] Un evento asociado a un proyecto no aparece duplicado como trabajo independiente en la vista principal.
+- [x] Proyecto y evento tienen jerarquía visual distinta.
+- [x] El badge "Confirmado" no añade ruido si es el estado normal.
 - [ ] Las notas de evento/proyecto se pueden editar desde su contexto.
+
+## Iteración 2026-05-05
+
+PR `#75` corrigió la navegación básica de “Trabajos”:
+
+- `Trabajos` pasa a ser el flujo principal para proyectos y eventos.
+- Los tabs de `Trabajos` son direccionables por URL (`/work?view=projects`, `/work?view=events`).
+- Los detalles de proyecto y evento vuelven a la pestaña correcta de `Trabajos`, no a listados aislados ni al historial del navegador.
+- Los eventos asociados se agrupan bajo su proyecto y los eventos sin proyecto quedan separados.
+- Los CTAs en detalles se compactan y se elimina el ruido visual de badges `Confirmado`.
+
+## Lecciones Aprendidas
+
+- “Trabajos” no puede ser una pestaña decorativa encima de `/projects` y `/events`; debe tener ownership del flujo mental completo: listado, detalle, vuelta y navegación entre entidades relacionadas.
+- En móvil, una navegación que exige usar el botón atrás del navegador se siente rota aunque las rutas existan técnicamente.
+- Las acciones de gestión financiera y edición deben estar disponibles, pero no dominar visualmente la pantalla ni duplicarse en estados vacíos.
+- Los estados normales como `Confirmado` deben ocultarse o minimizarse cuando no aportan decisión.
+- Las futuras revisiones de esta zona deben probar el bucle completo: `Trabajos -> Proyectos/Eventos -> Detalle -> volver a la pestaña correcta`.
 
 ## Related
 


### PR DESCRIPTION
## Resumen

- Consolida en memoria las lecciones duraderas de la iteración de navegación de `Trabajos`.
- Actualiza el snapshot de producto y el mapa de riesgos beta con el criterio de vuelta a la pestaña correcta.
- Actualiza `CACH-B0001` con la iteración de 2026-05-05 y marca los criterios ya cubiertos por PR #75.

## Issue

`CACH-B0001` — Rediseñar Trabajos y jerarquía proyecto-evento.

## Validación

- `npm run pb:check` — OK

## Memoria

Actualizada en `.memory/projects/culturaapp-status.md`.