### PR TITLE
feat(CACH-0033): refine project planning calendar

### DIFF
--- a/src/components/calendar/ProjectYearView.jsx
+++ b/src/components/calendar/ProjectYearView.jsx
@@ -1,110 +1,416 @@
 import { useMemo } from 'react'
 import dayjs from 'dayjs'
-import { buildProjectYearMonths } from '../../lib/projectYearCalendar'
+import {
+  MONTH_LABELS,
+  MONTH_SHORT_LABELS,
+  getBusiestMonth,
+  getNextProjectStart,
+  getProjectTimelineRows,
+  getProjectsByMonth,
+  getProjectsForMonth,
+} from '../../lib/projectYearCalendar'
+import { formatDateRange } from '../../lib/formatters'
+import { CalendarRange, FolderOpen } from 'lucide-react'
 
-const COLUMN_WIDTH = 100 / 7
-const LANE_HEIGHT = 18
-const LANE_GAP = 4
-
-function getSegmentStyle(segment) {
-  const borderRadius = segment.startsInCell && segment.endsInCell
-    ? '999px'
-    : segment.startsInCell
-    ? '999px 6px 6px 999px'
-    : segment.endsInCell
-    ? '6px 999px 999px 6px'
-    : '6px'
-
-  return {
-    left: `calc(${segment.startColumn * COLUMN_WIDTH}% + 2px)`,
-    width: `calc(${segment.span * COLUMN_WIDTH}% - 4px)`,
-    top: `${segment.lane * (LANE_HEIGHT + LANE_GAP)}px`,
-    height: `${LANE_HEIGHT}px`,
-    backgroundColor: segment.color,
-    borderRadius,
-  }
-}
-
-function getWeekSegmentsHeight(week) {
-  if (week.segments.length === 0) {
-    return 0
+function getRangeLabel(project) {
+  if (!project.endDate) {
+    return `${dayjs(project.startDate).format('D MMM')} - sin fecha fin`
   }
 
-  const laneCount = Math.max(...week.segments.map((segment) => segment.lane)) + 1
-  return laneCount * LANE_HEIGHT + (laneCount - 1) * LANE_GAP
+  return formatDateRange(project.startDate, project.endDate)
 }
 
-export function ProjectYearView({ date, projects, onSelectProject }) {
-  const year = dayjs(date).year()
-  const months = useMemo(() => buildProjectYearMonths(projects, year), [projects, year])
+function getVisibleRangeLabel(project) {
+  if (project.visibleStart === project.visibleEnd) {
+    return dayjs(project.visibleStart).format('D MMM')
+  }
+
+  return `${dayjs(project.visibleStart).format('D MMM')} - ${dayjs(project.visibleEnd).format('D MMM')}`
+}
+
+function getCompactDurationLabel(project) {
+  const monthCount = project.endMonthIndex - project.startMonthIndex + 1
+
+  if (monthCount <= 1) {
+    return '1 mes activo'
+  }
+
+  return `${monthCount} meses activos`
+}
+
+export function ProjectYearSummary({ projects, year }) {
+  const busiestMonth = useMemo(() => getBusiestMonth(projects, year), [projects, year])
+  const nextProject = useMemo(() => {
+    const nextStartFrom = dayjs().year() === year ? new Date() : `${year}-01-01`
+    return getNextProjectStart(projects, nextStartFrom, { year })
+  }, [projects, year])
+  const activeCount = useMemo(() => getProjectTimelineRows(projects, year).length, [projects, year])
 
   return (
-    <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
-      {months.map((month) => (
-        <section key={month.monthStart} className="min-w-0 overflow-hidden rounded-xl border border-gray-200 bg-white">
-          <header className="border-b border-gray-200 bg-gray-50 px-3 py-2">
-            <p className="text-sm font-semibold text-gray-800">
-              {month.monthLabel} {month.year}
-            </p>
-          </header>
+    <section className="rounded-2xl border border-[#E6DDC9] bg-[#FFFCF5] p-4 shadow-sm">
+      <div className="mb-3 flex items-center gap-2 text-[#211C18]">
+        <CalendarRange size={18} className="text-[#C94035]" />
+        <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-[#5C5149]">Resumen {year}</h2>
+      </div>
 
-          <div className="p-2">
-            <div className="mb-1 grid grid-cols-7 gap-px text-center">
-              {month.weeks[0]?.days.map((day) => (
-                <div key={`${month.monthStart}-${day.weekdayLabel}`} className="pb-1 text-[10px] font-medium text-gray-400">
-                  {day.weekdayLabel}
-                </div>
+      <div className="grid gap-3 sm:grid-cols-3">
+        <div className="rounded-xl border border-[#EFE6D2] bg-white px-4 py-3">
+          <p className="text-2xl font-semibold text-[#211C18]">{activeCount}</p>
+          <p className="text-xs text-[#6F6258]">proyectos activos</p>
+        </div>
+        <div className="rounded-xl border border-[#EFE6D2] bg-white px-4 py-3">
+          <p className="truncate text-lg font-semibold text-[#211C18]">
+            {busiestMonth ? busiestMonth.monthLabel : 'Sin carga'}
+          </p>
+          <p className="text-xs text-[#6F6258]">
+            {busiestMonth ? `${busiestMonth.projects.length} proyectos` : 'No hay proyectos este año'}
+          </p>
+        </div>
+        <div className="rounded-xl border border-[#EFE6D2] bg-white px-4 py-3">
+          <p className="truncate text-lg font-semibold text-[#211C18]">
+            {nextProject ? nextProject.title : 'Sin próximos inicios'}
+          </p>
+          <p className="text-xs text-[#6F6258]">
+            {nextProject ? `Próximo inicio · ${dayjs(nextProject.startDate).format('D MMM')}` : 'Añade un proyecto para planificar'}
+          </p>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function ProjectMobileGanttCard({ project, maxMonthLoad, monthLoads, onSelectProject }) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelectProject(project.source)}
+      className="w-full rounded-2xl border border-[#E2D9C2] bg-white p-4 text-left shadow-sm transition hover:border-[#D7C6A9] hover:bg-[#FFFCF5] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2"
+      aria-label={`Abrir ${project.title}: ${getRangeLabel(project)}`}
+    >
+      <span className="mb-3 flex min-w-0 items-start justify-between gap-3">
+        <span className="min-w-0">
+          <span className="block truncate text-base font-semibold text-[#211C18]">{project.title}</span>
+          <span className="block text-sm text-[#6F6258]">{getRangeLabel(project)}</span>
+        </span>
+        <span className="shrink-0 rounded-full bg-[#F5EFE0] px-2.5 py-1 text-xs font-semibold text-[#5C5149]">
+          {getCompactDurationLabel(project)}
+        </span>
+      </span>
+
+      <span className="grid grid-cols-12 gap-1 text-center text-[10px] font-semibold text-[#8B7A6B]" aria-hidden="true">
+        {MONTH_SHORT_LABELS.map((month, index) => (
+          <span
+            key={`${project.id}-${month}-label`}
+            className={`rounded-md py-1 ${monthLoads[index] === maxMonthLoad && maxMonthLoad > 1 ? 'bg-[#FBE8E6] text-[#A8342B]' : ''}`}
+          >
+            {month.slice(0, 1)}
+          </span>
+        ))}
+      </span>
+
+      <span className="mt-1 grid grid-cols-12 gap-1" aria-hidden="true">
+        {MONTH_SHORT_LABELS.map((month, index) => {
+          const isActive = index >= project.startMonthIndex && index <= project.endMonthIndex
+          const isEdge = index === project.startMonthIndex || index === project.endMonthIndex
+
+          return (
+            <span
+              key={`${project.id}-${month}-segment`}
+              className={`h-8 rounded-lg border transition ${
+                isActive
+                  ? 'border-transparent shadow-sm'
+                  : 'border-[#EFE6D2] bg-[#FAF6EC]'
+              } ${isEdge ? 'ring-1 ring-[#211C18]/20' : ''}`}
+              style={isActive ? { backgroundColor: project.color } : undefined}
+            />
+          )
+        })}
+      </span>
+
+      <span className="mt-2 flex items-center justify-between text-xs text-[#6F6258]">
+        <span>
+          Inicio · {MONTH_LABELS[project.startMonthIndex].slice(0, 3)}
+        </span>
+        <span>
+          Fin · {MONTH_LABELS[project.endMonthIndex].slice(0, 3)}
+        </span>
+      </span>
+    </button>
+  )
+}
+
+export function ProjectMobileCompactGantt({ projects, year, onSelectProject }) {
+  const rows = useMemo(() => getProjectTimelineRows(projects, year), [projects, year])
+  const months = useMemo(() => getProjectsByMonth(projects, year), [projects, year])
+  const monthLoads = months.map((month) => month.projects.length)
+  const maxMonthLoad = Math.max(0, ...monthLoads)
+  const busiestMonths = months.filter((month) => month.projects.length === maxMonthLoad && maxMonthLoad > 0)
+
+  if (rows.length === 0) {
+    return null
+  }
+
+  return (
+    <section className="space-y-3 md:hidden" aria-label={`Gantt compacto de proyectos ${year}`}>
+      <div className="rounded-2xl border border-[#E2D9C2] bg-[#FFFCF5] p-4">
+        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[#6F6258]">Timeline anual</p>
+        <h2 className="mt-1 text-lg font-semibold text-[#211C18]">Gantt compacto</h2>
+        <p className="mt-1 text-sm text-[#6F6258]">
+          Cada tarjeta resume 12 meses. Meses más cargados: {busiestMonths.map((month) => month.monthLabel).join(', ')}.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {rows.map((project) => (
+          <ProjectMobileGanttCard
+            key={project.id}
+            project={project}
+            maxMonthLoad={maxMonthLoad}
+            monthLoads={monthLoads}
+            onSelectProject={onSelectProject}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function ProjectTimelineSegment({ project, onSelectProject }) {
+  const gridColumn = `${project.startMonthIndex + 1} / ${project.endMonthIndex + 2}`
+  const title = `${project.title}: ${getRangeLabel(project)}`
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelectProject(project.source)}
+      className="group pointer-events-auto relative z-10 my-1 min-h-9 overflow-hidden rounded-full px-3 text-left text-xs font-semibold text-white shadow-sm transition hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2"
+      style={{ gridColumn, backgroundColor: project.color }}
+      title={title}
+    >
+      <span className="flex min-w-0 items-center gap-2">
+        {project.startsBeforeYear && <span aria-hidden="true">...</span>}
+        <span className="truncate">{project.title}</span>
+        <span className="hidden shrink-0 text-[10px] font-medium opacity-85 md:inline">
+          {getVisibleRangeLabel(project)}
+        </span>
+        {project.endsAfterYear && <span aria-hidden="true">...</span>}
+      </span>
+    </button>
+  )
+}
+
+export function ProjectYearTimeline({ projects, year, selectedMonth, onSelectMonth, onSelectProject }) {
+  const rows = useMemo(() => getProjectTimelineRows(projects, year), [projects, year])
+
+  if (rows.length === 0) {
+    return (
+      <section className="rounded-2xl border border-dashed border-[#E2D9C2] bg-white px-5 py-8 text-center">
+        <FolderOpen className="mx-auto mb-3 text-[#B9A995]" size={28} />
+        <p className="font-medium text-[#211C18]">No hay proyectos activos en {year}</p>
+        <p className="mt-1 text-sm text-[#6F6258]">Cambia de año o crea el primer proyecto para verlo en la planificación.</p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="hidden rounded-2xl border border-[#E2D9C2] bg-white p-4 shadow-sm md:block">
+      <div className="grid grid-cols-[minmax(12rem,18rem)_1fr] gap-4">
+        <div className="border-b border-[#EFE6D2] pb-3 text-xs font-semibold uppercase tracking-[0.12em] text-[#6F6258]">
+          Proyecto
+        </div>
+        <div className="grid grid-cols-12 gap-1 border-b border-[#EFE6D2] pb-3">
+          {MONTH_SHORT_LABELS.map((month, index) => (
+            <button
+              key={month}
+              type="button"
+              onClick={() => onSelectMonth(index)}
+              className={`rounded-lg px-1 py-2 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] ${
+                selectedMonth === index
+                  ? 'bg-[#C94035] text-white shadow-sm'
+                  : 'text-[#6F6258] hover:bg-[#F5EFE0] hover:text-[#211C18]'
+              }`}
+              aria-pressed={selectedMonth === index}
+            >
+              {month}
+            </button>
+          ))}
+        </div>
+
+        {rows.map((project) => (
+          <div key={project.id} className="contents">
+            <button
+              type="button"
+              onClick={() => onSelectProject(project.source)}
+              className="min-w-0 border-b border-[#F3EBDD] py-3 pr-2 text-left transition hover:text-[#C94035] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035]"
+              title={project.title}
+            >
+              <span className="block truncate text-sm font-semibold text-[#211C18]">{project.title}</span>
+              <span className="block truncate text-xs text-[#6F6258]">{getRangeLabel(project)}</span>
+            </button>
+            <div className="relative grid grid-cols-12 gap-1 border-b border-[#F3EBDD] py-3">
+              {MONTH_SHORT_LABELS.map((month, index) => (
+                <button
+                  key={`${project.id}-${month}`}
+                  type="button"
+                  onClick={() => onSelectMonth(index)}
+                  className={`min-h-9 rounded-lg transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] ${
+                    selectedMonth === index ? 'bg-[#FBE8E6]' : 'bg-[#FAF6EC]'
+                  }`}
+                  aria-label={`Seleccionar ${MONTH_LABELS[index]} ${year}`}
+                />
               ))}
-            </div>
-
-            <div className="space-y-1.5">
-              {month.weeks.map((week) => {
-                const segmentsHeight = getWeekSegmentsHeight(week)
-
-                return (
-                  <div key={week.weekId} className="rounded-lg border border-gray-100 bg-white">
-                    <div className="grid grid-cols-7 gap-px rounded-t-lg bg-gray-100">
-                      {week.days.map((day) => (
-                        <div
-                          key={day.date}
-                          className={`min-h-[2rem] px-1 py-1 text-center text-[10px] font-medium ${
-                            day.isCurrentMonth ? 'bg-white text-gray-700' : 'bg-gray-50 text-gray-300'
-                          }`}
-                        >
-                          <span
-                            className={`inline-flex h-5 w-5 items-center justify-center rounded-full ${
-                              day.isToday ? 'bg-[var(--color-primary-100)] text-[var(--color-primary-700)]' : ''
-                            }`}
-                          >
-                            {day.dayOfMonth}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-
-                    {segmentsHeight > 0 && (
-                      <div className="relative px-1 pb-1 pt-1" style={{ height: `${segmentsHeight + 8}px` }}>
-                        {week.segments.map((segment) => (
-                          <button
-                            key={`${segment.projectId}-${segment.weekId}-${segment.lane}`}
-                            type="button"
-                            onClick={() => onSelectProject(segment.source)}
-                            className="absolute overflow-hidden text-ellipsis whitespace-nowrap px-2 text-left text-[10px] font-medium text-white shadow-sm transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary-500)]"
-                            style={getSegmentStyle(segment)}
-                            title={`${segment.title}: ${segment.visibleStart} - ${segment.visibleEnd}`}
-                          >
-                            {segment.title}
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                )
-              })}
+              <div className="pointer-events-none absolute inset-x-0 top-3 grid grid-cols-12 gap-1 px-0">
+                <ProjectTimelineSegment project={project} onSelectProject={onSelectProject} />
+              </div>
             </div>
           </div>
-        </section>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function ProjectMonthProjectList({ projects, onSelectProject }) {
+  if (projects.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-[#E2D9C2] bg-[#FFFCF5] px-4 py-6 text-sm text-[#6F6258]">
+        No hay proyectos activos en este mes.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {projects.map((project) => (
+        <button
+          key={project.id}
+          type="button"
+          onClick={() => onSelectProject(project.source)}
+          className="flex w-full min-w-0 items-center gap-3 rounded-xl border border-[#EFE6D2] bg-white px-4 py-3 text-left shadow-sm transition hover:border-[#E2D9C2] hover:bg-[#FFFCF5] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035]"
+        >
+          <span className="h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: project.color }} />
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-sm font-semibold text-[#211C18]">{project.title}</span>
+            <span className="block text-xs text-[#6F6258]">{getRangeLabel(project)}</span>
+          </span>
+        </button>
       ))}
+    </div>
+  )
+}
+
+export function ProjectMonthDetail({ projects, year, selectedMonth, onSelectProject }) {
+  const monthProjects = useMemo(
+    () => getProjectsForMonth(projects, year, selectedMonth),
+    [projects, selectedMonth, year]
+  )
+
+  return (
+    <section className="hidden rounded-2xl border border-[#E2D9C2] bg-[#FFFCF5] p-4 shadow-sm md:block">
+      <div className="mb-4">
+        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[#6F6258]">Detalle mensual</p>
+        <h2 className="mt-1 text-xl font-semibold text-[#211C18]">
+          {MONTH_LABELS[selectedMonth]} {year}
+        </h2>
+        <p className="text-sm text-[#6F6258]">Proyectos activos</p>
+      </div>
+      <ProjectMonthProjectList projects={monthProjects} onSelectProject={onSelectProject} />
+    </section>
+  )
+}
+
+function ProjectMonthCard({ month, isSelected, onSelectMonth, onSelectProject }) {
+  const visibleProjects = month.projects.slice(0, 3)
+  const hiddenCount = month.projects.length - visibleProjects.length
+
+  return (
+    <article className={`rounded-2xl border bg-white shadow-sm transition ${isSelected ? 'border-[#C94035]' : 'border-[#E2D9C2]'}`}>
+      <button
+        type="button"
+        onClick={() => onSelectMonth(month.monthIndex)}
+        className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035]"
+        aria-expanded={isSelected}
+      >
+        <span>
+          <span className="block text-base font-semibold text-[#211C18]">{month.monthLabel}</span>
+          <span className="text-sm text-[#6F6258]">
+            {month.projects.length === 1 ? '1 proyecto' : `${month.projects.length} proyectos`}
+          </span>
+        </span>
+        <span className={`h-3 w-3 rounded-full ${isSelected ? 'bg-[#C94035]' : 'bg-[#E2D9C2]'}`} />
+      </button>
+
+      {visibleProjects.length > 0 && !isSelected && (
+        <div className="border-t border-[#F3EBDD] px-4 pb-3 pt-2">
+          <div className="flex flex-wrap gap-1.5">
+            {visibleProjects.map((project) => (
+              <span key={project.id} className="max-w-full truncate rounded-full bg-[#F5EFE0] px-2.5 py-1 text-xs font-medium text-[#5C5149]">
+                {project.title}
+              </span>
+            ))}
+            {hiddenCount > 0 && (
+              <span className="rounded-full bg-[#EFE6D2] px-2.5 py-1 text-xs font-semibold text-[#5C5149]">+{hiddenCount} más</span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {isSelected && (
+        <div className="border-t border-[#F3EBDD] px-4 pb-4 pt-3">
+          <ProjectMonthProjectList projects={month.projects} onSelectProject={onSelectProject} />
+        </div>
+      )}
+    </article>
+  )
+}
+
+export function ProjectMobileYearList({ projects, year, selectedMonth, onSelectMonth, onSelectProject }) {
+  const months = useMemo(() => getProjectsByMonth(projects, year), [projects, year])
+
+  return (
+    <section className="space-y-3 md:hidden" aria-label={`Planificación de proyectos ${year}`}>
+      {months.map((month) => (
+        <ProjectMonthCard
+          key={month.monthIndex}
+          month={month}
+          isSelected={selectedMonth === month.monthIndex}
+          onSelectMonth={onSelectMonth}
+          onSelectProject={onSelectProject}
+        />
+      ))}
+    </section>
+  )
+}
+
+export function ProjectYearView({ projects, year, selectedMonth, onSelectMonth, onSelectProject }) {
+  return (
+    <div className="space-y-4">
+      <ProjectYearSummary projects={projects} year={year} />
+      <ProjectYearTimeline
+        projects={projects}
+        year={year}
+        selectedMonth={selectedMonth}
+        onSelectMonth={onSelectMonth}
+        onSelectProject={onSelectProject}
+      />
+      <ProjectMobileCompactGantt
+        projects={projects}
+        year={year}
+        onSelectProject={onSelectProject}
+      />
+      <ProjectMobileYearList
+        projects={projects}
+        year={year}
+        selectedMonth={selectedMonth}
+        onSelectMonth={onSelectMonth}
+        onSelectProject={onSelectProject}
+      />
+      <ProjectMonthDetail
+        projects={projects}
+        year={year}
+        selectedMonth={selectedMonth}
+        onSelectProject={onSelectProject}
+      />
     </div>
   )
 }

--- a/src/components/calendar/ProjectYearView.jsx
+++ b/src/components/calendar/ProjectYearView.jsx
@@ -1,0 +1,110 @@
+import { useMemo } from 'react'
+import dayjs from 'dayjs'
+import { buildProjectYearMonths } from '../../lib/projectYearCalendar'
+
+const COLUMN_WIDTH = 100 / 7
+const LANE_HEIGHT = 18
+const LANE_GAP = 4
+
+function getSegmentStyle(segment) {
+  const borderRadius = segment.startsInCell && segment.endsInCell
+    ? '999px'
+    : segment.startsInCell
+    ? '999px 6px 6px 999px'
+    : segment.endsInCell
+    ? '6px 999px 999px 6px'
+    : '6px'
+
+  return {
+    left: `calc(${segment.startColumn * COLUMN_WIDTH}% + 2px)`,
+    width: `calc(${segment.span * COLUMN_WIDTH}% - 4px)`,
+    top: `${segment.lane * (LANE_HEIGHT + LANE_GAP)}px`,
+    height: `${LANE_HEIGHT}px`,
+    backgroundColor: segment.color,
+    borderRadius,
+  }
+}
+
+function getWeekSegmentsHeight(week) {
+  if (week.segments.length === 0) {
+    return 0
+  }
+
+  const laneCount = Math.max(...week.segments.map((segment) => segment.lane)) + 1
+  return laneCount * LANE_HEIGHT + (laneCount - 1) * LANE_GAP
+}
+
+export function ProjectYearView({ date, projects, onSelectProject }) {
+  const year = dayjs(date).year()
+  const months = useMemo(() => buildProjectYearMonths(projects, year), [projects, year])
+
+  return (
+    <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+      {months.map((month) => (
+        <section key={month.monthStart} className="min-w-0 overflow-hidden rounded-xl border border-gray-200 bg-white">
+          <header className="border-b border-gray-200 bg-gray-50 px-3 py-2">
+            <p className="text-sm font-semibold text-gray-800">
+              {month.monthLabel} {month.year}
+            </p>
+          </header>
+
+          <div className="p-2">
+            <div className="mb-1 grid grid-cols-7 gap-px text-center">
+              {month.weeks[0]?.days.map((day) => (
+                <div key={`${month.monthStart}-${day.weekdayLabel}`} className="pb-1 text-[10px] font-medium text-gray-400">
+                  {day.weekdayLabel}
+                </div>
+              ))}
+            </div>
+
+            <div className="space-y-1.5">
+              {month.weeks.map((week) => {
+                const segmentsHeight = getWeekSegmentsHeight(week)
+
+                return (
+                  <div key={week.weekId} className="rounded-lg border border-gray-100 bg-white">
+                    <div className="grid grid-cols-7 gap-px rounded-t-lg bg-gray-100">
+                      {week.days.map((day) => (
+                        <div
+                          key={day.date}
+                          className={`min-h-[2rem] px-1 py-1 text-center text-[10px] font-medium ${
+                            day.isCurrentMonth ? 'bg-white text-gray-700' : 'bg-gray-50 text-gray-300'
+                          }`}
+                        >
+                          <span
+                            className={`inline-flex h-5 w-5 items-center justify-center rounded-full ${
+                              day.isToday ? 'bg-[var(--color-primary-100)] text-[var(--color-primary-700)]' : ''
+                            }`}
+                          >
+                            {day.dayOfMonth}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+
+                    {segmentsHeight > 0 && (
+                      <div className="relative px-1 pb-1 pt-1" style={{ height: `${segmentsHeight + 8}px` }}>
+                        {week.segments.map((segment) => (
+                          <button
+                            key={`${segment.projectId}-${segment.weekId}-${segment.lane}`}
+                            type="button"
+                            onClick={() => onSelectProject(segment.source)}
+                            className="absolute overflow-hidden text-ellipsis whitespace-nowrap px-2 text-left text-[10px] font-medium text-white shadow-sm transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary-500)]"
+                            style={getSegmentStyle(segment)}
+                            title={`${segment.title}: ${segment.visibleStart} - ${segment.visibleEnd}`}
+                          >
+                            {segment.title}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/src/lib/projectYearCalendar.js
+++ b/src/lib/projectYearCalendar.js
@@ -1,0 +1,197 @@
+import dayjs from 'dayjs'
+
+const MONTH_LABELS = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre']
+const WEEKDAY_LABELS = ['D', 'L', 'M', 'X', 'J', 'V', 'S']
+
+function formatIsoDate(value) {
+  return dayjs(value).format('YYYY-MM-DD')
+}
+
+function getWeekId(date) {
+  return formatIsoDate(date.startOf('week'))
+}
+
+function getProjectTitle(project) {
+  return project.name ?? project.title ?? 'Proyecto sin nombre'
+}
+
+function getProjectEnd(project) {
+  return project.end_date ?? project.start_date ?? project.end ?? project.start
+}
+
+function normalizeProject(project) {
+  const start = dayjs(project.start_date ?? project.start)
+  const end = dayjs(getProjectEnd(project))
+
+  if (!start.isValid() || !end.isValid()) {
+    return null
+  }
+
+  return {
+    id: project.id,
+    title: getProjectTitle(project),
+    color: project.color ?? '#4f98a3',
+    start,
+    end: end.isBefore(start, 'day') ? start : end,
+    raw: project,
+  }
+}
+
+function getVisibleWeeks(monthStart, monthEnd, today) {
+  const firstWeekStart = monthStart.startOf('month').startOf('week')
+  const lastWeekEnd = monthEnd.endOf('month').endOf('week')
+  const weeks = []
+
+  let current = firstWeekStart
+  let weekIndex = 0
+
+  while (current.isBefore(lastWeekEnd, 'day') || current.isSame(lastWeekEnd, 'day')) {
+    const weekStart = current
+    const weekEnd = current.endOf('week')
+
+    weeks.push({
+      weekId: getWeekId(weekStart),
+      weekIndex,
+      start: formatIsoDate(weekStart),
+      end: formatIsoDate(weekEnd),
+      days: Array.from({ length: 7 }, (_, dayIndex) => {
+        const date = weekStart.add(dayIndex, 'day')
+        return {
+          date: formatIsoDate(date),
+          dayOfMonth: date.date(),
+          weekdayLabel: WEEKDAY_LABELS[dayIndex],
+          isCurrentMonth: date.month() === monthStart.month(),
+          isToday: date.isSame(today, 'day'),
+        }
+      }),
+    })
+
+    current = current.add(1, 'week')
+    weekIndex += 1
+  }
+
+  return weeks
+}
+
+function maxDay(...dates) {
+  return dates.reduce((currentMax, candidate) => candidate.isAfter(currentMax, 'day') ? candidate : currentMax)
+}
+
+function minDay(...dates) {
+  return dates.reduce((currentMin, candidate) => candidate.isBefore(currentMin, 'day') ? candidate : currentMin)
+}
+
+function buildWeekSegment(project, week, monthStart, monthEnd) {
+  const weekStart = dayjs(week.start)
+  const weekEnd = dayjs(week.end)
+  const visibleStart = maxDay(project.start, weekStart, monthStart)
+  const visibleEnd = minDay(project.end, weekEnd, monthEnd)
+
+  if (visibleEnd.isBefore(visibleStart, 'day')) {
+    return null
+  }
+
+  return {
+    projectId: project.id,
+    title: project.title,
+    color: project.color,
+    weekId: week.weekId,
+    weekIndex: week.weekIndex,
+    visibleStart: formatIsoDate(visibleStart),
+    visibleEnd: formatIsoDate(visibleEnd),
+    startColumn: visibleStart.day(),
+    endColumn: visibleEnd.day(),
+    span: visibleEnd.diff(visibleStart, 'day') + 1,
+    startsInCell: visibleStart.isSame(project.start, 'day'),
+    endsInCell: visibleEnd.isSame(project.end, 'day'),
+    source: project.raw,
+  }
+}
+
+function assignLanes(segments) {
+  const lanes = []
+
+  return segments.map((segment) => {
+    let lane = 0
+
+    while (lanes[lane] !== undefined && lanes[lane] >= segment.startColumn) {
+      lane += 1
+    }
+
+    lanes[lane] = segment.endColumn
+
+    return {
+      ...segment,
+      lane,
+    }
+  })
+}
+
+function sortSegments(segments) {
+  return [...segments].sort((left, right) => {
+    if (left.startColumn !== right.startColumn) {
+      return left.startColumn - right.startColumn
+    }
+
+    if (left.span !== right.span) {
+      return right.span - left.span
+    }
+
+    return left.title.localeCompare(right.title, 'es')
+  })
+}
+
+export function getProjectMonthSegments(project, monthStartValue, monthEndValue) {
+  const normalizedProject = normalizeProject(project)
+  const monthStart = dayjs(monthStartValue).startOf('day')
+  const monthEnd = dayjs(monthEndValue).startOf('day')
+
+  if (!normalizedProject || monthEnd.isBefore(monthStart, 'day')) {
+    return []
+  }
+
+  if (normalizedProject.end.isBefore(monthStart, 'day') || normalizedProject.start.isAfter(monthEnd, 'day')) {
+    return []
+  }
+
+  const visibleWeeks = getVisibleWeeks(monthStart, monthEnd, dayjs())
+
+  return visibleWeeks
+    .map((week) => buildWeekSegment(normalizedProject, week, monthStart, monthEnd))
+    .filter(Boolean)
+}
+
+export function buildProjectYearMonths(projects, year, options = {}) {
+  const today = dayjs(options.today ?? new Date()).startOf('day')
+  const normalizedProjects = projects.map(normalizeProject).filter(Boolean)
+
+  return Array.from({ length: 12 }, (_, monthIndex) => {
+    const monthStart = dayjs(`${year}-${String(monthIndex + 1).padStart(2, '0')}-01`).startOf('day')
+    const monthEnd = monthStart.endOf('month').startOf('day')
+    const weeks = getVisibleWeeks(monthStart, monthEnd, today)
+
+    const segments = sortSegments(
+      normalizedProjects.flatMap((project) => getProjectMonthSegments(project.raw, monthStart, monthEnd))
+    )
+
+    const segmentsByWeekId = new Map(
+      weeks.map((week) => [
+        week.weekId,
+        assignLanes(segments.filter((segment) => segment.weekId === week.weekId)),
+      ])
+    )
+
+    return {
+      monthIndex,
+      monthNumber: monthIndex + 1,
+      monthLabel: MONTH_LABELS[monthIndex],
+      year,
+      monthStart: formatIsoDate(monthStart),
+      monthEnd: formatIsoDate(monthEnd),
+      weeks: weeks.map((week) => ({
+        ...week,
+        segments: segmentsByWeekId.get(week.weekId) ?? [],
+      })),
+    }
+  })
+}

--- a/src/lib/projectYearCalendar.js
+++ b/src/lib/projectYearCalendar.js
@@ -1,14 +1,22 @@
 import dayjs from 'dayjs'
 
-const MONTH_LABELS = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre']
-const WEEKDAY_LABELS = ['D', 'L', 'M', 'X', 'J', 'V', 'S']
+export const MONTH_LABELS = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre']
+export const MONTH_SHORT_LABELS = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic']
 
-function formatIsoDate(value) {
+export function formatIsoDate(value) {
   return dayjs(value).format('YYYY-MM-DD')
 }
 
-function getWeekId(date) {
-  return formatIsoDate(date.startOf('week'))
+export function normalizeDate(value) {
+  if (!value) {
+    return dayjs('')
+  }
+
+  if (typeof value === 'string' && value.length >= 10) {
+    return dayjs(value.slice(0, 10)).startOf('day')
+  }
+
+  return dayjs(value).startOf('day')
 }
 
 function getProjectTitle(project) {
@@ -16,12 +24,13 @@ function getProjectTitle(project) {
 }
 
 function getProjectEnd(project) {
-  return project.end_date ?? project.start_date ?? project.end ?? project.start
+  return project.end_date ?? project.end ?? project.start_date ?? project.start
 }
 
-function normalizeProject(project) {
-  const start = dayjs(project.start_date ?? project.start)
-  const end = dayjs(getProjectEnd(project))
+export function normalizeProject(project) {
+  const start = normalizeDate(project.start_date ?? project.start)
+  const rawEnd = project.end_date ?? project.end
+  const end = normalizeDate(getProjectEnd(project))
 
   if (!start.isValid() || !end.isValid()) {
     return null
@@ -33,165 +42,164 @@ function normalizeProject(project) {
     color: project.color ?? '#4f98a3',
     start,
     end: end.isBefore(start, 'day') ? start : end,
+    hasExplicitEnd: Boolean(rawEnd),
     raw: project,
   }
 }
 
-function getVisibleWeeks(monthStart, monthEnd, today) {
-  const firstWeekStart = monthStart.startOf('month').startOf('week')
-  const lastWeekEnd = monthEnd.endOf('month').endOf('week')
-  const weeks = []
-
-  let current = firstWeekStart
-  let weekIndex = 0
-
-  while (current.isBefore(lastWeekEnd, 'day') || current.isSame(lastWeekEnd, 'day')) {
-    const weekStart = current
-    const weekEnd = current.endOf('week')
-
-    weeks.push({
-      weekId: getWeekId(weekStart),
-      weekIndex,
-      start: formatIsoDate(weekStart),
-      end: formatIsoDate(weekEnd),
-      days: Array.from({ length: 7 }, (_, dayIndex) => {
-        const date = weekStart.add(dayIndex, 'day')
-        return {
-          date: formatIsoDate(date),
-          dayOfMonth: date.date(),
-          weekdayLabel: WEEKDAY_LABELS[dayIndex],
-          isCurrentMonth: date.month() === monthStart.month(),
-          isToday: date.isSame(today, 'day'),
-        }
-      }),
-    })
-
-    current = current.add(1, 'week')
-    weekIndex += 1
-  }
-
-  return weeks
+function overlapsMonth(project, monthStart, monthEnd) {
+  return !project.end.isBefore(monthStart, 'day') && !project.start.isAfter(monthEnd, 'day')
 }
 
-function maxDay(...dates) {
-  return dates.reduce((currentMax, candidate) => candidate.isAfter(currentMax, 'day') ? candidate : currentMax)
-}
-
-function minDay(...dates) {
-  return dates.reduce((currentMin, candidate) => candidate.isBefore(currentMin, 'day') ? candidate : currentMin)
-}
-
-function buildWeekSegment(project, week, monthStart, monthEnd) {
-  const weekStart = dayjs(week.start)
-  const weekEnd = dayjs(week.end)
-  const visibleStart = maxDay(project.start, weekStart, monthStart)
-  const visibleEnd = minDay(project.end, weekEnd, monthEnd)
-
-  if (visibleEnd.isBefore(visibleStart, 'day')) {
-    return null
-  }
-
-  return {
-    projectId: project.id,
-    title: project.title,
-    color: project.color,
-    weekId: week.weekId,
-    weekIndex: week.weekIndex,
-    visibleStart: formatIsoDate(visibleStart),
-    visibleEnd: formatIsoDate(visibleEnd),
-    startColumn: visibleStart.day(),
-    endColumn: visibleEnd.day(),
-    span: visibleEnd.diff(visibleStart, 'day') + 1,
-    startsInCell: visibleStart.isSame(project.start, 'day'),
-    endsInCell: visibleEnd.isSame(project.end, 'day'),
-    source: project.raw,
-  }
-}
-
-function assignLanes(segments) {
-  const lanes = []
-
-  return segments.map((segment) => {
-    let lane = 0
-
-    while (lanes[lane] !== undefined && lanes[lane] >= segment.startColumn) {
-      lane += 1
+function sortNormalizedProjects(projects) {
+  return [...projects].sort((left, right) => {
+    if (!left.start.isSame(right.start, 'day')) {
+      return left.start.valueOf() - right.start.valueOf()
     }
 
-    lanes[lane] = segment.endColumn
-
-    return {
-      ...segment,
-      lane,
-    }
-  })
-}
-
-function sortSegments(segments) {
-  return [...segments].sort((left, right) => {
-    if (left.startColumn !== right.startColumn) {
-      return left.startColumn - right.startColumn
-    }
-
-    if (left.span !== right.span) {
-      return right.span - left.span
+    if (!left.end.isSame(right.end, 'day')) {
+      return left.end.valueOf() - right.end.valueOf()
     }
 
     return left.title.localeCompare(right.title, 'es')
   })
 }
 
-export function getProjectMonthSegments(project, monthStartValue, monthEndValue) {
-  const normalizedProject = normalizeProject(project)
-  const monthStart = dayjs(monthStartValue).startOf('day')
-  const monthEnd = dayjs(monthEndValue).startOf('day')
+export function getProjectActiveMonths(project, year) {
+  const normalized = normalizeProject(project)
 
-  if (!normalizedProject || monthEnd.isBefore(monthStart, 'day')) {
+  if (!normalized) {
     return []
   }
-
-  if (normalizedProject.end.isBefore(monthStart, 'day') || normalizedProject.start.isAfter(monthEnd, 'day')) {
-    return []
-  }
-
-  const visibleWeeks = getVisibleWeeks(monthStart, monthEnd, dayjs())
-
-  return visibleWeeks
-    .map((week) => buildWeekSegment(normalizedProject, week, monthStart, monthEnd))
-    .filter(Boolean)
-}
-
-export function buildProjectYearMonths(projects, year, options = {}) {
-  const today = dayjs(options.today ?? new Date()).startOf('day')
-  const normalizedProjects = projects.map(normalizeProject).filter(Boolean)
 
   return Array.from({ length: 12 }, (_, monthIndex) => {
     const monthStart = dayjs(`${year}-${String(monthIndex + 1).padStart(2, '0')}-01`).startOf('day')
     const monthEnd = monthStart.endOf('month').startOf('day')
-    const weeks = getVisibleWeeks(monthStart, monthEnd, today)
+    return overlapsMonth(normalized, monthStart, monthEnd) ? monthIndex : null
+  }).filter((monthIndex) => monthIndex !== null)
+}
 
-    const segments = sortSegments(
-      normalizedProjects.flatMap((project) => getProjectMonthSegments(project.raw, monthStart, monthEnd))
-    )
+export function getProjectsForMonth(projects, year, monthIndex) {
+  const monthStart = dayjs(`${year}-${String(monthIndex + 1).padStart(2, '0')}-01`).startOf('day')
+  const monthEnd = monthStart.endOf('month').startOf('day')
 
-    const segmentsByWeekId = new Map(
-      weeks.map((week) => [
-        week.weekId,
-        assignLanes(segments.filter((segment) => segment.weekId === week.weekId)),
-      ])
-    )
+  return sortNormalizedProjects(
+    projects
+      .map(normalizeProject)
+      .filter(Boolean)
+      .filter((project) => overlapsMonth(project, monthStart, monthEnd))
+  ).map((project) => ({
+    id: project.id,
+    title: project.title,
+    color: project.color,
+    startDate: formatIsoDate(project.start),
+    endDate: project.hasExplicitEnd ? formatIsoDate(project.end) : null,
+    visibleStart: formatIsoDate(project.start.isBefore(monthStart, 'day') ? monthStart : project.start),
+    visibleEnd: formatIsoDate(project.end.isAfter(monthEnd, 'day') ? monthEnd : project.end),
+    startsBeforeMonth: project.start.isBefore(monthStart, 'day'),
+    endsAfterMonth: project.end.isAfter(monthEnd, 'day'),
+    source: project.raw,
+  }))
+}
 
-    return {
-      monthIndex,
-      monthNumber: monthIndex + 1,
-      monthLabel: MONTH_LABELS[monthIndex],
-      year,
-      monthStart: formatIsoDate(monthStart),
-      monthEnd: formatIsoDate(monthEnd),
-      weeks: weeks.map((week) => ({
-        ...week,
-        segments: segmentsByWeekId.get(week.weekId) ?? [],
-      })),
+export function getProjectsByMonth(projects, year) {
+  return Array.from({ length: 12 }, (_, monthIndex) => ({
+    monthIndex,
+    monthNumber: monthIndex + 1,
+    monthLabel: MONTH_LABELS[monthIndex],
+    monthShortLabel: MONTH_SHORT_LABELS[monthIndex],
+    projects: getProjectsForMonth(projects, year, monthIndex),
+  }))
+}
+
+export function clampProjectRangeToYear(project, year) {
+  const normalized = normalizeProject(project)
+
+  if (!normalized) {
+    return null
+  }
+
+  const yearStart = dayjs(`${year}-01-01`).startOf('day')
+  const yearEnd = dayjs(`${year}-12-31`).startOf('day')
+
+  if (normalized.end.isBefore(yearStart, 'day') || normalized.start.isAfter(yearEnd, 'day')) {
+    return null
+  }
+
+  const visibleStart = normalized.start.isBefore(yearStart, 'day') ? yearStart : normalized.start
+  const visibleEnd = normalized.end.isAfter(yearEnd, 'day') ? yearEnd : normalized.end
+
+  return {
+    id: normalized.id,
+    title: normalized.title,
+    color: normalized.color,
+    startDate: formatIsoDate(normalized.start),
+    endDate: normalized.hasExplicitEnd ? formatIsoDate(normalized.end) : null,
+    visibleStart: formatIsoDate(visibleStart),
+    visibleEnd: formatIsoDate(visibleEnd),
+    startMonthIndex: visibleStart.month(),
+    endMonthIndex: visibleEnd.month(),
+    startsBeforeYear: normalized.start.isBefore(yearStart, 'day'),
+    endsAfterYear: normalized.end.isAfter(yearEnd, 'day'),
+    source: normalized.raw,
+  }
+}
+
+export function getProjectTimelineRows(projects, year) {
+  return sortNormalizedProjects(projects.map(normalizeProject).filter(Boolean))
+    .map((project) => clampProjectRangeToYear(project.raw, year))
+    .filter(Boolean)
+}
+
+export function getBusiestMonth(projects, year) {
+  const months = getProjectsByMonth(projects, year)
+  const busiest = months.reduce((current, month) => {
+    if (month.projects.length > current.projects.length) {
+      return month
     }
-  })
+
+    return current
+  }, months[0])
+
+  return busiest.projects.length > 0 ? busiest : null
+}
+
+export function getNextProjectStart(projects, fromDate = new Date(), options = {}) {
+  const from = normalizeDate(fromDate)
+
+  if (!from.isValid()) {
+    return null
+  }
+
+  const upcoming = sortNormalizedProjects(
+    projects
+      .map(normalizeProject)
+      .filter(Boolean)
+      .filter((project) => options.year === undefined || project.start.year() === options.year)
+      .filter((project) => !project.start.isBefore(from, 'day'))
+  )
+
+  if (upcoming.length === 0) {
+    return null
+  }
+
+  const [project] = upcoming
+
+  return {
+    id: project.id,
+    title: project.title,
+    startDate: formatIsoDate(project.start),
+    source: project.raw,
+  }
+}
+
+export function getDefaultSelectedMonth(projects, year, todayValue = new Date()) {
+  const today = normalizeDate(todayValue)
+
+  if (today.isValid() && today.year() === year) {
+    return today.month()
+  }
+
+  const firstActiveMonth = getProjectsByMonth(projects, year).find((month) => month.projects.length > 0)
+  return firstActiveMonth?.monthIndex ?? 0
 }

--- a/src/lib/projectYearCalendar.test.ts
+++ b/src/lib/projectYearCalendar.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+import { buildProjectYearMonths, getProjectMonthSegments } from './projectYearCalendar'
+
+describe('project year calendar helper', () => {
+  it('segmenta un proyecto de un solo dia en una unica celda', () => {
+    const [segment] = getProjectMonthSegments(
+      { id: 'p1', name: 'Proyecto', color: '#123456', start_date: '2026-05-15', end_date: '2026-05-15' },
+      '2026-05-01',
+      '2026-05-31'
+    )
+
+    expect(segment).toMatchObject({
+      projectId: 'p1',
+      title: 'Proyecto',
+      color: '#123456',
+      visibleStart: '2026-05-15',
+      visibleEnd: '2026-05-15',
+      startColumn: 5,
+      endColumn: 5,
+      span: 1,
+      startsInCell: true,
+      endsInCell: true,
+    })
+  })
+
+  it('parte un proyecto largo en segmentos semanales dentro del mismo mes', () => {
+    const segments = getProjectMonthSegments(
+      { id: 'p1', name: 'Residencia', start_date: '2026-05-10', end_date: '2026-05-20' },
+      '2026-05-01',
+      '2026-05-31'
+    )
+
+    expect(segments).toHaveLength(2)
+    expect(segments[0]).toMatchObject({
+      visibleStart: '2026-05-10',
+      visibleEnd: '2026-05-16',
+      startColumn: 0,
+      endColumn: 6,
+      span: 7,
+      startsInCell: true,
+      endsInCell: false,
+    })
+    expect(segments[1]).toMatchObject({
+      visibleStart: '2026-05-17',
+      visibleEnd: '2026-05-20',
+      startColumn: 0,
+      endColumn: 3,
+      span: 4,
+      startsInCell: false,
+      endsInCell: true,
+    })
+  })
+
+  it('recorta correctamente el inicio visible cuando el proyecto viene del mes anterior', () => {
+    const segments = getProjectMonthSegments(
+      { id: 'p1', name: 'Gira', start_date: '2026-04-29', end_date: '2026-05-03' },
+      '2026-05-01',
+      '2026-05-31'
+    )
+
+    expect(segments).toHaveLength(2)
+    expect(segments[0]).toMatchObject({
+      visibleStart: '2026-05-01',
+      visibleEnd: '2026-05-02',
+      startColumn: 5,
+      endColumn: 6,
+      span: 2,
+      startsInCell: false,
+      endsInCell: false,
+    })
+    expect(segments[1]).toMatchObject({
+      visibleStart: '2026-05-03',
+      visibleEnd: '2026-05-03',
+      startColumn: 0,
+      endColumn: 0,
+      span: 1,
+      startsInCell: false,
+      endsInCell: true,
+    })
+  })
+
+  it('recorta diciembre a enero por el mes visible sin perder el final real', () => {
+    const segments = getProjectMonthSegments(
+      { id: 'p1', name: 'Temporada', start_date: '2026-12-28', end_date: '2027-01-04' },
+      '2027-01-01',
+      '2027-01-31'
+    )
+
+    expect(segments).toHaveLength(2)
+    expect(segments[0]).toMatchObject({
+      visibleStart: '2027-01-01',
+      visibleEnd: '2027-01-02',
+      startsInCell: false,
+      endsInCell: false,
+      span: 2,
+    })
+    expect(segments[1]).toMatchObject({
+      visibleStart: '2027-01-03',
+      visibleEnd: '2027-01-04',
+      startsInCell: false,
+      endsInCell: true,
+      span: 2,
+    })
+  })
+
+  it('respeta febrero bisiesto en el ano construido', () => {
+    const months = buildProjectYearMonths(
+      [{ id: 'p1', name: 'Expo', start_date: '2028-02-28', end_date: '2028-03-01' }],
+      2028,
+      { today: '2028-02-15' }
+    )
+
+    const february = months[1]
+    const februarySegments = february.weeks.flatMap((week) => week.segments)
+
+    expect(february.monthEnd).toBe('2028-02-29')
+    expect(februarySegments.some((segment) => segment.visibleEnd === '2028-02-29')).toBe(true)
+  })
+
+  it('asigna lanes distintas cuando dos proyectos se solapan en la misma semana', () => {
+    const months = buildProjectYearMonths(
+      [
+        { id: 'p1', name: 'Proyecto A', start_date: '2026-05-11', end_date: '2026-05-14' },
+        { id: 'p2', name: 'Proyecto B', start_date: '2026-05-12', end_date: '2026-05-15' },
+      ],
+      2026
+    )
+
+    const mayWeek = months[4].weeks.find((week) => week.start === '2026-05-10')
+
+    expect(mayWeek?.segments.map((segment) => [segment.projectId, segment.lane])).toEqual([
+      ['p1', 0],
+      ['p2', 1],
+    ])
+  })
+})

--- a/src/lib/projectYearCalendar.test.ts
+++ b/src/lib/projectYearCalendar.test.ts
@@ -1,136 +1,147 @@
 import { describe, expect, it } from 'vitest'
-import { buildProjectYearMonths, getProjectMonthSegments } from './projectYearCalendar'
+import {
+  clampProjectRangeToYear,
+  getBusiestMonth,
+  getDefaultSelectedMonth,
+  getNextProjectStart,
+  getProjectActiveMonths,
+  getProjectTimelineRows,
+  getProjectsByMonth,
+  getProjectsForMonth,
+} from './projectYearCalendar'
 
-describe('project year calendar helper', () => {
-  it('segmenta un proyecto de un solo dia en una unica celda', () => {
-    const [segment] = getProjectMonthSegments(
-      { id: 'p1', name: 'Proyecto', color: '#123456', start_date: '2026-05-15', end_date: '2026-05-15' },
-      '2026-05-01',
-      '2026-05-31'
-    )
+describe('project year planning helpers', () => {
+  it('detecta un proyecto que empieza y termina dentro del mismo mes', () => {
+    expect(getProjectActiveMonths(
+      { id: 'p1', name: 'Proyecto', start_date: '2026-05-15', end_date: '2026-05-20' },
+      2026
+    )).toEqual([4])
+  })
 
-    expect(segment).toMatchObject({
-      projectId: 'p1',
-      title: 'Proyecto',
-      color: '#123456',
-      visibleStart: '2026-05-15',
-      visibleEnd: '2026-05-15',
-      startColumn: 5,
-      endColumn: 5,
-      span: 1,
-      startsInCell: true,
-      endsInCell: true,
+  it('detecta todos los meses activos de un proyecto multi-mes', () => {
+    expect(getProjectActiveMonths(
+      { id: 'p1', name: 'Residencia', start_date: '2026-03-20', end_date: '2026-06-02' },
+      2026
+    )).toEqual([2, 3, 4, 5])
+  })
+
+  it('recorta un proyecto que viene de un ano anterior', () => {
+    expect(clampProjectRangeToYear(
+      { id: 'p1', name: 'Temporada', start_date: '2025-11-01', end_date: '2026-02-15' },
+      2026
+    )).toMatchObject({
+      visibleStart: '2026-01-01',
+      visibleEnd: '2026-02-15',
+      startMonthIndex: 0,
+      endMonthIndex: 1,
+      startsBeforeYear: true,
+      endsAfterYear: false,
     })
   })
 
-  it('parte un proyecto largo en segmentos semanales dentro del mismo mes', () => {
-    const segments = getProjectMonthSegments(
-      { id: 'p1', name: 'Residencia', start_date: '2026-05-10', end_date: '2026-05-20' },
-      '2026-05-01',
-      '2026-05-31'
-    )
-
-    expect(segments).toHaveLength(2)
-    expect(segments[0]).toMatchObject({
-      visibleStart: '2026-05-10',
-      visibleEnd: '2026-05-16',
-      startColumn: 0,
-      endColumn: 6,
-      span: 7,
-      startsInCell: true,
-      endsInCell: false,
-    })
-    expect(segments[1]).toMatchObject({
-      visibleStart: '2026-05-17',
-      visibleEnd: '2026-05-20',
-      startColumn: 0,
-      endColumn: 3,
-      span: 4,
-      startsInCell: false,
-      endsInCell: true,
+  it('recorta un proyecto que termina en un ano posterior', () => {
+    expect(clampProjectRangeToYear(
+      { id: 'p1', name: 'Festival', start_date: '2026-11-20', end_date: '2027-01-10' },
+      2026
+    )).toMatchObject({
+      visibleStart: '2026-11-20',
+      visibleEnd: '2026-12-31',
+      startMonthIndex: 10,
+      endMonthIndex: 11,
+      startsBeforeYear: false,
+      endsAfterYear: true,
     })
   })
 
-  it('recorta correctamente el inicio visible cuando el proyecto viene del mes anterior', () => {
-    const segments = getProjectMonthSegments(
-      { id: 'p1', name: 'Gira', start_date: '2026-04-29', end_date: '2026-05-03' },
-      '2026-05-01',
-      '2026-05-31'
+  it('trata proyectos sin fecha final como activos en su mes de inicio', () => {
+    const [project] = getProjectsForMonth(
+      [{ id: 'p1', name: 'Investigacion', start_date: '2026-04-08', end_date: null }],
+      2026,
+      3
     )
 
-    expect(segments).toHaveLength(2)
-    expect(segments[0]).toMatchObject({
-      visibleStart: '2026-05-01',
-      visibleEnd: '2026-05-02',
-      startColumn: 5,
-      endColumn: 6,
-      span: 2,
-      startsInCell: false,
-      endsInCell: false,
-    })
-    expect(segments[1]).toMatchObject({
-      visibleStart: '2026-05-03',
-      visibleEnd: '2026-05-03',
-      startColumn: 0,
-      endColumn: 0,
-      span: 1,
-      startsInCell: false,
-      endsInCell: true,
+    expect(project).toMatchObject({
+      title: 'Investigacion',
+      startDate: '2026-04-08',
+      endDate: null,
+      visibleStart: '2026-04-08',
+      visibleEnd: '2026-04-08',
     })
   })
 
-  it('recorta diciembre a enero por el mes visible sin perder el final real', () => {
-    const segments = getProjectMonthSegments(
-      { id: 'p1', name: 'Temporada', start_date: '2026-12-28', end_date: '2027-01-04' },
-      '2027-01-01',
-      '2027-01-31'
+  it('agrupa proyectos por mes y deja vacios los meses sin proyectos', () => {
+    const months = getProjectsByMonth(
+      [{ id: 'p1', name: 'Expo', start_date: '2026-04-01', end_date: '2026-04-30' }],
+      2026
     )
 
-    expect(segments).toHaveLength(2)
-    expect(segments[0]).toMatchObject({
-      visibleStart: '2027-01-01',
-      visibleEnd: '2027-01-02',
-      startsInCell: false,
-      endsInCell: false,
-      span: 2,
-    })
-    expect(segments[1]).toMatchObject({
-      visibleStart: '2027-01-03',
-      visibleEnd: '2027-01-04',
-      startsInCell: false,
-      endsInCell: true,
-      span: 2,
-    })
+    expect(months[2].projects).toHaveLength(0)
+    expect(months[3].projects.map((project) => project.title)).toEqual(['Expo'])
   })
 
-  it('respeta febrero bisiesto en el ano construido', () => {
-    const months = buildProjectYearMonths(
-      [{ id: 'p1', name: 'Expo', start_date: '2028-02-28', end_date: '2028-03-01' }],
-      2028,
-      { today: '2028-02-15' }
-    )
-
-    const february = months[1]
-    const februarySegments = february.weeks.flatMap((week) => week.segments)
-
-    expect(february.monthEnd).toBe('2028-02-29')
-    expect(februarySegments.some((segment) => segment.visibleEnd === '2028-02-29')).toBe(true)
-  })
-
-  it('asigna lanes distintas cuando dos proyectos se solapan en la misma semana', () => {
-    const months = buildProjectYearMonths(
+  it('calcula el mes mas cargado', () => {
+    const busiestMonth = getBusiestMonth(
       [
-        { id: 'p1', name: 'Proyecto A', start_date: '2026-05-11', end_date: '2026-05-14' },
-        { id: 'p2', name: 'Proyecto B', start_date: '2026-05-12', end_date: '2026-05-15' },
+        { id: 'p1', name: 'A', start_date: '2026-04-01', end_date: '2026-04-30' },
+        { id: 'p2', name: 'B', start_date: '2026-04-20', end_date: '2026-05-02' },
+        { id: 'p3', name: 'C', start_date: '2026-05-01', end_date: '2026-05-03' },
       ],
       2026
     )
 
-    const mayWeek = months[4].weeks.find((week) => week.start === '2026-05-10')
+    expect(busiestMonth?.monthLabel).toBe('Abril')
+    expect(busiestMonth?.projects).toHaveLength(2)
+  })
 
-    expect(mayWeek?.segments.map((segment) => [segment.projectId, segment.lane])).toEqual([
-      ['p1', 0],
-      ['p2', 1],
-    ])
+  it('calcula el proximo inicio desde una fecha dada', () => {
+    const nextProject = getNextProjectStart(
+      [
+        { id: 'p1', name: 'Pasado', start_date: '2026-03-01', end_date: '2026-03-03' },
+        { id: 'p2', name: 'Siguiente', start_date: '2026-05-10', end_date: '2026-05-12' },
+        { id: 'p3', name: 'Despues', start_date: '2026-06-01', end_date: '2026-06-02' },
+      ],
+      '2026-05-01'
+    )
+
+    expect(nextProject).toMatchObject({ title: 'Siguiente', startDate: '2026-05-10' })
+  })
+
+  it('limita el proximo inicio al ano visible cuando se indica', () => {
+    const nextProject = getNextProjectStart(
+      [
+        { id: 'p1', name: 'Cruza', start_date: '2025-12-20', end_date: '2026-01-10' },
+        { id: 'p2', name: 'Visible', start_date: '2026-02-01', end_date: '2026-02-03' },
+        { id: 'p3', name: 'Futuro', start_date: '2027-01-01', end_date: '2027-01-02' },
+      ],
+      '2026-01-01',
+      { year: 2026 }
+    )
+
+    expect(nextProject).toMatchObject({ title: 'Visible', startDate: '2026-02-01' })
+  })
+
+  it('ordena las filas por fecha de inicio e ignora fechas invalidas', () => {
+    const rows = getProjectTimelineRows(
+      [
+        { id: 'invalid', name: 'Sin fecha', start_date: null, end_date: null },
+        { id: 'p2', name: 'B', start_date: '2026-05-01', end_date: '2026-05-02' },
+        { id: 'p1', name: 'A', start_date: '2026-04-01', end_date: '2026-04-02' },
+      ],
+      2026
+    )
+
+    expect(rows.map((row) => row.id)).toEqual(['p1', 'p2'])
+  })
+
+  it('selecciona el mes actual si pertenece al ano visible', () => {
+    expect(getDefaultSelectedMonth([], 2026, '2026-05-06')).toBe(4)
+  })
+
+  it('selecciona el primer mes con proyectos si el ano visible no es el actual', () => {
+    expect(getDefaultSelectedMonth(
+      [{ id: 'p1', name: 'Abril', start_date: '2026-04-01', end_date: '2026-04-30' }],
+      2026,
+      '2025-05-06'
+    )).toBe(3)
   })
 })

--- a/src/pages/Calendar/CalendarProjects.jsx
+++ b/src/pages/Calendar/CalendarProjects.jsx
@@ -3,6 +3,7 @@ import { Calendar, dayjsLocalizer } from 'react-big-calendar'
 import dayjs from 'dayjs'
 import 'react-big-calendar/lib/css/react-big-calendar.css'
 import { Link } from 'react-router-dom'
+import { ProjectYearView } from '../../components/calendar/ProjectYearView'
 import { PageWrapper } from '../../components/layout/PageWrapper'
 import { Button } from '../../components/ui/Button'
 import { StatusBadge } from '../../components/ui/Badge'
@@ -37,87 +38,6 @@ const messages = {
   showMore: (total) => `+${total} más`,
 }
 
-// Componente de vista anual - grid de 12 meses
-function YearView({ date, events, onSelectEvent }) {
-  const year = dayjs(date).year()
-  const months = Array.from({ length: 12 }, (_, i) => dayjs().month(i).year(year).startOf('month'))
-
-  const getProjectsForMonth = (monthStart) => {
-    const monthEnd = monthStart.endOf('month')
-    return events.filter((event) => {
-      const eventStart = dayjs(event.start)
-      const eventEnd = dayjs(event.end)
-      return eventStart.isBefore(monthEnd, 'day') && eventEnd.isAfter(monthStart, 'day')
-    })
-  }
-
-  const monthNames = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre']
-
-  return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 p-2">
-      {months.map((monthStart, idx) => {
-        const monthProjects = getProjectsForMonth(monthStart)
-        const daysInMonth = monthStart.daysInMonth()
-        const firstDayOfWeek = monthStart.day()
-
-        return (
-          <div key={idx} className="border border-gray-200 rounded-lg bg-white overflow-hidden min-h-[140px]">
-            {/* Cabecera del mes */}
-            <div className="bg-gray-50 px-3 py-2 border-b border-gray-200">
-              <p className="text-sm font-semibold text-gray-800">{monthNames[idx]} {year}</p>
-            </div>
-            {/* Grid de días del mes */}
-            <div className="p-2">
-              {/* Días de la semana */}
-              <div className="grid grid-cols-7 gap-0.5 mb-1">
-                {['D', 'L', 'M', 'X', 'J', 'V', 'S'].map((d, i) => (
-                  <div key={i} className="text-[10px] text-gray-400 text-center font-medium">{d}</div>
-                ))}
-              </div>
-              {/* Días del mes */}
-              <div className="grid grid-cols-7 gap-0.5">
-                {/* Espacios vacíos antes del primer día */}
-                {Array.from({ length: firstDayOfWeek }).map((_, i) => (
-                  <div key={`empty-${i}`} className="h-5" />
-                ))}
-                {/* Días del mes */}
-                {Array.from({ length: daysInMonth }).map((_, dayIdx) => {
-                  const currentDay = monthStart.date(dayIdx + 1)
-                  return (
-                    <div
-                      key={dayIdx}
-                      className={`h-5 text-[10px] text-center flex items-center justify-center ${currentDay.isSame(dayjs(), 'day') ? 'bg-[var(--color-primary-100)] text-[var(--color-primary-700)] rounded font-medium' : 'text-gray-600'}`}
-                    >
-                      {dayIdx + 1}
-                    </div>
-                  )
-                })}
-              </div>
-              {/* Proyectos del mes */}
-              <div className="mt-2 space-y-1 max-h-[60px] overflow-y-auto">
-                {monthProjects.slice(0, 3).map((project) => (
-                  <button
-                    key={project.id}
-                    onClick={() => onSelectEvent(project)}
-                    className="w-full text-left px-2 py-1 rounded text-[10px] truncate text-white font-medium hover:opacity-90 transition-opacity"
-                    style={{ backgroundColor: project.resource?.color ?? '#4f98a3' }}
-                    title={project.title}
-                  >
-                    {project.title}
-                  </button>
-                ))}
-                {monthProjects.length > 3 && (
-                  <p className="text-[10px] text-gray-500 px-2">+{monthProjects.length - 3} más</p>
-                )}
-              </div>
-            </div>
-          </div>
-        )
-      })}
-    </div>
-  )
-}
-
 // Detectar si es viewport móvil
 function useIsMobile() {
   const [isMobile, setIsMobile] = useState(false)
@@ -135,7 +55,7 @@ export default function CalendarProjects() {
   const { projects, loading, error, createProject } = useProjects(user?.id)
   const isMobile = useIsMobile()
   const [calendarDate, setCalendarDate] = useState(() => new Date())
-  const [calendarView, setCalendarView] = useState('month')
+  const [calendarView, setCalendarView] = useState('year')
   const [selectedProject, setSelectedProject] = useState(null)
   const [newModal, setNewModal] = useState(false)
   const [newProjectInitialData, setNewProjectInitialData] = useState(null)
@@ -143,9 +63,8 @@ export default function CalendarProjects() {
   const [panelExpanded, setPanelExpanded] = useState(false)
   const { toasts, addToast, removeToast } = useToast()
   
-  // En móvil solo mostrar month, no week ni year
-  const availableViews = isMobile ? ['month'] : ['month', 'week', 'year']
-  const calendarMinWidth = calendarView === 'week' ? 'min-w-[46rem]' : calendarView === 'year' ? 'min-w-[40rem]' : 'min-w-full'
+  const availableViews = isMobile ? ['year', 'month'] : ['year', 'month', 'week']
+  const calendarMinWidth = calendarView === 'week' ? 'min-w-[46rem]' : 'min-w-full'
 
   const calendarEvents = useMemo(() =>
     projects.map((p) => ({
@@ -226,7 +145,6 @@ export default function CalendarProjects() {
             </div>
           ) : (
             <div className="flex flex-1 flex-col">
-              {/* Navegación de año para vista year */}
               {calendarView === 'year' && (
                 <div className="mb-3 flex items-center justify-center gap-4">
                   <button
@@ -248,13 +166,13 @@ export default function CalendarProjects() {
                   </button>
                 </div>
               )}
-              <div className={`h-[min(62dvh,520px)] min-h-[420px] overflow-x-auto overflow-y-hidden sm:h-[560px] sm:min-h-[560px] lg:h-full lg:min-h-0 ${calendarView === 'year' ? 'overflow-x-auto' : ''}`}>
+              <div className={`h-[min(62dvh,520px)] min-h-[420px] overflow-x-auto overflow-y-hidden sm:h-[560px] sm:min-h-[560px] lg:h-full lg:min-h-0 ${calendarView === 'year' ? 'overflow-x-hidden overflow-y-auto' : ''}`}>
                 <div className={`h-full ${calendarMinWidth}`}>
                   {calendarView === 'year' ? (
-                    <YearView
+                    <ProjectYearView
                       date={calendarDate}
-                      events={calendarEvents}
-                      onSelectEvent={(event) => setSelectedProject(event.resource)}
+                      projects={projects}
+                      onSelectProject={setSelectedProject}
                     />
                   ) : (
                     <Calendar

--- a/src/pages/Calendar/CalendarProjects.jsx
+++ b/src/pages/Calendar/CalendarProjects.jsx
@@ -1,7 +1,5 @@
-import { useState, useMemo, useEffect } from 'react'
-import { Calendar, dayjsLocalizer } from 'react-big-calendar'
+import { useState, useEffect } from 'react'
 import dayjs from 'dayjs'
-import 'react-big-calendar/lib/css/react-big-calendar.css'
 import { Link } from 'react-router-dom'
 import { ProjectYearView } from '../../components/calendar/ProjectYearView'
 import { PageWrapper } from '../../components/layout/PageWrapper'
@@ -13,30 +11,8 @@ import { ProjectForm } from '../Projects/ProjectForm'
 import { useAuth } from '../../hooks/useAuth'
 import { useProjects } from '../../hooks/useProjects'
 import { formatDate } from '../../lib/formatters'
+import { getDefaultSelectedMonth } from '../../lib/projectYearCalendar'
 import { AlertCircle, FolderOpen, Plus, X, ChevronDown, ChevronUp, ChevronLeft, ChevronRight } from 'lucide-react'
-
-const localizer = dayjsLocalizer(dayjs)
-const calendarFormats = {
-  dayFormat: (date) => dayjs(date).format('D ddd'),
-  dayRangeHeaderFormat: ({ start, end }) => `${dayjs(start).format('D MMM')} – ${dayjs(end).format('D MMM')}`,
-}
-
-const messages = {
-  allDay: 'Todo el día',
-  previous: 'Anterior',
-  next: 'Siguiente',
-  today: 'Hoy',
-  month: 'Mes',
-  week: 'Semana',
-  day: 'Día',
-  year: 'Año',
-  agenda: 'Agenda',
-  date: 'Fecha',
-  time: 'Hora',
-  event: 'Proyecto',
-  noEventsInRange: 'No hay proyectos en este período.',
-  showMore: (total) => `+${total} más`,
-}
 
 // Detectar si es viewport móvil
 function useIsMobile() {
@@ -54,38 +30,14 @@ export default function CalendarProjects() {
   const { user } = useAuth()
   const { projects, loading, error, createProject } = useProjects(user?.id)
   const isMobile = useIsMobile()
-  const [calendarDate, setCalendarDate] = useState(() => new Date())
-  const [calendarView, setCalendarView] = useState('year')
+  const [visibleYear, setVisibleYear] = useState(() => dayjs().year())
+  const [selectedMonth, setSelectedMonth] = useState(() => dayjs().month())
   const [selectedProject, setSelectedProject] = useState(null)
   const [newModal, setNewModal] = useState(false)
   const [newProjectInitialData, setNewProjectInitialData] = useState(null)
   const [saving, setSaving] = useState(false)
   const [panelExpanded, setPanelExpanded] = useState(false)
   const { toasts, addToast, removeToast } = useToast()
-  
-  const availableViews = isMobile ? ['year', 'month'] : ['year', 'month', 'week']
-  const calendarMinWidth = calendarView === 'week' ? 'min-w-[46rem]' : 'min-w-full'
-
-  const calendarEvents = useMemo(() =>
-    projects.map((p) => ({
-      id: p.id,
-      title: p.name,
-      start: new Date(p.start_date + 'T00:00:00'),
-      end: new Date((p.end_date ?? p.start_date) + 'T23:59:59'),
-      resource: p,
-    }))
-  , [projects])
-
-  const eventStyleGetter = (event) => ({
-    style: {
-      backgroundColor: event.resource.color ?? '#4f98a3',
-      borderRadius: '6px',
-      border: 'none',
-      color: '#fff',
-      fontSize: '12px',
-      padding: '2px 6px',
-    },
-  })
 
   const handleCreate = async (formData) => {
     setSaving(true)
@@ -106,32 +58,43 @@ export default function CalendarProjects() {
     setNewProjectInitialData(null)
   }
 
-  const handleSelectSlot = ({ start, end }) => {
-    const startDate = dayjs(start).format('YYYY-MM-DD')
-    const exclusiveEnd = dayjs(end)
-    const inclusiveEnd = exclusiveEnd.isAfter(dayjs(start), 'day')
-      ? exclusiveEnd.subtract(1, 'day')
-      : dayjs(start)
-
-    openNewProject({
-      start_date: startDate,
-      end_date: inclusiveEnd.format('YYYY-MM-DD'),
-    })
+  const changeYear = (nextYear) => {
+    setVisibleYear(nextYear)
+    setSelectedMonth(getDefaultSelectedMonth(projects, nextYear))
   }
 
   return (
     <PageWrapper title="Calendario de proyectos">
-      <div className="flex flex-col gap-4 lg:flex-row lg:h-[calc(100vh-8rem)]">
+      <div className="flex flex-col gap-4 lg:flex-row">
         <div className="flex flex-1 flex-col rounded-xl border border-gray-200 bg-white p-3 sm:p-4 lg:min-h-0">
           <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-sm font-medium text-gray-900">{projects.length} proyectos</p>
-              <p className="text-xs text-gray-400">Vista interna por rango de fechas.</p>
+              <p className="text-xs text-gray-400">Vista interna por rango de fechas</p>
             </div>
-            <Button size="sm" onClick={() => openNewProject()} className="w-full justify-center sm:w-auto">
-              <Plus size={16} />
-              Nuevo proyecto
-            </Button>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <div className="flex items-center justify-center gap-2 rounded-xl border border-[#E2D9C2] bg-[#FFFCF5] px-2 py-1">
+                <button
+                  onClick={() => changeYear(visibleYear - 1)}
+                  className="rounded-lg p-1.5 text-gray-600 hover:bg-[#F5EFE0] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary-500)]"
+                  aria-label="Año anterior"
+                >
+                  <ChevronLeft size={20} />
+                </button>
+                <span className="min-w-16 text-center text-base font-semibold text-gray-900">{visibleYear}</span>
+                <button
+                  onClick={() => changeYear(visibleYear + 1)}
+                  className="rounded-lg p-1.5 text-gray-600 hover:bg-[#F5EFE0] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary-500)]"
+                  aria-label="Año siguiente"
+                >
+                  <ChevronRight size={20} />
+                </button>
+              </div>
+              <Button size="sm" onClick={() => openNewProject()} className="w-full justify-center sm:w-auto">
+                <Plus size={16} />
+                Nuevo proyecto
+              </Button>
+            </div>
           </div>
           {error && (
             <div className="mb-3 flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
@@ -141,64 +104,21 @@ export default function CalendarProjects() {
           )}
           {loading ? (
             <div className="flex flex-1 items-center justify-center rounded-lg border border-dashed border-gray-200 bg-gray-50 text-sm text-gray-400">
-              Cargando calendario...
+              Cargando planificación...
             </div>
           ) : (
-            <div className="flex flex-1 flex-col">
-              {calendarView === 'year' && (
-                <div className="mb-3 flex items-center justify-center gap-4">
-                  <button
-                    onClick={() => setCalendarDate(dayjs(calendarDate).subtract(1, 'year').toDate())}
-                    className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary-500)]"
-                    aria-label="Año anterior"
-                  >
-                    <ChevronLeft size={20} />
-                  </button>
-                  <span className="text-base font-semibold text-gray-900 min-w-[80px] text-center">
-                    {dayjs(calendarDate).year()}
-                  </span>
-                  <button
-                    onClick={() => setCalendarDate(dayjs(calendarDate).add(1, 'year').toDate())}
-                    className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary-500)]"
-                    aria-label="Año siguiente"
-                  >
-                    <ChevronRight size={20} />
-                  </button>
-                </div>
-              )}
-              <div className={`h-[min(62dvh,520px)] min-h-[420px] overflow-x-auto overflow-y-hidden sm:h-[560px] sm:min-h-[560px] lg:h-full lg:min-h-0 ${calendarView === 'year' ? 'overflow-x-hidden overflow-y-auto' : ''}`}>
-                <div className={`h-full ${calendarMinWidth}`}>
-                  {calendarView === 'year' ? (
-                    <ProjectYearView
-                      date={calendarDate}
-                      projects={projects}
-                      onSelectProject={setSelectedProject}
-                    />
-                  ) : (
-                    <Calendar
-                      localizer={localizer}
-                      events={calendarEvents}
-                      date={calendarDate}
-                      view={calendarView}
-                      views={availableViews}
-                      messages={messages}
-                      formats={calendarFormats}
-                      selectable
-                      eventPropGetter={eventStyleGetter}
-                      onNavigate={setCalendarDate}
-                      onView={setCalendarView}
-                      onSelectEvent={(event) => setSelectedProject(event.resource)}
-                      onSelectSlot={handleSelectSlot}
-                      popup
-                      style={{ height: '100%' }}
-                    />
-                  )}
-                </div>
-              </div>
+            <div className="flex flex-1 flex-col gap-4">
+              <ProjectYearView
+                projects={projects}
+                year={visibleYear}
+                selectedMonth={selectedMonth}
+                onSelectMonth={setSelectedMonth}
+                onSelectProject={setSelectedProject}
+              />
               {projects.length === 0 && (
                 <div className="mt-3 flex items-center gap-2 rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-4 text-sm text-gray-500">
                   <FolderOpen size={16} className="text-gray-400 flex-shrink-0" />
-                  No hay proyectos en esta cuenta. Puedes moverte por meses o seleccionar días para crear el primero.
+                  No hay proyectos en esta cuenta. Crea el primero para verlo en la planificación anual.
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Resumen

Rediseña `/calendar/projects` para que funcione como una planificación anual de producción en lugar de un calendario clásico de citas.

- Sustituye la parrilla diaria/semanal de proyectos por una timeline anual tipo Gantt en desktop.
- Añade resumen anual, selección de mes y detalle mensual en lista.
- Añade vista móvil con Gantt compacto por proyecto y lista de meses/cards.
- Extrae helpers puros para meses activos, agrupación mensual, rangos cruzando años, mes más cargado y próximo inicio.
- Mantiene los contratos actuales de datos y el flujo de creación de proyecto.

## Validación

- `npm run test -- projectYearCalendar`
- `npm run lint`
- `npm run build`

El build mantiene el warning habitual de chunk grande de Vite.

## Memoria

No aplica: no surgieron nuevas reglas duraderas ni gotchas reutilizables para `.memory/`.