### PR TITLE
fix(CACH-0034): show '—' for €/h when no billable events

### DIFF
--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -256,7 +256,7 @@ export default function Dashboard() {
             <KpiCard
               title="Cobro bruto/hora"
               value={kpis.billableHours > 0 ? formatCurrencyPerHour(kpis.grossHourlyRate) : '—'}
-              subtitle={`Solo eventos cobrados · ${formatHours(kpis.billableHours)} h`}
+              subtitle={kpis.billableHours > 0 ? `Solo eventos cobrados · ${formatHours(kpis.billableHours)} h` : 'Sin eventos cobrados'}
               icon={Timer}
               color="red"
             />

--- a/src/pages/Projects/ProjectDetail.jsx
+++ b/src/pages/Projects/ProjectDetail.jsx
@@ -299,7 +299,7 @@ export default function ProjectDetail() {
             { label: 'Ingresos previstos', value: formatCurrency(totalGross) },
             { label: 'IRPF sobre cobrado', value: formatCurrency(totalRetentions) },
             { label: 'Gastos registrados', value: formatCurrency(totalExpenses) },
-            { label: 'Cobro bruto/hora', value: projectHours > 0 ? formatCurrencyPerHour(grossHourlyRate) : '—', detail: `Solo eventos cobrados · ${formatHours(projectHours)} h` },
+            { label: 'Cobro bruto/hora', value: projectHours > 0 ? formatCurrencyPerHour(grossHourlyRate) : '—', detail: projectHours > 0 ? `Solo eventos cobrados · ${formatHours(projectHours)} h` : 'Sin eventos cobrados' },
             { label: 'Beneficio neto', value: formatCurrency(netProfit), highlight: true },
           ].map(({ label, value, detail, highlight }) => (
             <div key={label} className={`rounded-lg border p-4 ${highlight ? 'bg-[#fef3f2] border-[var(--color-primary-200)]' : 'bg-white border-gray-200'}`}>


### PR DESCRIPTION
## Summary
- Dashboard: muestra "Sin eventos cobrados" en subtitle cuando billableHours es 0
- ProjectDetail: muestra "Sin eventos cobrados" en detail cuando projectHours es 0
- El valor ya mostraba '—' correctamente; solo faltaba el texto explicativo

## Changes
- `src/pages/Dashboard/Dashboard.jsx`: línea 259 — subtitle condicionado
- `src/pages/Projects/ProjectDetail.jsx`: línea 302 — detail condicionado

## Verification
npm run lint && npm run build (pendiente — entorno sin node_modules)

## Memoria
No aplica — fix simple de UI siguiendo patrón existente en EventDetail.jsx