### PR TITLE
Beta 6 — Estabilización visual y mobile financiero

### DIFF
--- a/.agents/skills/cultura-agent-orchestration/SKILL.md
+++ b/.agents/skills/cultura-agent-orchestration/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: cultura-agent-orchestration
+description: "Orquestar agentes para tareas de CulturaApp desde Codex, Claude Code u OpenCode: decidir si usar subagentes nativos, agentes OpenCode, exploracion paralela, ownership de escritura y verificacion. Usar cuando el usuario pida agentes, subagentes, Codex agents, Claude agents, OpenCode agents, revisar un plan con agentes o acelerar una tarea con delegacion. No usar para tareas triviales ni para implementar directamente sin necesidad de delegacion."
+---
+
+# Cultura Agent Orchestration
+
+## Purpose
+
+Acelera decisiones de delegacion en CulturaApp sin obligar a pasar siempre por OpenCode. La skill ayuda a elegir entre subagentes nativos del entorno actual, agentes OpenCode y trabajo local directo, manteniendo trazabilidad, ownership y verificacion.
+
+No sustituye las skills de dominio. Si la tarea es frontend, datos, seguridad, testing, release o review, combina esta skill con la skill especializada correspondiente.
+
+## When to use this skill
+
+- El usuario pide ejecutar, coordinar o lanzar agentes.
+- El usuario menciona Codex agents, Claude agents, OpenCode agents, subagentes, agentes en paralelo o "revisa el plan con agentes".
+- Una tarea de Beta/release necesita exploracion paralela antes de editar.
+- Hay trabajo de implementacion suficientemente grande para dividir por ownership de archivos.
+- Se quiere acelerar una revision usando agentes sin arrancar OpenCode.
+
+## When not to use this skill
+
+- No usar para cambios triviales que puede resolver un unico agente local.
+- No usar para saltarse `cultura-issue-launch` cuando el usuario pide lanzar una tarea nueva sin issue.
+- No usar para reemplazar `cultura-release-task-flow` cuando el trabajo es integrar una tarea terminada en una beta activa.
+- No usar para pedir a agentes que manejen secretos, `.env.local`, Supabase remoto, Vercel produccion o acciones destructivas sin confirmacion explicita.
+
+## Inputs to inspect
+
+- `git status --short --branch`
+- `AGENTS.md`
+- `docs/agent-context-policy.md`
+- `.memory/MEMORY.md`
+- `.memory/topics/agent-workflows.md`
+- `.opencode/README.md` solo si el usuario pide OpenCode o si hacen falta esos agentes concretos.
+- Issue `docs/project/issues/CACH-*.md` y release activa si la tarea pertenece a una release.
+- Diff actual si se revisa o verifica trabajo ya hecho.
+
+## Procedure
+
+1. Clasifica la peticion:
+   - `directa`: tarea pequena o de bajo riesgo; trabaja localmente.
+   - `revision paralela`: varias preguntas independientes; usa subagentes nativos si el entorno los ofrece.
+   - `implementacion dividida`: solo delegar escritura si hay ownership disjunto claro.
+   - `OpenCode solicitado`: usar `npm run agents:plan`, `npm run agents:run`, `npm run agents:parallel` o `npm run agents:verify`.
+2. Antes de delegar, define el trabajo local inmediato. No mandes a un agente el bloqueo critico si tu siguiente paso depende de su respuesta.
+3. Para subagentes nativos de Codex/Claude:
+   - Usalos solo cuando el usuario haya pedido agentes, delegacion o trabajo paralelo.
+   - Da prompts concretos, autocontenidos y con salida esperada.
+   - Para exploracion, pide hallazgos con archivos/lineas y nivel de confianza.
+   - Para escritura, asigna ownership disjunto por archivos o modulos y recuerda que no deben revertir cambios ajenos.
+4. Para OpenCode:
+   - Si no hay issue estructurada y el usuario pide lanzar implementacion, usa `npm run agents:plan -- "<prompt>"`.
+   - Si ya hay issue/rama/contexto, usa `npm run agents:run -- "<tarea>"`.
+   - Para revision paralela read-only, usa `npm run agents:parallel -- --agents <lista> "<tarea>"`.
+   - Para cierre, usa `npm run agents:verify -- "<contexto>"`.
+5. Siempre coordina por dominio:
+   - UI, rutas, formularios, calendarios, responsive: frontend/UX.
+   - Datos, hooks, Supabase, finanzas: data.
+   - Auth, RLS, secretos, privacidad: security.
+   - Checks, release readiness, regression matrix: testing.
+   - Docs, Product Brain, memoria, skills: docs/release.
+6. Integra resultados:
+   - Contrasta recomendaciones entre agentes.
+   - Decide y edita localmente o integra parches sin pisar cambios ajenos.
+   - Ejecuta verificaciones acordes al cambio.
+7. Cierre:
+   - Resume agentes usados, hallazgos incorporados, cambios, verificaciones y riesgos.
+   - Antes de PR, declarar `Memoria: actualizada` o `Memoria: no aplica`.
+
+## Output format
+
+```
+Modo: directo / subagentes nativos / OpenCode / mixto
+Agentes: <roles usados o "no aplica">
+Ownership: <archivos/modulos si hubo escritura>
+Resultado: <decision o cambios integrados>
+Verificacion: <comandos/checks>
+Memoria: actualizada / no aplica
+Pendiente: <bloqueos reales o "nada">
+```
+
+## Severity / priority model
+
+- CRITICAL: delegacion con secretos, acciones destructivas, force push, produccion o Supabase remoto sin confirmacion.
+- HIGH: agentes escribiendo sobre los mismos archivos sin ownership, o trabajo fuera de scope de release.
+- MEDIUM: prompts vagos, salida no accionable, verificacion insuficiente o resultados no integrados.
+- LOW: uso de OpenCode cuando bastaban subagentes nativos, wording o formato de cierre.
+
+## Quality bar
+
+- La delegacion reduce riesgo o tiempo de forma concreta.
+- Cada agente tiene una pregunta o ownership claro.
+- No hay duplicacion de trabajo entre agente principal y subagentes.
+- Las recomendaciones se integran en una decision final, no quedan como opiniones sueltas.
+- La verificacion corresponde al blast radius real.
+
+## Common mistakes to avoid
+
+- Lanzar agentes por reflejo cuando la tarea es pequena.
+- Usar OpenCode aunque el usuario pidiera agentes desde Codex o Claude.
+- Pedir "revisa todo" sin ruta, scope, diff, criterio o salida.
+- Delegar escritura paralela sin ownership disjunto.
+- Esperar a subagentes mientras hay trabajo local independiente que puede avanzar.
+- Guardar run logs o decisiones efimeras en `.memory/`.
+
+## Safety notes
+
+No incluir secretos, valores de `.env.local`, tokens, datos personales reales ni credenciales en prompts a agentes. No ejecutar acciones remotas, destructivas, de produccion, Supabase o Vercel sin confirmacion explicita. Si el entorno no ofrece subagentes nativos, usar OpenCode solo cuando encaje con la peticion o explicar el fallback.

--- a/.claude/skills/cultura-agent-orchestration
+++ b/.claude/skills/cultura-agent-orchestration
@@ -1,0 +1,1 @@
+../../.agents/skills/cultura-agent-orchestration

--- a/.memory/topics/portable-skills.md
+++ b/.memory/topics/portable-skills.md
@@ -12,6 +12,12 @@
 - Durable memory: las skills en `.agents/skills/` son: `portable-skill-authoring`, `cultura-frontend-review`, `cultura-data-finance-review`, `cultura-security-privacy-review`, `cultura-testing-release-check`, `cultura-code-review`, `memory-protocol`, `compact-memory`, `caveman`, `product-brain-capture`, `cultura-issue-launch`, `memory-orient`. Symlinks en `.claude/skills/`. Patrón: fuente canónica siempre en `.agents/skills/<nombre>/SKILL.md`.
 - Source: `ls .agents/skills/`; análisis 2026-05-06.
 
+## 2026-05-07 - cultura-agent-orchestration: Delegación Codex/Claude/OpenCode
+
+- Context: Beta 6 necesitaba acelerar revisión de planes y trabajo con agentes sin depender siempre de OpenCode.
+- Durable memory: `cultura-agent-orchestration` decide cuándo usar trabajo directo, subagentes nativos de Codex/Claude, agentes OpenCode, revisión paralela, ownership de escritura y verificación. Mantiene OpenCode para peticiones explícitas o flujos que lo requieran, y evita delegación en tareas triviales.
+- Source: `.agents/skills/cultura-agent-orchestration/SKILL.md`; `docs/agent-skills-strategy.md`.
+
 ## 2026-05-06 - memory-orient: Briefing De Memoria Por Contexto De Tarea
 
 - Context: No existía una forma rápida de obtener solo la memoria relevante para una tarea concreta sin leer los 17 archivos completos. Análogo a `brain-orient` pero para `.memory/`.

--- a/docs/agent-skills-strategy.md
+++ b/docs/agent-skills-strategy.md
@@ -30,6 +30,7 @@ Do not copy the same skill into both `.agents` and `.claude`. If a tool cannot f
 | `cultura-testing-release-check` | Lint/build, smoke tests, regression matrices, Vercel readiness. |
 | `cultura-code-review` | Cross-cutting code review of diffs, PRs, architecture, risk, and maintainability. |
 | `cultura-release-task-flow` | Integrate finished CACH tasks and documentation into the active beta release branch with Product Brain validation. |
+| `cultura-agent-orchestration` | Decide when to use native Codex/Claude subagents, OpenCode agents, parallel review, ownership, and verification. |
 | `memory-protocol` | File-based Markdown memory for durable agent context, recall, curation, and forgetting. |
 | `agent-context-maintenance` | Maintain agent context hygiene, review context-check warnings, and compact prompts/memory without losing critical rules. |
 | `caveman` | Ultra-concise communication mode adapted for CulturaApp, with safety fallbacks for reviews, data, finance, RLS, and irreversible actions. |
@@ -118,6 +119,7 @@ Validation status for the current setup:
 | `cultura-security-privacy-review` | Valid |
 | `cultura-testing-release-check` | Valid |
 | `cultura-code-review` | Valid |
+| `cultura-agent-orchestration` | Valid |
 | `memory-protocol` | Valid |
 | `.agents/templates/portable-skill` | Valid |
 | `git diff --check` | Pass |

--- a/docs/project/DIGEST.md
+++ b/docs/project/DIGEST.md
@@ -2,8 +2,8 @@
 id: PB-DIGEST
 type: digest
 status: Active
-created: 2026-05-06
-updated: 2026-05-06
+created: 2026-05-07
+updated: 2026-05-07
 aliases:
   - Digest
   - Brain Digest
@@ -14,33 +14,34 @@ tags:
 
 # Product Brain Digest
 
-*Generado: 2026-05-06 17:30 UTC*
+*Generado: 2026-05-07 07:46 UTC*
 
 ---
 
 ## Estado operacional
 
-- **Release activa:** ninguna — PRs directas a `main`
-- **Último corte:** `RELEASE-0.1.0-beta.4` — mergeada a `main` el 2026-05-06. Ver RELEASE-0.1.0-beta.4.
-- **Foco:** Sin release activa. Siguiente: CACH-0030 (PR directo) o abrir beta.5.
+- **Release activa:** RELEASE-0.1.0-beta.6 — Estabilización visual y mobile financiero.
+- **Último corte:** `RELEASE-0.1.0-beta.5` — mergeada a `main` en PR #84 el 2026-05-07. Ver RELEASE-0.1.0-beta.5.
+- **Foco:** Release activa: RELEASE-0.1.0-beta.6 — estabilización visual y mobile financiero.
 
 ## Prioridades del plan
 
-1. CACH-0030 (paleta/fuentes) como PR directo a main.
-2. Evaluar backlog p1 para definir si se abre `beta.5`.
-3. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
+1. Ejecutar CACH-0030 y CACH-0038 desde `release/0.1.0-beta.6`.
+2. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
+3. Dejar CACH-B0005 y CACH-B0006 como candidatas naturales para las siguientes betas, no para este corte visual/mobile.
 
 ## Tablero
 
 ### Inbox
 
-| ID | Título | Tipo | P |
-|---|---|---|---|
-| CACH-0030 | Homogeneizar diseno con nueva paleta | chore | p1 |
+_Sin issues._
 
 ### In progress
 
-_Sin issues._
+| ID | Título | Tipo | P |
+|---|---|---|---|
+| CACH-0030 | Homogeneizar diseno con nueva paleta | chore | p1 |
+| CACH-0038 | Compactar mobile financiero y detalles accionables | feature | p1 |
 
 ### Review
 
@@ -52,7 +53,6 @@ _Sin issues._
 |---|---|---|---|
 | CACH-B0001 | Redisenar Trabajos y jerarquia proyecto-evento | feature | p1 |
 | CACH-B0002 | Simplificar experiencia mobile financiera | feature | p1 |
-| CACH-B0003 | Cobro rapido y gestion de pendientes | feature | p1 |
 | CACH-B0004 | Contratantes, facturacion y liquidacion neta | feature | p1 |
 | CACH-B0005 | Importacion, exportacion y portabilidad de datos | feature | p1 |
 | CACH-B0006 | Onboarding y acceso beta | feature | p1 |
@@ -62,10 +62,10 @@ _Sin issues._
 
 | ID | Título | Estado | Tipo | P |
 |---|---|---|---|---|
-| CACH-0030 | Homogeneizar diseno con nueva paleta de colores y fuentes | inbox | chore | p1 |
+| CACH-0030 | Homogeneizar diseno con nueva paleta de colores y fuentes | in-progress | chore | p1 |
+| CACH-0038 | Compactar mobile financiero y detalles accionables | in-progress | feature | p1 |
 | CACH-B0001 | Redisenar Trabajos y jerarquia proyecto-evento | backlog | feature | p1 |
 | CACH-B0002 | Simplificar experiencia mobile financiera | backlog | feature | p1 |
-| CACH-B0003 | Cobro rapido y gestion de pendientes | backlog | feature | p1 |
 | CACH-B0004 | Contratantes facturacion y liquidacion neta | backlog | feature | p1 |
 | CACH-B0005 | Importacion exportacion y portabilidad de datos | backlog | feature | p1 |
 | CACH-B0006 | Onboarding y acceso beta | backlog | feature | p1 |
@@ -98,5 +98,3 @@ _Sin issues._
 | PB-ZK-20260504-TECH-AUDIT | Auditoría técnica repo — 2026-05-04 |
 
 ## Próxima acción
-
-Decidir si CACH-0030 va como PR directo o si se abre `beta.3` con más scope.

--- a/docs/project/DIGEST.md
+++ b/docs/project/DIGEST.md
@@ -14,7 +14,7 @@ tags:
 
 # Product Brain Digest
 
-*Generado: 2026-05-07 07:46 UTC*
+*Generado: 2026-05-07 07:59 UTC*
 
 ---
 
@@ -38,14 +38,14 @@ _Sin issues._
 
 ### In progress
 
+_Sin issues._
+
+### Review
+
 | ID | Título | Tipo | P |
 |---|---|---|---|
 | CACH-0030 | Homogeneizar diseno con nueva paleta | chore | p1 |
 | CACH-0038 | Compactar mobile financiero y detalles accionables | feature | p1 |
-
-### Review
-
-_Sin issues._
 
 ### Backlog (p1)
 
@@ -62,8 +62,8 @@ _Sin issues._
 
 | ID | Título | Estado | Tipo | P |
 |---|---|---|---|---|
-| CACH-0030 | Homogeneizar diseno con nueva paleta de colores y fuentes | in-progress | chore | p1 |
-| CACH-0038 | Compactar mobile financiero y detalles accionables | in-progress | feature | p1 |
+| CACH-0030 | Homogeneizar diseno con nueva paleta de colores y fuentes | review | chore | p1 |
+| CACH-0038 | Compactar mobile financiero y detalles accionables | review | feature | p1 |
 | CACH-B0001 | Redisenar Trabajos y jerarquia proyecto-evento | backlog | feature | p1 |
 | CACH-B0002 | Simplificar experiencia mobile financiera | backlog | feature | p1 |
 | CACH-B0004 | Contratantes facturacion y liquidacion neta | backlog | feature | p1 |

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -39,9 +39,7 @@ Tablero ligero del Product Brain. Cada trabajo ejecutable vive como issue Markdo
 
 ## Inbox
 
-| ID | Titulo | Tipo | Prioridad | Nota |
-|---|---|---|---|---|
-| [[../issues/CACH-0030|CACH-0030]] | Homogeneizar diseno con nueva paleta | chore | p1 | QA visual pendiente. |
+Sin issues en inbox.
 
 ## Backlog
 
@@ -61,7 +59,10 @@ Tablero ligero del Product Brain. Cada trabajo ejecutable vive como issue Markdo
 | [[../issues/CACH-B0013|CACH-B0013]] | Gestion documental por proyecto/evento | feature | p3 | Post-MVP. |
 ## In progress
 
-Sin issues en progreso.
+| ID | Titulo | Tipo | Prioridad | Nota |
+|---|---|---|---|---|
+| [[../issues/CACH-0030|CACH-0030]] | Homogeneizar diseno con nueva paleta | chore | p1 | Scope Beta 6: consistencia visual y QA responsive. |
+| [[../issues/CACH-0038|CACH-0038]] | Compactar mobile financiero y detalles accionables | feature | p1 | Slice de CACH-B0002 para Beta 6. |
 
 ## Review
 

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -59,14 +59,14 @@ Sin issues en inbox.
 | [[../issues/CACH-B0013|CACH-B0013]] | Gestion documental por proyecto/evento | feature | p3 | Post-MVP. |
 ## In progress
 
-| ID | Titulo | Tipo | Prioridad | Nota |
-|---|---|---|---|---|
-| [[../issues/CACH-0030|CACH-0030]] | Homogeneizar diseno con nueva paleta | chore | p1 | Scope Beta 6: consistencia visual y QA responsive. |
-| [[../issues/CACH-0038|CACH-0038]] | Compactar mobile financiero y detalles accionables | feature | p1 | Slice de CACH-B0002 para Beta 6. |
+Sin issues en progreso.
 
 ## Review
 
-Sin issues en review.
+| ID | Titulo | Tipo | Prioridad | Nota |
+|---|---|---|---|---|
+| [[../issues/CACH-0030|CACH-0030]] | Homogeneizar diseno con nueva paleta | chore | p1 | Pendiente QA visual autenticada. |
+| [[../issues/CACH-0038|CACH-0038]] | Compactar mobile financiero y detalles accionables | feature | p1 | Pendiente QA visual autenticada. |
 
 ## Done
 

--- a/docs/project/indexes/by-area.md
+++ b/docs/project/indexes/by-area.md
@@ -2,7 +2,7 @@
 id: PB-BY-AREA
 type: index
 status: Active
-created: 2026-05-06
+created: 2026-05-07
 updated: 2026-05-07
 aliases:
   - Issues por area
@@ -30,6 +30,7 @@ tags:
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos
+- [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -2,7 +2,7 @@
 id: PB-BY-RELEASE
 type: index
 status: Active
-created: 2026-05-06
+created: 2026-05-07
 updated: 2026-05-07
 aliases:
   - Issues por release
@@ -16,7 +16,6 @@ tags:
 
 - [[../issues/CACH-0026|CACH-0026]] — Setup inicial Product Brain
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada
-- [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion
 - [[../issues/CACH-0032|CACH-0032]] — Priorizar operativa diaria en dashboard movil
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas
@@ -38,6 +37,11 @@ tags:
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain
 - [[../issues/CACH-B0016|CACH-B0016]] — Refundacion operativa del Product Brain y tests B0014
+
+## RELEASE-0.1.0-beta.6
+
+- [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes
+- [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables
 
 ## RELEASE-0.1.0-beta.4
 

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -2,7 +2,7 @@
 id: PB-BY-STATUS
 type: index
 status: Active
-created: 2026-05-06
+created: 2026-05-07
 updated: 2026-05-07
 aliases:
   - Issues por estado
@@ -29,9 +29,10 @@ tags:
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain
 - [[../issues/CACH-B0016|CACH-B0016]] — Refundacion operativa del Product Brain y tests B0014
 
-## inbox
+## in-progress
 
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes
+- [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables
 
 ## backlog
 

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -29,11 +29,10 @@ tags:
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain
 - [[../issues/CACH-B0016|CACH-B0016]] — Refundacion operativa del Product Brain y tests B0014
 
-## in-progress
+## review
 
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables
-
 ## backlog
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento

--- a/docs/project/indexes/decisions.index.md
+++ b/docs/project/indexes/decisions.index.md
@@ -2,8 +2,8 @@
 id: PB-DECISIONS-INDEX
 type: index
 status: Active
-created: 2026-05-06
-updated: 2026-05-06
+created: 2026-05-07
+updated: 2026-05-07
 aliases:
   - Decisions Index
 tags:

--- a/docs/project/indexes/issues.index.md
+++ b/docs/project/indexes/issues.index.md
@@ -2,8 +2,8 @@
 id: PB-ISSUES-INDEX
 type: index
 status: Active
-created: 2026-05-06
-updated: 2026-05-06
+created: 2026-05-07
+updated: 2026-05-07
 aliases:
   - Issues Index
 tags:
@@ -23,6 +23,7 @@ tags:
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos
 - [[../issues/CACH-0036|CACH-0036]] — Profesionalizar flujo de ramas por beta
 - [[../issues/CACH-0037|CACH-0037]] — Consolidar PRD y sistema de diseno de Cachés
+- [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes

--- a/docs/project/indexes/knowledge.index.md
+++ b/docs/project/indexes/knowledge.index.md
@@ -2,8 +2,8 @@
 id: PB-KNOWLEDGE-INDEX
 type: index
 status: Active
-created: 2026-05-06
-updated: 2026-05-06
+created: 2026-05-07
+updated: 2026-05-07
 aliases:
   - Knowledge Index
 tags:

--- a/docs/project/indexes/releases.index.md
+++ b/docs/project/indexes/releases.index.md
@@ -2,8 +2,8 @@
 id: PB-RELEASES-INDEX
 type: index
 status: Active
-created: 2026-05-06
-updated: 2026-05-06
+created: 2026-05-07
+updated: 2026-05-07
 aliases:
   - Releases Index
 tags:
@@ -18,4 +18,5 @@ tags:
 - [[../releases/RELEASE-0.1.0-beta.3|RELEASE-0.1.0-beta.3]] — Rediseño financiero del Dashboard
 - [[../releases/RELEASE-0.1.0-beta.4|RELEASE-0.1.0-beta.4]] — Planificacion anual de proyectos
 - [[../releases/RELEASE-0.1.0-beta.5|RELEASE-0.1.0-beta.5]] — Flujo profesional de ramas beta
+- [[../releases/RELEASE-0.1.0-beta.6|RELEASE-0.1.0-beta.6]] — Estabilización visual y mobile financiero
 - [[../releases/RELEASE_TEMPLATE|PB-RELEASE-TEMPLATE]] — RELEASE_TEMPLATE

--- a/docs/project/issues/CACH-0030.md
+++ b/docs/project/issues/CACH-0030.md
@@ -2,14 +2,14 @@
 id: CACH-0030
 title: Homogeneizar diseno con nueva paleta de colores y fuentes
 type: chore
-status: inbox
+status: in-progress
 cycle: unassigned
-release: null
+release: RELEASE-0.1.0-beta.6
 priority: p1
 estimate: m
 area: frontend
 created_at: 2026-05-05
-updated_at: 2026-05-05
+updated_at: 2026-05-07
 aliases:
   - CACH-0030
 tags:
@@ -39,13 +39,20 @@ Tokens visuales definidos en `ui-direction-v3-20260504`:
 
 ## Proposed Solution
 
-1. Auditoria de componentes que faltan por aplicar la paleta
-2. Aplicar tokens CSS a cada componente
-3. Verificar consistencia visual en desktop y mobile
+1. Auditar el inventario cerrado de Beta 6: `Button`, `Card`, `Badge`, `Modal`, `Input`, `Select`, `Dashboard`, `Work`, `ProjectDetail`, `EventDetail`, `CalendarEvents`, `CalendarProjects`, `ProjectForm` y `EventForm`.
+2. Aplicar tokens CSS a inconsistencias visibles dentro de ese inventario.
+3. Corregir tokens base incoherentes en `src/index.css`, incluyendo `--font-mono` autorreferente y `--color-gray-950` sin definición.
+4. Verificar consistencia visual en desktop y mobile.
+
+## Out of Scope
+
+- Migración global de todos los `gray-*` o hex directos de la app.
+- Cambios de marca, paleta nueva o rediseño completo.
+- Hex dinámicos de color de proyecto/evento asignado por usuario.
 
 ## Acceptance Criteria
 
-- [ ] Todos los UI components aplican la paleta de colores v3
+- [ ] El inventario cerrado de Beta 6 aplica la paleta de colores v3
 - [ ] Tipografías consistentes (DM Serif Display, Instrument Sans, DM Mono)
 - [ ] Radios y sombras aplicados según tokens
 - [ ] Verificación responsive en mobile y desktop

--- a/docs/project/issues/CACH-0030.md
+++ b/docs/project/issues/CACH-0030.md
@@ -2,7 +2,7 @@
 id: CACH-0030
 title: Homogeneizar diseno con nueva paleta de colores y fuentes
 type: chore
-status: in-progress
+status: review
 cycle: unassigned
 release: RELEASE-0.1.0-beta.6
 priority: p1
@@ -52,10 +52,16 @@ Tokens visuales definidos en `ui-direction-v3-20260504`:
 
 ## Acceptance Criteria
 
-- [ ] El inventario cerrado de Beta 6 aplica la paleta de colores v3
-- [ ] Tipografías consistentes (DM Serif Display, Instrument Sans, DM Mono)
-- [ ] Radios y sombras aplicados según tokens
-- [ ] Verificación responsive en mobile y desktop
+- [x] El inventario cerrado de Beta 6 aplica la paleta de colores v3
+- [x] Tipografías consistentes (DM Serif Display, Instrument Sans, DM Mono)
+- [x] Radios y sombras aplicados según tokens
+- [ ] Verificación responsive autenticada en mobile y desktop
+
+## Implementation Notes
+
+- `src/index.css` corrige `--font-mono` autorreferente y define `--color-gray-950`.
+- Componentes base y superficies principales migran a tokens en el inventario cerrado.
+- QA visual autenticada queda pendiente por falta de sesión local; las rutas privadas redirigen a `/login` sin credenciales.
 
 ## Related
 

--- a/docs/project/issues/CACH-0038.md
+++ b/docs/project/issues/CACH-0038.md
@@ -1,0 +1,66 @@
+---
+id: CACH-0038
+title: Compactar mobile financiero y detalles accionables
+type: feature
+status: in-progress
+cycle: unassigned
+release: RELEASE-0.1.0-beta.6
+priority: p1
+estimate: m
+area: frontend
+created_at: 2026-05-07
+updated_at: 2026-05-07
+related:
+  - CACH-B0002
+aliases:
+  - CACH-0038
+tags:
+  - product-brain
+  - issue
+  - mobile
+  - finance
+---
+
+# CACH-0038 — Compactar mobile financiero y detalles accionables
+
+## Summary
+
+Ejecutar una porción concreta de [[CACH-B0002|CACH-B0002]] para que el dashboard y los detalles financieros sean más escaneables en móvil sin rediseñar todo el modelo financiero.
+
+## Problem
+
+El backlog marca la experiencia mobile financiera como p1, pero la issue madre es demasiado amplia para un único corte beta. Beta 6 necesita una mejora visible y verificable: menos densidad, acciones más directas y lectura financiera más clara en los flujos que ya existen.
+
+## Scope
+
+- Dashboard mobile: compactar KPIs financieros y priorizar lectura operativa.
+- Detalles de proyecto/evento: reducir peso visual del resumen financiero.
+- Ingresos/gastos: mejorar filas o cards mobile para editar, borrar y marcar cobros sin que los botones dominen.
+- Formularios rápidos: revisar importes, paid toggle, concepto y espaciado en viewport móvil.
+
+## Constraints
+
+- Solo presentación y ergonomía.
+- No cambiar schema Supabase, RLS, hooks, contratos de datos, fórmulas financieras, `profiles.tax_rate`, `is_paid`, `paid_date`, cobro/hora ni lógica de agregación.
+- Reutilizar mutaciones existentes.
+- No añadir acciones destructivas en filas mobile; `Eliminar` vive dentro del modal de edición con confirmación.
+
+## Acceptance Criteria
+
+- [ ] En móvil, el primer pantallazo del dashboard no queda dominado por cajas financieras grandes.
+- [ ] En detalle de proyecto/evento, el resumen financiero móvil muestra `Cobrado`, `Pendiente` y `Neto` por defecto.
+- [ ] Ingresos y gastos se leen como lista compacta en móvil, con edición por tap y cobro táctil donde aplique.
+- [ ] Añadir o editar un ingreso/gasto desde móvil no exige girar pantalla ni pelearse con controles pequeños.
+- [ ] Desktop no pierde densidad ni jerarquía por los ajustes mobile.
+
+## Validation
+
+- Verificar rutas `/dashboard`, `/work`, detalles de proyecto y detalles de evento.
+- Probar viewport móvil crítico `390x844` y desktop.
+- Ejecutar `npm run test`, `npm run lint` y `npm run build`.
+
+## Related
+
+- [[CACH-B0002|CACH-B0002]]
+- [[../context/ux-mobile-guardrails-20260504|ux-mobile-guardrails-20260504]]
+- [[../context/design-system-caches-20260506|design-system-caches-20260506]]

--- a/docs/project/issues/CACH-0038.md
+++ b/docs/project/issues/CACH-0038.md
@@ -2,7 +2,7 @@
 id: CACH-0038
 title: Compactar mobile financiero y detalles accionables
 type: feature
-status: in-progress
+status: review
 cycle: unassigned
 release: RELEASE-0.1.0-beta.6
 priority: p1
@@ -47,17 +47,23 @@ El backlog marca la experiencia mobile financiera como p1, pero la issue madre e
 
 ## Acceptance Criteria
 
-- [ ] En móvil, el primer pantallazo del dashboard no queda dominado por cajas financieras grandes.
-- [ ] En detalle de proyecto/evento, el resumen financiero móvil muestra `Cobrado`, `Pendiente` y `Neto` por defecto.
-- [ ] Ingresos y gastos se leen como lista compacta en móvil, con edición por tap y cobro táctil donde aplique.
-- [ ] Añadir o editar un ingreso/gasto desde móvil no exige girar pantalla ni pelearse con controles pequeños.
-- [ ] Desktop no pierde densidad ni jerarquía por los ajustes mobile.
+- [x] En móvil, el primer pantallazo del dashboard no queda dominado por cajas financieras grandes.
+- [x] En detalle de proyecto/evento, el resumen financiero móvil muestra `Cobrado`, `Pendiente` y `Neto` por defecto.
+- [x] Ingresos y gastos se leen como lista compacta en móvil, con edición por tap y cobro táctil donde aplique.
+- [x] Añadir o editar un ingreso/gasto desde móvil no exige girar pantalla ni pelearse con controles pequeños.
+- [x] Desktop no pierde densidad ni jerarquía por los ajustes mobile.
 
 ## Validation
 
 - Verificar rutas `/dashboard`, `/work`, detalles de proyecto y detalles de evento.
 - Probar viewport móvil crítico `390x844` y desktop.
 - Ejecutar `npm run test`, `npm run lint` y `npm run build`.
+
+## Implementation Notes
+
+- No cambia schema, hooks, mutaciones, fórmulas financieras ni semántica de cobro.
+- `Eliminar` para ingresos/gastos queda dentro del modal de edición con confirmación.
+- QA visual autenticada queda pendiente por falta de sesión local; las rutas privadas redirigen a `/login` sin credenciales.
 
 ## Related
 

--- a/docs/project/plans/CURRENT_PLAN.md
+++ b/docs/project/plans/CURRENT_PLAN.md
@@ -16,29 +16,29 @@ tags:
 
 ## Foco actual
 
-Sin release activa. Ultimo corte: [[../releases/RELEASE-0.1.0-beta.5|RELEASE-0.1.0-beta.5]] — mergeada a `main` en PR #84 el 2026-05-07.
+Release activa: [[../releases/RELEASE-0.1.0-beta.6|RELEASE-0.1.0-beta.6]] — estabilización visual y mobile financiero.
 
 ## Release activa
 
-No active release.
+[[../releases/RELEASE-0.1.0-beta.6|RELEASE-0.1.0-beta.6]]
 
 Ultimo corte: [[../releases/RELEASE-0.1.0-beta.5|RELEASE-0.1.0-beta.5]] — mergeada a `main` el 2026-05-07.
 
 ## Prioridades
 
-1. CACH-0030 (paleta/fuentes) como PR directo a main o siguiente corte, segun scope.
+1. Ejecutar CACH-0030 y CACH-0038 desde `release/0.1.0-beta.6`.
 2. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
-3. Definir el siguiente corte beta solo si agrupa varias issues con fase real de estabilizacion.
+3. Dejar CACH-B0005 y CACH-B0006 como candidatas naturales para las siguientes betas, no para este corte visual/mobile.
 
 ## Plan operativo
 
 - Usar [[../backlog/BACKLOG|Backlog]] como tablero.
-- Usar [[../process/DEVELOPMENT_WORKFLOW|Development Workflow]] como contrato.
+- Usar [[../process/WORKFLOW|Workflow]] como contrato.
 - Usar [[../process/BRANCHING_STRATEGY|Branching Strategy]] para ramas.
 - Usar [[../process/COMMIT_CONVENTION|Commit Convention]] para commits.
 - Usar [[../process/RELEASE_PROCESS|Release Process]] para cierre de release.
-- Usar [[../process/AGENT_WORKFLOW|Agent Workflow]] antes de implementar.
+- Usar [[../process/WORKFLOW|Workflow]] antes de implementar.
 
-## Proximo checkpoint
+## Próximo checkpoint
 
-Elegir siguiente prioridad desde [[../backlog/BACKLOG|Backlog]] y decidir si va por PR directa o por una nueva release.
+Completar CACH-0030 y CACH-0038, validar la release y abrir PR única `release/0.1.0-beta.6` -> `main`.

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -1,7 +1,7 @@
 ---
 id: PB-CURRENT-RELEASE
 type: release-status
-status: No active release
+status: Active
 created: 2026-05-05
 updated: 2026-05-07
 aliases:
@@ -16,11 +16,11 @@ tags:
 
 ## Release activa
 
-No active release.
+[[RELEASE-0.1.0-beta.6|RELEASE-0.1.0-beta.6]] — Estabilización visual y mobile financiero.
 
 ## Rama activa
 
-No active release branch.
+`release/0.1.0-beta.6`
 
 ## Ultimo corte
 
@@ -28,22 +28,15 @@ No active release branch.
 
 ## Scope actual
 
-Sin scope activo.
+- [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseño con nueva paleta de colores y fuentes.
+- [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables.
 
 ## Regla de trabajo para esta release
 
-No hay release activa. Para fixes, chores y mejoras menores: PR directa a `main`.
+Beta 6 usa rama de release activa y PR única a `main`.
 
-## Cuando activar una release
-
-Usar release branch solo si:
-
-- Hay varias issues relacionadas que se integran antes de main.
-- Hay fase de estabilización real.
-- Se necesita release notes agrupadas.
-
-Para fixes, chores y mejoras menores: PR directa a `main` sin release branch.
+Las ramas de tarea salen de `release/0.1.0-beta.6` y se integran con squash en la release. No añadir tareas fuera de CACH-0030/CACH-0038 sin actualizar primero el documento de release.
 
 ## Como cerrar esta release
 
-No aplica hasta activar la siguiente release.
+Abrir PR `release/0.1.0-beta.6` -> `main`, esperar CI en verde, mergear, crear tag `v0.1.0-beta.6` desde `main`, verificar producción si aplica y limpiar la rama remota de release.

--- a/docs/project/releases/RELEASE-0.1.0-beta.6.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.6.md
@@ -159,6 +159,7 @@ Beta 6 no activa una nueva arquitectura de datos: prepara una base visual y mobi
 
 ### Técnico
 
+- Mejora auxiliar de delivery, fuera del scope funcional de CACH-0030/CACH-0038: añadida skill operativa `cultura-agent-orchestration` para acelerar delegación entre subagentes nativos de Codex/Claude y OpenCode durante Beta 6.
 - Validación esperada: `npm run test`, `npm run lint`, `npm run build`, `npm run pb:check`, `git diff --check` y verificación visual responsive.
 - Validación ejecutada: `npm run test`, `npm run lint`, `npm run build`, `npm run pb:check`, `git diff --check`.
 - QA visual autenticada pendiente: Playwright local confirma redirección a `/login` en rutas privadas sin sesión.

--- a/docs/project/releases/RELEASE-0.1.0-beta.6.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.6.md
@@ -122,7 +122,7 @@ Beta 6 no activa una nueva arquitectura de datos: prepara una base visual y mobi
 
 ## Checklist de salida
 
-- [ ] PR `release/0.1.0-beta.6` -> `main` abierta
+- [x] PR `release/0.1.0-beta.6` -> `main` abierta: https://github.com/dignacioconde/culturApp/pull/85
 - [ ] CI en verde
 - [ ] Revisión aprobada
 - [ ] PR mergeada en `main`
@@ -166,4 +166,6 @@ Beta 6 no activa una nueva arquitectura de datos: prepara una base visual y mobi
 
 ## Resultado final
 
-Pendiente hasta cerrar la release.
+PR abierta en draft: https://github.com/dignacioconde/culturApp/pull/85.
+
+Pendiente hasta CI en verde, revisión/QA visual autenticada, merge a `main`, tag y verificación de producción si aplica.

--- a/docs/project/releases/RELEASE-0.1.0-beta.6.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.6.md
@@ -1,7 +1,7 @@
 ---
 id: RELEASE-0.1.0-beta.6
 type: release
-status: Active
+status: Stabilizing
 created: 2026-05-07
 updated: 2026-05-07
 release_branch: release/0.1.0-beta.6
@@ -18,7 +18,7 @@ tags:
 
 ## Estado
 
-Active
+Stabilizing
 
 ## Rama de release
 
@@ -71,8 +71,8 @@ Beta 6 no activa una nueva arquitectura de datos: prepara una base visual y mobi
 
 | Issue | Título | Estado | Rama |
 |---|---|---|---|
-| [[../issues/CACH-0030|CACH-0030]] | Homogeneizar diseño con nueva paleta de colores y fuentes | In progress | `release/0.1.0-beta.6` |
-| [[../issues/CACH-0038|CACH-0038]] | Compactar mobile financiero y detalles accionables | In progress | `release/0.1.0-beta.6` |
+| [[../issues/CACH-0030|CACH-0030]] | Homogeneizar diseño con nueva paleta de colores y fuentes | Review | `release/0.1.0-beta.6` |
+| [[../issues/CACH-0038|CACH-0038]] | Compactar mobile financiero y detalles accionables | Review | `release/0.1.0-beta.6` |
 
 ## Fuera de alcance
 
@@ -105,20 +105,20 @@ Beta 6 no activa una nueva arquitectura de datos: prepara una base visual y mobi
 ## Checklist de desarrollo
 
 - [x] Todas las issues están en progreso o cerradas
-- [ ] Commits integrados en rama release
-- [ ] No hay cambios sueltos fuera de release
-- [ ] No hay issues sin estado
-- [ ] No hay decisiones importantes sin documentar
+- [x] Commits integrados en rama release
+- [x] No hay cambios sueltos fuera de release
+- [x] No hay issues sin estado
+- [x] No hay decisiones importantes sin documentar
 
 ## Checklist de estabilización
 
-- [ ] Build correcto
-- [ ] Tests/checks correctos (`npm run test`, `npm run lint`, `npm run build`, `npm run pb:check`, `git diff --check`)
-- [ ] Revisión visual
-- [ ] Revisión responsive
-- [ ] Revisión accesibilidad
-- [ ] Revisión de regresión básica
-- [ ] Revisión de documentación
+- [x] Build correcto
+- [x] Tests/checks correctos (`npm run test`, `npm run lint`, `npm run build`, `npm run pb:check`, `git diff --check`)
+- [ ] Revisión visual autenticada
+- [ ] Revisión responsive autenticada
+- [x] Revisión accesibilidad
+- [x] Revisión de regresión básica
+- [x] Revisión de documentación
 
 ## Checklist de salida
 
@@ -145,11 +145,13 @@ Beta 6 no activa una nueva arquitectura de datos: prepara una base visual y mobi
 
 ### Cambiado
 
-- Pendiente.
+- Componentes base, formularios, dashboard, calendarios y detalles usan tokens visuales de forma más consistente.
+- Los resúmenes financieros móviles de proyecto y evento muestran `Cobrado`, `Pendiente` y `Neto` por defecto.
+- Ingresos y gastos móviles usan filas compactas con edición por tap; el borrado vive dentro del modal de edición.
 
 ### Corregido
 
-- Pendiente.
+- `--font-mono` deja de ser autorreferente y `--color-gray-950` queda definido en tokens.
 
 ### Eliminado
 
@@ -158,6 +160,8 @@ Beta 6 no activa una nueva arquitectura de datos: prepara una base visual y mobi
 ### Técnico
 
 - Validación esperada: `npm run test`, `npm run lint`, `npm run build`, `npm run pb:check`, `git diff --check` y verificación visual responsive.
+- Validación ejecutada: `npm run test`, `npm run lint`, `npm run build`, `npm run pb:check`, `git diff --check`.
+- QA visual autenticada pendiente: Playwright local confirma redirección a `/login` en rutas privadas sin sesión.
 
 ## Resultado final
 

--- a/docs/project/releases/RELEASE-0.1.0-beta.6.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.6.md
@@ -1,0 +1,164 @@
+---
+id: RELEASE-0.1.0-beta.6
+type: release
+status: Active
+created: 2026-05-07
+updated: 2026-05-07
+release_branch: release/0.1.0-beta.6
+release_tag: v0.1.0-beta.6
+aliases:
+  - RELEASE-0.1.0-beta.6
+tags:
+  - product-brain
+  - release
+  - beta
+---
+
+# RELEASE-0.1.0-beta.6 — Estabilización visual y mobile financiero
+
+## Estado
+
+Active
+
+## Rama de release
+
+`release/0.1.0-beta.6`
+
+## Tag
+
+`v0.1.0-beta.6`
+
+## Ciclo
+
+`0.1` es el ciclo organizativo. `0.1.0-beta.6` es un corte iterativo mergeable centrado en confianza visual, lectura mobile y consistencia de UI.
+
+## Objetivo de la release
+
+Cerrar la deuda visual más evidente tras consolidar el sistema de diseño y hacer que la experiencia financiera móvil sea más escaneable antes de abordar portabilidad, onboarding o cambios de modelo de datos.
+
+Beta 6 no activa una nueva arquitectura de datos: prepara una base visual y mobile más fiable para que las siguientes betas puedan trabajar portabilidad y primera sesión con menos ruido de interfaz.
+
+## Alcance funcional
+
+- Homogeneizar componentes y pantallas pendientes con la paleta, tipografías y tokens del sistema de diseño.
+- Revisar badges, botones, selects, calendarios y superficies que todavía mezclan estilos antiguos.
+- Compactar la lectura financiera en móvil en dashboard y detalles.
+- Mejorar listas/cards mobile de ingresos y gastos con acciones claras y targets táctiles razonables.
+- Verificar responsive en desktop y mobile, con atención especial a calendarios si se tocan estilos compartidos.
+
+## Inventario cerrado CACH-0030
+
+- Componentes: `Button`, `Card`, `Badge`, `Modal`, `Input`, `Select`.
+- Pantallas: `Dashboard`, `Work`, `ProjectDetail`, `EventDetail`, `CalendarEvents`, `CalendarProjects`.
+- Formularios: `ProjectForm`, `EventForm` y formularios/modales financieros dentro de detalles.
+- Regla visual: usar tokens de `src/index.css`; hex directos solo para colores dinámicos de entidades/proyectos/eventos.
+- No hacer migración masiva de todos los `gray-*` si no afecta al inventario cerrado.
+
+## Restricciones CACH-0038
+
+- Cambios solo de presentación y ergonomía.
+- No cambiar schema Supabase, RLS, hooks, contratos de datos, fórmulas financieras, `profiles.tax_rate`, `is_paid`, `paid_date`, cobro/hora ni lógica de agregación.
+- Reutilizar mutaciones y confirmaciones existentes.
+- En móvil, mostrar `Cobrado`, `Pendiente` y `Neto` en resumen de proyecto y evento; métricas secundarias solo bajo detalle expandible.
+- No añadir acciones destructivas en filas mobile; exponer `Eliminar` dentro del modal de edición con confirmación.
+
+## Scope
+
+- [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseño con nueva paleta de colores y fuentes.
+- [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables.
+
+## Issues incluidas
+
+| Issue | Título | Estado | Rama |
+|---|---|---|---|
+| [[../issues/CACH-0030|CACH-0030]] | Homogeneizar diseño con nueva paleta de colores y fuentes | In progress | `release/0.1.0-beta.6` |
+| [[../issues/CACH-0038|CACH-0038]] | Compactar mobile financiero y detalles accionables | In progress | `release/0.1.0-beta.6` |
+
+## Fuera de alcance
+
+- Importación/exportación y portabilidad de datos de [[../issues/CACH-B0005|CACH-B0005]].
+- Onboarding, invitaciones, consentimiento de analítica o acceso beta de [[../issues/CACH-B0006|CACH-B0006]].
+- Contratantes, facturación, liquidación neta o migraciones de modelo financiero de [[../issues/CACH-B0004|CACH-B0004]].
+- Calendario unificado con filtros de [[../issues/CACH-B0007|CACH-B0007]], salvo ajustes visuales menores derivados de CACH-0030.
+- PWA/offline, notificaciones, features Pro, perfil público, referidos o gestión documental.
+
+## Riesgos
+
+- CACH-0030 puede crecer demasiado si se convierte en rediseño general; se mitiga limitándolo a tokens, consistencia y QA visual.
+- CACH-0038 puede solaparse con la issue madre CACH-B0002; se mitiga dejando B0002 como épica/backlog y cerrando solo esta porción verificable.
+- Cambios visuales globales pueden romper calendarios por altura o densidad; se mitiga con verificación explícita de toolbar, cabeceras, filas/celdas y eventos.
+- Cambios de UI financiera pueden confundirse con cambios de semántica; se mitiga prohibiendo cambios en hooks, cálculos, mutaciones y datos.
+
+## Decisiones relacionadas
+
+- [[../decisions/ADR-0002-beta-trust-before-pro|ADR-0002]]
+- [[../decisions/ADR-0005-custom-form-controls-and-date-inputs|ADR-0005]]
+
+## Checklist de entrada
+
+- [x] Release creada
+- [x] Rama de release creada
+- [x] Issues asociadas
+- [x] Alcance definido
+- [x] Criterios de validación definidos
+
+## Checklist de desarrollo
+
+- [x] Todas las issues están en progreso o cerradas
+- [ ] Commits integrados en rama release
+- [ ] No hay cambios sueltos fuera de release
+- [ ] No hay issues sin estado
+- [ ] No hay decisiones importantes sin documentar
+
+## Checklist de estabilización
+
+- [ ] Build correcto
+- [ ] Tests/checks correctos (`npm run test`, `npm run lint`, `npm run build`, `npm run pb:check`, `git diff --check`)
+- [ ] Revisión visual
+- [ ] Revisión responsive
+- [ ] Revisión accesibilidad
+- [ ] Revisión de regresión básica
+- [ ] Revisión de documentación
+
+## Checklist de salida
+
+- [ ] PR `release/0.1.0-beta.6` -> `main` abierta
+- [ ] CI en verde
+- [ ] Revisión aprobada
+- [ ] PR mergeada en `main`
+- [ ] `main` actualizado en local
+- [ ] Tag `v0.1.0-beta.6` creado desde `main`
+- [ ] Producción verificada si aplica
+- [ ] Rama remota `release/0.1.0-beta.6` eliminada
+- [ ] Release notes actualizadas
+- [ ] Issues marcadas como `Released`
+- [ ] Estado actual actualizado
+- [ ] Current Release actualizado
+- [ ] Backlog actualizado
+- [ ] Documento de release actualizado como cerrado
+
+## Release notes
+
+### Añadido
+
+- Pendiente.
+
+### Cambiado
+
+- Pendiente.
+
+### Corregido
+
+- Pendiente.
+
+### Eliminado
+
+- Pendiente.
+
+### Técnico
+
+- Validación esperada: `npm run test`, `npm run lint`, `npm run build`, `npm run pb:check`, `git diff --check` y verificación visual responsive.
+
+## Resultado final
+
+Pendiente hasta cerrar la release.

--- a/docs/project/releases/RELEASE-0.1.0-beta.6.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.6.md
@@ -123,7 +123,7 @@ Beta 6 no activa una nueva arquitectura de datos: prepara una base visual y mobi
 ## Checklist de salida
 
 - [x] PR `release/0.1.0-beta.6` -> `main` abierta: https://github.com/dignacioconde/culturApp/pull/85
-- [ ] CI en verde
+- [x] CI en verde
 - [ ] Revisión aprobada
 - [ ] PR mergeada en `main`
 - [ ] `main` actualizado en local
@@ -166,6 +166,6 @@ Beta 6 no activa una nueva arquitectura de datos: prepara una base visual y mobi
 
 ## Resultado final
 
-PR abierta en draft: https://github.com/dignacioconde/culturApp/pull/85.
+PR abierta en draft con CI en verde: https://github.com/dignacioconde/culturApp/pull/85.
 
-Pendiente hasta CI en verde, revisión/QA visual autenticada, merge a `main`, tag y verificación de producción si aplica.
+Pendiente hasta revisión/QA visual autenticada, merge a `main`, tag y verificación de producción si aplica.

--- a/src/components/ui/Badge.jsx
+++ b/src/components/ui/Badge.jsx
@@ -2,7 +2,7 @@ import { STATUS_COLORS, STATUS_LABELS } from '../../lib/constants'
 
 export function Badge({ children, className = '' }) {
   return (
-    <span className={`inline-flex min-h-6 items-center rounded-full px-2.5 py-0.5 text-xs font-semibold leading-none ring-1 ring-inset ring-black/5 ${className}`}>
+    <span className={`inline-flex min-h-6 items-center rounded-full px-2.5 py-0.5 text-xs font-semibold leading-none ring-1 ring-inset ring-[var(--color-ink)]/5 ${className}`}>
       {children}
     </span>
   )

--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -1,8 +1,8 @@
 const variants = {
-  primary: 'bg-[#C94035] text-white shadow-sm hover:bg-[#A8342B] active:bg-[#8f2b23] disabled:bg-[#ef8580]',
-  secondary: 'border border-[#E2D9C2] bg-[#F5EFE0] text-[#211C18] shadow-sm hover:bg-[#EBE3CE] hover:text-[#211C18] active:bg-[#E2D9C2] disabled:bg-[#EBE3CE] disabled:text-[#5C5149]',
-  danger: 'bg-[#C94035] text-white shadow-sm hover:bg-[#A8342B] active:bg-[#8f2b23] disabled:bg-[#ef8580]',
-  ghost: 'text-[#5C5149] hover:bg-[#EBE3CE] hover:text-[#211C18] active:bg-[#E2D9C2] disabled:text-[#5C5149]',
+  primary: 'bg-[var(--color-red)] text-white shadow-sm hover:bg-[var(--color-red-hover)] active:bg-[var(--color-primary-800)] disabled:bg-[var(--color-primary-400)]',
+  secondary: 'border border-[var(--color-paper-mid)] bg-[var(--color-paper)] text-[var(--color-ink)] shadow-sm hover:bg-[var(--color-paper-dark)] hover:text-[var(--color-ink)] active:bg-[var(--color-paper-mid)] disabled:bg-[var(--color-paper-dark)] disabled:text-[var(--color-ink-muted)]',
+  danger: 'bg-[var(--color-red)] text-white shadow-sm hover:bg-[var(--color-red-hover)] active:bg-[var(--color-primary-800)] disabled:bg-[var(--color-primary-400)]',
+  ghost: 'text-[var(--color-ink-muted)] hover:bg-[var(--color-paper-dark)] hover:text-[var(--color-ink)] active:bg-[var(--color-paper-mid)] disabled:text-[var(--color-ink-muted)]',
 }
 
 const sizes = {
@@ -18,7 +18,7 @@ export function Button({ children, variant = 'primary', size = 'md', className =
   return (
     <button
       type={type}
-      className={`inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 rounded-lg font-medium leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:shadow-none ${variantClass} ${sizeClass} ${className}`}
+      className={`inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 rounded-lg font-medium leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-red)] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:shadow-none ${variantClass} ${sizeClass} ${className}`}
       {...props}
     >
       {children}

--- a/src/index.css
+++ b/src/index.css
@@ -44,6 +44,7 @@
   --color-gray-700: #374151;
   --color-gray-800: #1f2937;
   --color-gray-900: #111827;
+  --color-gray-950: #030712;
 
   /* ─────────────────────────────────────────
      BRAND / PRIMARY — Red (replaces Indigo)
@@ -130,10 +131,10 @@
   /* Font stack — DM Serif Display para títulos, Instrument Sans UI, DM Mono datos */
   --font-display: 'DM Serif Display', Georgia, serif;
   --font-ui:      'Instrument Sans', system-ui, sans-serif;
-  --font-mono:    'DM Mono', 'Cascadia Code', monospace;
+  --font-data:    'DM Mono', 'Cascadia Code', monospace;
 
   --font-sans: var(--font-ui);
-  --font-mono: var(--font-mono);
+  --font-mono: var(--font-data);
 
   /* Size scale */
   --text-xs:   0.75rem;

--- a/src/pages/Calendar/CalendarEvents.jsx
+++ b/src/pages/Calendar/CalendarEvents.jsx
@@ -133,11 +133,11 @@ export default function CalendarEvents() {
   return (
     <PageWrapper title="Calendario de eventos">
       <div className="flex flex-col gap-4 lg:flex-row lg:h-[calc(100vh-8rem)]">
-        <div className="flex flex-1 flex-col rounded-xl border border-gray-200 bg-white p-3 sm:p-4 lg:min-h-0">
+        <div className="flex flex-1 flex-col rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-surface)] p-3 sm:p-4 lg:min-h-0">
           <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <p className="text-sm font-medium text-gray-900">{events.length} eventos</p>
-              <p className="text-xs text-gray-400">Calendario compartible con fecha y hora exactas.</p>
+              <p className="text-sm font-medium text-[var(--color-ink)]">{events.length} eventos</p>
+              <p className="text-xs text-[var(--color-ink-muted)]">Calendario compartible con fecha y hora exactas.</p>
             </div>
             <Button size="sm" onClick={() => openNewEvent()} className="w-full justify-center sm:w-auto">
               <Plus size={16} />

--- a/src/pages/Calendar/CalendarProjects.jsx
+++ b/src/pages/Calendar/CalendarProjects.jsx
@@ -66,11 +66,11 @@ export default function CalendarProjects() {
   return (
     <PageWrapper title="Calendario de proyectos">
       <div className="flex flex-col gap-4 lg:flex-row">
-        <div className="flex flex-1 flex-col rounded-xl border border-gray-200 bg-white p-3 sm:p-4 lg:min-h-0">
+        <div className="flex flex-1 flex-col rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-surface)] p-3 sm:p-4 lg:min-h-0">
           <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <p className="text-sm font-medium text-gray-900">{projects.length} proyectos</p>
-              <p className="text-xs text-gray-400">Vista interna por rango de fechas</p>
+              <p className="text-sm font-medium text-[var(--color-ink)]">{projects.length} proyectos</p>
+              <p className="text-xs text-[var(--color-ink-muted)]">Vista interna por rango de fechas</p>
             </div>
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
               <div className="flex items-center justify-center gap-2 rounded-xl border border-[#E2D9C2] bg-[#FFFCF5] px-2 py-1">

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -132,13 +132,13 @@ export default function Dashboard() {
         <Card className="p-3 sm:p-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="grid grid-cols-[2.75rem_minmax(0,1fr)_2.75rem_6.5rem] items-center gap-2 sm:flex sm:gap-1">
-              <button onClick={prevMonth} className="flex min-h-11 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100" aria-label="Mes anterior">
+              <button onClick={prevMonth} className="flex min-h-11 items-center justify-center rounded-lg text-[var(--color-ink-muted)] hover:bg-[var(--color-paper-dark)]" aria-label="Mes anterior">
                 <ChevronLeft size={18} />
               </button>
-              <span className="min-w-0 truncate text-center text-sm font-medium capitalize text-gray-900 sm:min-w-[130px]">
+              <span className="min-w-0 truncate text-center text-sm font-medium capitalize text-[var(--color-ink)] sm:min-w-[130px]">
                 {selectedMonthLabel}
               </span>
-              <button onClick={nextMonth} className="flex min-h-11 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100" aria-label="Mes siguiente">
+              <button onClick={nextMonth} className="flex min-h-11 items-center justify-center rounded-lg text-[var(--color-ink-muted)] hover:bg-[var(--color-paper-dark)]" aria-label="Mes siguiente">
                 <ChevronRight size={18} />
               </button>
               <Select
@@ -151,16 +151,16 @@ export default function Dashboard() {
               </Select>
             </div>
 
-            <div className="flex self-start overflow-hidden rounded-lg border border-gray-200 text-sm">
+            <div className="flex self-start overflow-hidden rounded-lg border border-[var(--color-paper-mid)] text-sm">
               <button
                 onClick={() => setView('cash')}
-                className={`min-h-[44px] px-3 py-2 transition-colors sm:min-h-[unset] sm:px-2.5 sm:py-1.5 ${view === 'cash' ? 'bg-[var(--color-primary-500)] text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+                className={`min-h-[44px] px-3 py-2 transition-colors sm:min-h-[unset] sm:px-2.5 sm:py-1.5 ${view === 'cash' ? 'bg-[var(--color-primary-500)] text-white' : 'bg-[var(--color-surface)] text-[var(--color-ink-muted)] hover:bg-[var(--color-surface-alt)]'}`}
               >
                 Caja del mes
               </button>
               <button
                 onClick={() => setView('work')}
-                className={`min-h-[44px] border-l border-gray-200 px-3 py-2 transition-colors sm:min-h-[unset] sm:px-2.5 sm:py-1.5 ${view === 'work' ? 'bg-[var(--color-primary-500)] text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+                className={`min-h-[44px] border-l border-[var(--color-paper-mid)] px-3 py-2 transition-colors sm:min-h-[unset] sm:px-2.5 sm:py-1.5 ${view === 'work' ? 'bg-[var(--color-primary-500)] text-white' : 'bg-[var(--color-surface)] text-[var(--color-ink-muted)] hover:bg-[var(--color-surface-alt)]'}`}
               >
                 Trabajos
               </button>
@@ -195,9 +195,9 @@ export default function Dashboard() {
             <Card className="p-4 md:hidden">
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
-                  <p className="text-xs font-medium text-gray-500">A cobrar en {selectedMonthLabel}</p>
-                  <p className="mt-1 text-3xl font-semibold leading-tight text-[#211C18]">{formatCurrency(cashKpis.plannedTotal)}</p>
-                  <p className="mt-1 text-xs text-gray-400">
+                  <p className="text-xs font-medium text-[var(--color-ink-muted)]">A cobrar en {selectedMonthLabel}</p>
+                  <p className="mt-1 text-3xl font-semibold leading-tight text-[var(--color-ink)]">{formatCurrency(cashKpis.plannedTotal)}</p>
+                  <p className="mt-1 text-xs text-[var(--color-ink-muted)]">
                     {cashKpis.planned.length} ingreso{cashKpis.planned.length === 1 ? '' : 's'} previsto{cashKpis.planned.length === 1 ? '' : 's'} o arrastrado{cashKpis.planned.length === 1 ? '' : 's'}
                   </p>
                 </div>

--- a/src/pages/Dashboard/KpiCard.jsx
+++ b/src/pages/Dashboard/KpiCard.jsx
@@ -2,15 +2,15 @@ import { Card } from '../../components/ui/Card'
 
 export function KpiCard({ title, value, subtitle, icon: Icon, color = 'red', progress }) {
   const colors = {
-    red: 'bg-[#F9EDEB] text-[#C94035] ring-[#F9EDEB]',
-    green: 'bg-[#E8F4EF] text-[#2D6A4F] ring-[#E8F4EF]',
-    amber: 'bg-[#FDF5E4] text-[#D4921A] ring-[#FDF5E4]',
+    red: 'bg-[var(--color-red-light)] text-[var(--color-red)] ring-[var(--color-red-light)]',
+    green: 'bg-[var(--color-green-light)] text-[var(--color-green)] ring-[var(--color-green-light)]',
+    amber: 'bg-[var(--color-amber-light)] text-[var(--color-amber)] ring-[var(--color-amber-light)]',
   }
 
   const progressBg = {
-    red: 'bg-[#C94035]',
-    green: 'bg-[#2D6A4F]',
-    amber: 'bg-[#D4921A]',
+    red: 'bg-[var(--color-red)]',
+    green: 'bg-[var(--color-green)]',
+    amber: 'bg-[var(--color-amber)]',
   }
 
   return (
@@ -22,11 +22,11 @@ export function KpiCard({ title, value, subtitle, icon: Icon, color = 'red', pro
         </div>
       )}
       <div className="flex-1 min-w-0">
-        <p className="text-xs sm:text-sm font-medium text-[#5C5149] mb-1 truncate">{title}</p>
-        <p className="text-xl sm:text-2xl font-semibold text-[#211C18] leading-tight break-words">{value}</p>
-        {subtitle && <p className="text-xs text-[#5C5149] mt-2 leading-snug">{subtitle}</p>}
+        <p className="text-xs sm:text-sm font-medium text-[var(--color-ink-muted)] mb-1 truncate">{title}</p>
+        <p className="text-xl sm:text-2xl font-semibold text-[var(--color-ink)] leading-tight break-words">{value}</p>
+        {subtitle && <p className="text-xs text-[var(--color-ink-muted)] mt-2 leading-snug">{subtitle}</p>}
         {progress != null && (
-          <div className="mt-3 h-1 w-full rounded-full bg-[#E2D9C2] overflow-hidden">
+          <div className="mt-3 h-1 w-full rounded-full bg-[var(--color-paper-mid)] overflow-hidden">
             <div
               className={`h-full rounded-full ${progressBg[color]}`}
               style={{ width: `${Math.min(Math.max(progress, 0), 1) * 100}%` }}

--- a/src/pages/Events/EventDetail.jsx
+++ b/src/pages/Events/EventDetail.jsx
@@ -22,7 +22,10 @@ import { isPaid, markPaid, markUnpaid, needsQuickPaidConfirmation, paymentDate }
 import { EXPENSE_CATEGORIES } from '../../lib/constants'
 
 const EMPTY_EXPENSE = { concept: '', amount: '', category: 'otros', expense_date: '', is_deductible: true }
-const compactPrimaryAction = 'inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-[#C94035] px-3 py-1.5 text-sm font-medium leading-none text-white shadow-sm transition-colors hover:bg-[#A8342B] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2'
+const compactPrimaryAction = 'inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-[var(--color-red)] px-3 py-1.5 text-sm font-medium leading-none text-white shadow-sm transition-colors hover:bg-[var(--color-red-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-red)] focus-visible:ring-offset-2'
+const compactPrimaryActionDesktop = 'hidden sm:inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-[var(--color-red)] px-3 py-1.5 text-sm font-medium leading-none text-white shadow-sm transition-colors hover:bg-[var(--color-red-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-red)] focus-visible:ring-offset-2'
+const compactSecondaryActionDesktop = 'hidden sm:inline-flex min-h-9 items-center justify-center gap-2 rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-paper)] px-3 py-1.5 text-sm font-medium leading-none text-[var(--color-ink)] shadow-sm transition-colors hover:bg-[var(--color-paper-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-red)] focus-visible:ring-offset-2'
+const compactDangerActionDesktop = 'hidden sm:inline-flex min-h-9 items-center justify-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium leading-none text-[var(--color-red)] transition-colors hover:bg-[var(--color-red-light)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-red)] focus-visible:ring-offset-2'
 const incomeConceptLabel = (income) => income.concept?.trim() || 'Ingreso sin concepto'
 const incomeDueClass = (income) => {
   if (!income.expected_date) return 'text-gray-400'
@@ -239,6 +242,15 @@ export default function EventDetail() {
     setIncomeModal(false)
   }
 
+  const handleDeleteEditingIncome = async () => {
+    if (!editingIncome) return
+    if (!confirm('¿Eliminar este ingreso?')) return
+    const { error } = await deleteIncome(editingIncome.id)
+    if (error) { addToast('Error al eliminar el ingreso.', 'error'); return }
+    addToast('Ingreso eliminado.')
+    setIncomeModal(false)
+  }
+
   const undoIncomePaid = async (income, previousPayment) => {
     if (!income || savingIncomeId) return
 
@@ -334,89 +346,98 @@ export default function EventDetail() {
     setExpenseModal(false)
   }
 
+  const handleDeleteEditingExpense = async () => {
+    if (!editingExpense) return
+    if (!confirm('¿Eliminar este gasto?')) return
+    const { error } = await deleteExpense(editingExpense.id)
+    if (error) { addToast('Error al eliminar el gasto.', 'error'); return }
+    addToast('Gasto eliminado.')
+    setExpenseModal(false)
+  }
+
   return (
     <PageWrapper title={event.name}>
       <div className="flex max-w-4xl flex-col gap-4 sm:gap-5 pb-20 sm:pb-5">
-        <nav className="flex items-center gap-1.5 text-xs text-gray-400 breadcrumbs">
-          <Link to="/work" className="hover:text-gray-600">Trabajos</Link>
+        <nav className="flex items-center gap-1.5 text-xs text-[var(--color-ink-muted)] breadcrumbs">
+          <Link to="/work" className="hover:text-[var(--color-ink)]">Trabajos</Link>
           <span>/</span>
-          <Link to="/work?view=events" className="hover:text-gray-600">Eventos</Link>
+          <Link to="/work?view=events" className="hover:text-[var(--color-ink)]">Eventos</Link>
           <span>/</span>
-          <span className="text-gray-600">{event.name}</span>
+          <span className="text-[var(--color-ink)]">{event.name}</span>
         </nav>
-        <div className="rounded-2xl border border-[#E9E2D3] bg-white p-4 shadow-sm sm:p-5">
+        <div className="rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-surface)] p-4 shadow-sm sm:p-5">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div className="flex items-start gap-3 sm:items-start">
-              <Link to="/work?view=events" className="mt-1 shrink-0 text-gray-400 hover:text-gray-700" aria-label="Volver a eventos en trabajos">
+              <Link to="/work?view=events" className="mt-1 shrink-0 text-[var(--color-ink-muted)] hover:text-[var(--color-ink)]" aria-label="Volver a eventos en trabajos">
                 <ArrowLeft size={20} />
               </Link>
               <div className="min-w-0">
                 <div className="flex min-w-0 flex-wrap items-center gap-2">
                   <div className="h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: event.color ?? '#4f98a3' }} />
-                  <h2 className="min-w-0 truncate text-lg font-semibold text-gray-900">{event.name}</h2>
+                  <h2 className="min-w-0 truncate text-lg font-semibold text-[var(--color-ink)]">{event.name}</h2>
                   <QuietStatusBadge status={event.status} />
                 </div>
                 {event.client && (
-                  <p className="mt-1 text-sm text-gray-500">{event.client}</p>
+                  <p className="mt-1 text-sm text-[var(--color-ink-muted)]">{event.client}</p>
                 )}
-                <p className="mt-1 text-xs text-gray-400">
+                <p className="mt-1 text-xs text-[var(--color-ink-muted)]">
                   {formatDatetime(event.start_datetime)}
                   {event.end_datetime && ` – ${formatDatetime(event.end_datetime)}`}
                 </p>
                 {project && (
                   <Link
                     to={`/projects/${project.id}`}
-                    className="mt-1 inline-flex items-center gap-1 text-xs text-gray-500 hover:text-[var(--color-primary-600)]"
+                    className="mt-1 inline-flex items-center gap-1 text-xs text-[var(--color-ink-muted)] hover:text-[var(--color-primary-600)]"
                   >
                     {project.name}
-                    <ExternalLink size={10} className="text-gray-400" />
+                    <ExternalLink size={10} className="text-[var(--color-ink-muted)]" />
                   </Link>
                 )}
               </div>
             </div>
-            <div className="fixed bottom-0 left-0 right-0 z-40 flex gap-1 border-t border-gray-200 bg-white px-2 py-2 shadow-[0_-2px_10px_rgba(0,0,0,0.1)] sm:static sm:border-0 sm:bg-transparent sm:p-0 sm:shadow-none">
-              <button type="button" onClick={openQuickIncome} className="flex-1 rounded-lg bg-[var(--color-primary-500)] py-2 text-xs font-medium text-white sm:hidden">
+            <div className="fixed bottom-0 left-0 right-0 z-40 flex gap-1 border-t border-[var(--color-paper-mid)] bg-[var(--color-surface)] px-2 py-2 shadow-[0_-2px_10px_rgba(0,0,0,0.1)] sm:static sm:border-0 sm:bg-transparent sm:p-0 sm:shadow-none">
+              <button type="button" onClick={openQuickIncome} className="flex-1 rounded-lg bg-[var(--color-red)] py-2 text-xs font-medium text-white sm:hidden">
                 Cobro
               </button>
-              <button type="button" onClick={openQuickExpense} className="flex-1 rounded-lg bg-[var(--color-primary-500)] py-2 text-xs font-medium text-white sm:hidden">
+              <button type="button" onClick={openQuickExpense} className="flex-1 rounded-lg bg-[var(--color-red)] py-2 text-xs font-medium text-white sm:hidden">
                 Gasto
               </button>
-              <button type="button" onClick={() => setEditModal(true)} className="flex-1 rounded-lg bg-[#C94035] py-2 text-xs font-medium text-white sm:hidden">
+              <button type="button" onClick={() => setEditModal(true)} className="flex-1 rounded-lg bg-[var(--color-red)] py-2 text-xs font-medium text-white sm:hidden">
                 Editar
               </button>
-              <button type="button" onClick={handleDeleteEvent} className="flex-1 rounded-lg border border-red-200 py-2 text-xs font-medium text-red-600 sm:hidden">
+              <button type="button" onClick={handleDeleteEvent} className="flex-1 rounded-lg border border-[var(--color-red-light)] py-2 text-xs font-medium text-[var(--color-red)] sm:hidden">
                 Eliminar
               </button>
               {/* Desktop - quick modals */}
-              <button type="button" onClick={openQuickIncome} className="hidden sm:inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-[#C94035] px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-[#A8342B]">
+              <button type="button" onClick={openQuickIncome} className={compactPrimaryActionDesktop}>
                 <Plus size={14} /> Ingreso
               </button>
-              <button type="button" onClick={openQuickExpense} className="hidden sm:inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-[#C94035] px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-[#A8342B]">
+              <button type="button" onClick={openQuickExpense} className={compactPrimaryActionDesktop}>
                 <Plus size={14} /> Gasto
               </button>
-              <button type="button" onClick={() => setEditModal(true)} className="hidden sm:inline-flex min-h-9 items-center justify-center gap-2 rounded-lg border border-[#E2D9C2] bg-[#F5EFE0] px-3 py-1.5 text-sm font-medium text-[#211C18] shadow-sm hover:bg-[#EBE3CE]">
+              <button type="button" onClick={() => setEditModal(true)} className={compactSecondaryActionDesktop}>
                 <Edit size={14} /> Editar
               </button>
-              <button type="button" onClick={handleDeleteEvent} className="hidden sm:inline-flex min-h-9 items-center justify-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium text-[#C94035] hover:bg-red-50">
+              <button type="button" onClick={handleDeleteEvent} className={compactDangerActionDesktop}>
                 <Trash2 size={14} /> Eliminar
               </button>
             </div>
           </div>
         </div>
 
-        <Card className="bg-gray-50 p-4 sm:p-5">
+        <Card className="bg-[var(--color-surface-alt)] p-4 sm:p-5">
           <button
             type="button"
             onClick={() => setFinancialSummaryExpanded((prev) => !prev)}
             className="mb-3 flex w-full flex-col gap-2 sm:mb-4 sm:flex-row sm:items-center sm:justify-between sm:gap-3"
           >
             <div className="flex flex-col items-start text-left">
-              <h3 className="text-sm font-semibold text-gray-900">Resumen financiero</h3>
-              <p className="hidden text-xs text-gray-500 sm:mt-1 sm:block">Lo importante primero. El detalle queda debajo.</p>
+              <h3 className="text-sm font-semibold text-[var(--color-ink)]">Resumen financiero</h3>
+              <p className="hidden text-xs text-[var(--color-ink-muted)] sm:mt-1 sm:block">Lo importante primero. El detalle queda debajo.</p>
             </div>
             <div className="flex items-center justify-between w-full sm:w-auto sm:justify-end gap-3">
-              <p className="text-[11px] text-gray-500 sm:text-xs">Cobrado: {formatCurrency(totalPaid)} · Pendiente: {formatCurrency(pendingAmount)}</p>
-              <ChevronDown size={16} className={`shrink-0 text-gray-400 transition-transform ${financialSummaryExpanded ? 'rotate-180' : ''}`} />
+              <p className="text-[11px] text-[var(--color-ink-muted)] sm:text-xs">Cobrado: {formatCurrency(totalPaid)} · Pendiente: {formatCurrency(pendingAmount)}</p>
+              <ChevronDown size={16} className={`shrink-0 text-[var(--color-ink-muted)] transition-transform ${financialSummaryExpanded ? 'rotate-180' : ''}`} />
             </div>
           </button>
           <div className="grid grid-cols-3 gap-2 sm:gap-3">
@@ -425,12 +446,12 @@ export default function EventDetail() {
               { label: 'Pendiente', mobileLabel: 'Pend.', value: formatCurrency(pendingAmount) },
               { label: 'Beneficio neto', mobileLabel: 'Neto', value: formatCurrency(netProfit), highlight: true },
             ].map(({ label, mobileLabel, value, highlight }) => (
-              <div key={label} className={`rounded-lg border p-2.5 sm:p-4 ${highlight ? 'border-[var(--color-primary-200)] bg-[#fef3f2]' : 'border-gray-200 bg-white'}`}>
-                <p className="text-[11px] leading-tight text-gray-500 sm:text-xs">
+              <div key={label} className={`rounded-lg border p-2.5 sm:p-4 ${highlight ? 'border-[var(--color-primary-200)] bg-[var(--color-red-light)]' : 'border-[var(--color-paper-mid)] bg-[var(--color-surface)]'}`}>
+                <p className="text-[11px] leading-tight text-[var(--color-ink-muted)] sm:text-xs">
                   <span className="sm:hidden">{mobileLabel}</span>
                   <span className="hidden sm:inline">{label}</span>
                 </p>
-                <p className={`mt-1 text-sm font-semibold leading-tight break-words sm:text-lg ${highlight ? 'text-[var(--color-primary-600)]' : 'text-gray-900'}`}>{value}</p>
+                <p className={`mt-1 text-sm font-semibold leading-tight break-words sm:text-lg ${highlight ? 'text-[var(--color-primary-600)]' : 'text-[var(--color-ink)]'}`}>{value}</p>
               </div>
             ))}
           </div>
@@ -441,10 +462,10 @@ export default function EventDetail() {
               { label: 'Gastos registrados', value: formatCurrency(totalExpenses) },
               { label: 'Cobro bruto/hora', value: eventHours > 0 ? formatCurrencyPerHour(grossHourlyRate) : '—', detail: eventHours > 0 ? `${formatHours(eventHours)} h` : null },
             ].map(({ label, value, detail }) => (
-              <div key={label} className="rounded-lg border border-gray-200 bg-white p-4">
-                <p className="text-xs text-gray-500">{label}</p>
-                <p className="mt-1 text-base font-semibold text-gray-900">{value}</p>
-                {detail && <p className="mt-1 text-xs text-gray-400">{detail}</p>}
+              <div key={label} className="rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-surface)] p-4">
+                <p className="text-xs text-[var(--color-ink-muted)]">{label}</p>
+                <p className="mt-1 text-base font-semibold text-[var(--color-ink)]">{value}</p>
+                {detail && <p className="mt-1 text-xs text-[var(--color-ink-muted)]">{detail}</p>}
               </div>
             ))}
           </div>
@@ -545,28 +566,28 @@ export default function EventDetail() {
                 {incomes.map((income) => {
                   const isSaving = savingIncomeId === income.id
                   return (
-                    <div key={income.id} className="flex items-center justify-between gap-2 py-2 border-b border-gray-50 last:border-0">
+                    <div key={income.id} className="flex items-center justify-between gap-2 border-b border-[var(--color-paper-mid)] py-2 last:border-0">
                       <button
                         type="button"
                         onClick={() => openEditIncome(income)}
                         className="min-w-0 flex-1 text-left"
                       >
-                        <span className="block truncate text-sm text-gray-900">{incomeConceptLabel(income)}</span>
-                        {!isPaid(income) && (
-                          <span className={`mt-0.5 block text-xs ${incomeDueClass(income)}`}>{formatDueDescription(income.expected_date)}</span>
-                        )}
+                        <span className="block truncate text-sm font-medium text-[var(--color-ink)]">{incomeConceptLabel(income)}</span>
+                        <span className={`mt-0.5 block text-xs ${isPaid(income) ? 'text-[var(--color-green)]' : incomeDueClass(income)}`}>
+                          {isPaid(income) ? 'Cobrado' : formatDueDescription(income.expected_date)}
+                        </span>
                       </button>
-                      <span className="shrink-0 text-sm font-medium text-gray-900">{formatCurrency(income.amount)}</span>
+                      <span className="shrink-0 text-sm font-semibold text-[var(--color-ink)]">{formatCurrency(income.amount)}</span>
                       <button
                         type="button"
                         onClick={() => handleTogglePaid(income)}
                         disabled={Boolean(savingIncomeId)}
                         aria-label={`${isPaid(income) ? 'Marcar como pendiente' : 'Marcar como cobrado'} ${incomeConceptLabel(income)}`}
-                        className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-[#2D6A4F] transition-colors hover:bg-[#F4FBF7] hover:text-[#1F5A42] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2D6A4F] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:text-gray-300 disabled:hover:bg-transparent"
+                        className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-[var(--color-green)] transition-colors hover:bg-[var(--color-green-light)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-green)] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:text-[var(--color-ink-muted)] disabled:hover:bg-transparent"
                       >
                         {isSaving
                           ? <span className="h-4 w-4 animate-spin rounded-full border-2 border-[#2D6A4F] border-t-transparent" />
-                          : isPaid(income) ? <CheckCircle size={18} className="text-green-500" /> : <Circle size={18} />}
+                          : isPaid(income) ? <CheckCircle size={18} /> : <Circle size={18} />}
                       </button>
                     </div>
                   )
@@ -642,14 +663,20 @@ export default function EventDetail() {
 {/* Cards minimalistas para móvil */}
               <div className="flex flex-col gap-1 md:hidden">
                 {expenses.map((expense) => (
-                  <div
+                  <button
                     key={expense.id}
+                    type="button"
                     onClick={() => openEditExpense(expense)}
-                    className="flex items-center justify-between py-2 border-b border-gray-50 last:border-0"
+                    className="flex items-center justify-between gap-3 border-b border-[var(--color-paper-mid)] py-2 text-left last:border-0"
                   >
-                    <span className="text-sm text-gray-900 truncate">{expense.concept}</span>
-                    <span className="text-sm font-medium text-gray-900">{formatCurrency(expense.amount)}</span>
-                  </div>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium text-[var(--color-ink)]">{expense.concept}</span>
+                      <span className="mt-0.5 block truncate text-xs capitalize text-[var(--color-ink-muted)]">
+                        {expense.category} · {formatDate(expense.expense_date)}
+                      </span>
+                    </span>
+                    <span className="shrink-0 text-sm font-semibold text-[var(--color-ink)]">{formatCurrency(expense.amount)}</span>
+                  </button>
                 ))}
               </div>
             </div>
@@ -683,7 +710,7 @@ export default function EventDetail() {
             placeholder="Actuación principal"
             required
           />
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <Input
               label="Importe (€) *"
               type="text"
@@ -708,8 +735,8 @@ export default function EventDetail() {
             <div className="flex items-center gap-2">
               <input type="checkbox" id="is_paid" checked={incomeForm.is_paid}
                 onChange={(e) => setIncomeForm((p) => ({ ...p, is_paid: e.target.checked, paid_date: e.target.checked ? (p.paid_date ?? p.expected_date ?? '') : null }))}
-                className="h-5 w-5 rounded border-gray-300 text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]" />
-              <label htmlFor="is_paid" className="text-sm text-gray-700">Ya está cobrado</label>
+                className="h-5 w-5 rounded border-[var(--color-paper-mid)] text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]" />
+              <label htmlFor="is_paid" className="text-sm text-[var(--color-ink)]">Ya está cobrado</label>
             </div>
             {incomeForm.is_paid && (
               <Input
@@ -720,11 +747,18 @@ export default function EventDetail() {
               />
             )}
           </div>
-          <div className="flex gap-3 justify-end">
-            <Button type="button" variant="secondary" onClick={() => setIncomeModal(false)}>Cancelar</Button>
-            <Button type="submit" disabled={savingIncome}>
-              {editingIncome ? 'Guardar cambios' : 'Añadir ingreso'}
-            </Button>
+          <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-between">
+            {editingIncome && (
+              <Button type="button" variant="ghost" onClick={handleDeleteEditingIncome} className="justify-center text-[var(--color-red)] hover:bg-[var(--color-red-light)]">
+                Eliminar
+              </Button>
+            )}
+            <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+              <Button type="button" variant="secondary" onClick={() => setIncomeModal(false)}>Cancelar</Button>
+              <Button type="submit" disabled={savingIncome}>
+                {editingIncome ? 'Guardar cambios' : 'Añadir ingreso'}
+              </Button>
+            </div>
           </div>
         </form>
       </Modal>
@@ -777,7 +811,7 @@ export default function EventDetail() {
             placeholder="Alquiler sala de ensayo"
             required
           />
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <Input
               label="Importe (€) *"
               type="text"
@@ -803,15 +837,22 @@ export default function EventDetail() {
             <div className="flex items-center gap-2">
               <input type="checkbox" id="is_deductible" checked={expenseForm.is_deductible}
                 onChange={(e) => setExpenseForm((p) => ({ ...p, is_deductible: e.target.checked }))}
-                className="h-5 w-5 rounded border-gray-300 text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]" />
-              <label htmlFor="is_deductible" className="text-sm text-gray-700">Gasto deducible fiscalmente</label>
+                className="h-5 w-5 rounded border-[var(--color-paper-mid)] text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]" />
+              <label htmlFor="is_deductible" className="text-sm text-[var(--color-ink)]">Gasto deducible fiscalmente</label>
             </div>
           </div>
-          <div className="flex gap-3 justify-end">
-            <Button type="button" variant="secondary" onClick={() => setExpenseModal(false)}>Cancelar</Button>
-            <Button type="submit" disabled={savingExpense}>
-              {editingExpense ? 'Guardar cambios' : 'Añadir gasto'}
-            </Button>
+          <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-between">
+            {editingExpense && (
+              <Button type="button" variant="ghost" onClick={handleDeleteEditingExpense} className="justify-center text-[var(--color-red)] hover:bg-[var(--color-red-light)]">
+                Eliminar
+              </Button>
+            )}
+            <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+              <Button type="button" variant="secondary" onClick={() => setExpenseModal(false)}>Cancelar</Button>
+              <Button type="submit" disabled={savingExpense}>
+                {editingExpense ? 'Guardar cambios' : 'Añadir gasto'}
+              </Button>
+            </div>
           </div>
         </form>
       </Modal>
@@ -830,14 +871,14 @@ export default function EventDetail() {
             onChange={(e) => setQuickIncomeForm((p) => ({ ...p, amount: e.target.value }))}
             required
           />
-          <label className="flex items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3">
+          <label className="flex items-center gap-3 rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-surface-alt)] p-3">
             <input
               type="checkbox"
               checked={quickIncomeForm.is_paid}
               onChange={(e) => setQuickIncomeForm((p) => ({ ...p, is_paid: e.target.checked }))}
-              className="h-5 w-5 rounded border-gray-300 text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]"
+              className="h-5 w-5 rounded border-[var(--color-paper-mid)] text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]"
             />
-            <span className="text-sm font-medium text-gray-700">Marcar como cobrado</span>
+            <span className="text-sm font-medium text-[var(--color-ink)]">Marcar como cobrado</span>
           </label>
           <div className="flex gap-3 justify-end">
             <Button type="button" variant="secondary" onClick={() => setQuickIncomeModal(false)}>Cancelar</Button>

--- a/src/pages/Events/EventForm.jsx
+++ b/src/pages/Events/EventForm.jsx
@@ -124,8 +124,8 @@ export function EventForm({ initialData, projects = [], onSubmit, onCancel, load
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       <section className="flex flex-col gap-3">
         <div>
-          <h3 className="text-sm font-semibold text-gray-900">Información básica</h3>
-          <p className="hidden sm:block text-sm text-gray-600 mt-1">Nombre, cliente y clasificación para encontrarlo rápido.</p>
+          <h3 className="text-sm font-semibold text-[var(--color-ink)]">Información básica</h3>
+          <p className="hidden sm:block text-sm text-[var(--color-ink-muted)] mt-1">Nombre, cliente y clasificación para encontrarlo rápido.</p>
         </div>
         <Input
           label="Nombre del evento *"
@@ -143,7 +143,7 @@ export function EventForm({ initialData, projects = [], onSubmit, onCancel, load
           placeholder="Ayuntamiento de Madrid"
         />
 
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <Select label="Categoría" name="category" value={form.category} onChange={handleChange}>
             {EVENT_CATEGORIES.map((c) => (
               <option key={c.value} value={c.value}>{c.label}</option>
@@ -157,10 +157,10 @@ export function EventForm({ initialData, projects = [], onSubmit, onCancel, load
         </div>
       </section>
 
-      <section className="flex flex-col gap-3 border-t border-gray-100 pt-4">
+      <section className="flex flex-col gap-3 border-t border-[var(--color-paper-mid)] pt-4">
         <div>
-          <h3 className="text-sm font-semibold text-gray-900">Planificación</h3>
-          <p className="hidden sm:block text-sm text-gray-600 mt-1">El calendario de eventos usa fecha y hora exactas.</p>
+          <h3 className="text-sm font-semibold text-[var(--color-ink)]">Planificación</h3>
+          <p className="hidden sm:block text-sm text-[var(--color-ink-muted)] mt-1">El calendario de eventos usa fecha y hora exactas.</p>
         </div>
 
         <Select label="Proyecto relacionado" name="project_id" value={form.project_id} onChange={handleChange}>
@@ -170,7 +170,7 @@ export function EventForm({ initialData, projects = [], onSubmit, onCancel, load
           ))}
         </Select>
 
-        <div className={`grid gap-3 ${isMultiDay ? 'grid-cols-2' : 'grid-cols-1'}`}>
+        <div className={`grid gap-3 ${isMultiDay ? 'grid-cols-1 sm:grid-cols-2' : 'grid-cols-1'}`}>
           <Input
             label="Inicio *"
             type="datetime-local"
@@ -191,25 +191,25 @@ export function EventForm({ initialData, projects = [], onSubmit, onCancel, load
             />
           )}
         </div>
-        <label htmlFor="is_multi_day" className="flex min-h-11 cursor-pointer items-center gap-3 text-sm text-gray-700">
+        <label htmlFor="is_multi_day" className="flex min-h-11 cursor-pointer items-center gap-3 text-sm text-[var(--color-ink)]">
           <input
             type="checkbox"
             id="is_multi_day"
             checked={isMultiDay}
             onChange={(e) => handleMultiDayChange(e.target.checked)}
-            className="h-5 w-5 rounded border-gray-300 text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]"
+            className="h-5 w-5 rounded border-[var(--color-paper-mid)] text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]"
           />
           <span>Evento de varios días</span>
         </label>
       </section>
 
-      <section className="flex flex-col gap-3 border-t border-gray-100 pt-4">
+      <section className="flex flex-col gap-3 border-t border-[var(--color-paper-mid)] pt-4">
         <div>
-          <h3 className="text-sm font-semibold text-gray-900">Notas y calendario</h3>
-          <p className="hidden sm:block text-sm text-gray-600 mt-1">El color ayuda a distinguirlo en las vistas de calendario.</p>
+          <h3 className="text-sm font-semibold text-[var(--color-ink)]">Notas y calendario</h3>
+          <p className="hidden sm:block text-sm text-[var(--color-ink-muted)] mt-1">El color ayuda a distinguirlo en las vistas de calendario.</p>
         </div>
         <div className="flex flex-col gap-2">
-          <label className="text-sm font-medium text-gray-700">Color en calendario</label>
+          <label className="text-sm font-medium text-[var(--color-ink)]">Color en calendario</label>
           <div className="flex gap-2 flex-wrap">
             {DEFAULT_PROJECT_COLORS.map((color) => (
               <button
@@ -217,7 +217,7 @@ export function EventForm({ initialData, projects = [], onSubmit, onCancel, load
                 type="button"
                 aria-label={`Usar color ${color}`}
                 onClick={() => setForm((prev) => ({ ...prev, color }))}
-                className={`h-10 w-10 rounded-full transition-transform ${form.color === color ? 'scale-110 ring-2 ring-offset-2 ring-gray-500' : 'hover:scale-105'}`}
+                className={`h-10 w-10 rounded-full transition-transform ${form.color === color ? 'scale-110 ring-2 ring-offset-2 ring-[var(--color-ink-muted)]' : 'hover:scale-105'}`}
                 style={{ backgroundColor: color }}
               />
             ))}
@@ -233,7 +233,7 @@ export function EventForm({ initialData, projects = [], onSubmit, onCancel, load
         />
       </section>
 
-      {error && <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+      {error && <p className="rounded-lg bg-[var(--color-red-light)] px-3 py-2 text-sm text-[var(--color-red)]">{error}</p>}
 
       <div className="flex flex-col-reverse sm:flex-row gap-3 sm:justify-end pt-1">
         <Button type="button" variant="secondary" onClick={onCancel} className="justify-center">

--- a/src/pages/Projects/ProjectDetail.jsx
+++ b/src/pages/Projects/ProjectDetail.jsx
@@ -22,7 +22,10 @@ import { isPaid, markPaid, markUnpaid, needsQuickPaidConfirmation, paymentDate }
 import { EXPENSE_CATEGORIES } from '../../lib/constants'
 
 const EMPTY_EXPENSE = { concept: '', amount: '', category: 'otros', expense_date: '', is_deductible: true }
-const compactSecondaryAction = 'inline-flex min-h-9 items-center justify-center gap-2 rounded-lg border border-[#E2D9C2] bg-[#F5EFE0] px-3 py-1.5 text-sm font-medium leading-none text-[#211C18] shadow-sm transition-colors hover:bg-[#EBE3CE] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2'
+const compactSecondaryAction = 'inline-flex min-h-9 items-center justify-center gap-2 rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-paper)] px-3 py-1.5 text-sm font-medium leading-none text-[var(--color-ink)] shadow-sm transition-colors hover:bg-[var(--color-paper-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-red)] focus-visible:ring-offset-2'
+const compactPrimaryActionDesktop = 'hidden sm:inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-[var(--color-red)] px-3 py-1.5 text-sm font-medium leading-none text-white shadow-sm transition-colors hover:bg-[var(--color-red-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-red)] focus-visible:ring-offset-2'
+const compactSecondaryActionDesktop = 'hidden sm:inline-flex min-h-9 items-center justify-center gap-2 rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-paper)] px-3 py-1.5 text-sm font-medium leading-none text-[var(--color-ink)] shadow-sm transition-colors hover:bg-[var(--color-paper-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-red)] focus-visible:ring-offset-2'
+const compactDangerActionDesktop = 'hidden sm:inline-flex min-h-9 items-center justify-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium leading-none text-[var(--color-red)] transition-colors hover:bg-[var(--color-red-light)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-red)] focus-visible:ring-offset-2'
 const incomeConceptLabel = (income) => income.concept?.trim() || 'Ingreso sin concepto'
 const incomeDueClass = (income) => {
   if (!income.expected_date) return 'text-gray-400'
@@ -184,6 +187,15 @@ export default function ProjectDetail() {
     setIncomeModal(false)
   }
 
+  const handleDeleteEditingIncome = async () => {
+    if (!editingIncome) return
+    if (!confirm('¿Eliminar este ingreso?')) return
+    const { error } = await deleteIncome(editingIncome.id)
+    if (error) { addToast('Error al eliminar el ingreso.', 'error'); return }
+    addToast('Ingreso eliminado.')
+    setIncomeModal(false)
+  }
+
   const undoIncomePaid = async (income, previousPayment) => {
     if (!income || savingIncomeId) return
 
@@ -279,6 +291,15 @@ export default function ProjectDetail() {
     setExpenseModal(false)
   }
 
+  const handleDeleteEditingExpense = async () => {
+    if (!editingExpense) return
+    if (!confirm('¿Eliminar este gasto?')) return
+    const { error } = await deleteExpense(editingExpense.id)
+    if (error) { addToast('Error al eliminar el gasto.', 'error'); return }
+    addToast('Gasto eliminado.')
+    setExpenseModal(false)
+  }
+
   const handleQuickSubmitIncome = async (e) => {
     e.preventDefault()
     const amount = parseDecimal(quickIncomeForm.amount)
@@ -331,29 +352,29 @@ export default function ProjectDetail() {
   return (
     <PageWrapper title={project.name}>
       <div className="flex max-w-4xl flex-col gap-4 sm:gap-5 pb-20 sm:pb-5">
-        <nav className="flex items-center gap-1.5 text-xs text-gray-400 breadcrumbs">
-          <Link to="/work" className="hover:text-gray-600">Trabajos</Link>
+        <nav className="flex items-center gap-1.5 text-xs text-[var(--color-ink-muted)] breadcrumbs">
+          <Link to="/work" className="hover:text-[var(--color-ink)]">Trabajos</Link>
           <span>/</span>
-          <Link to="/work?view=projects" className="hover:text-gray-600">Proyectos</Link>
+          <Link to="/work?view=projects" className="hover:text-[var(--color-ink)]">Proyectos</Link>
           <span>/</span>
-          <span className="text-gray-600">{project.name}</span>
+          <span className="text-[var(--color-ink)]">{project.name}</span>
         </nav>
-        <div className="rounded-2xl border border-[#E9E2D3] bg-white p-4 shadow-sm sm:p-5">
+        <div className="rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-surface)] p-4 shadow-sm sm:p-5">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div className="flex items-start gap-3 sm:items-start">
-              <Link to="/work?view=projects" className="mt-1 shrink-0 text-gray-400 hover:text-gray-700" aria-label="Volver a proyectos en trabajos">
+              <Link to="/work?view=projects" className="mt-1 shrink-0 text-[var(--color-ink-muted)] hover:text-[var(--color-ink)]" aria-label="Volver a proyectos en trabajos">
                 <ArrowLeft size={20} />
               </Link>
               <div className="min-w-0">
                 <div className="flex min-w-0 flex-wrap items-center gap-2">
                   <div className="h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: project.color ?? '#4f98a3' }} />
-                  <h2 className="min-w-0 truncate text-lg font-semibold text-gray-900">{project.name}</h2>
+                  <h2 className="min-w-0 truncate text-lg font-semibold text-[var(--color-ink)]">{project.name}</h2>
                   <QuietStatusBadge status={project.status} />
                 </div>
                 {project.client && (
-                  <p className="mt-1 text-sm text-gray-500">{project.client}</p>
+                  <p className="mt-1 text-sm text-[var(--color-ink-muted)]">{project.client}</p>
                 )}
-                <p className="mt-1 text-xs text-gray-400">
+                <p className="mt-1 text-xs text-[var(--color-ink-muted)]">
                   {project.category} · {formatDate(project.start_date)}{project.end_date && ` – ${formatDate(project.end_date)}`}
                 </p>
               </div>
@@ -361,45 +382,57 @@ export default function ProjectDetail() {
           </div>
         </div>
 
-        <Card className="bg-gray-50 p-4 sm:p-5">
+        <Card className="bg-[var(--color-surface-alt)] p-4 sm:p-5">
           <button
             type="button"
             onClick={() => setFinancialSummaryExpanded((prev) => !prev)}
             className="w-full flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4"
           >
             <div className="flex flex-col items-start text-left">
-              <h3 className="text-sm font-semibold text-gray-900">Resumen financiero</h3>
-              <p className="text-xs text-gray-500 mt-1">Incluye ingresos y gastos directos del proyecto y sus eventos.</p>
+              <h3 className="text-sm font-semibold text-[var(--color-ink)]">Resumen financiero</h3>
+              <p className="text-xs text-[var(--color-ink-muted)] mt-1">Incluye ingresos y gastos directos del proyecto y sus eventos.</p>
             </div>
             <div className="flex items-center justify-between w-full sm:w-auto sm:justify-end gap-3">
-              <p className="text-xs text-gray-500">Cobrado: {formatCurrency(totalPaid)} · Pendiente: {formatCurrency(pendingAmount)}</p>
-              <ChevronDown size={16} className={`shrink-0 text-gray-400 transition-transform sm:hidden ${financialSummaryExpanded ? 'rotate-180' : ''}`} />
+              <p className="text-xs text-[var(--color-ink-muted)]">Cobrado: {formatCurrency(totalPaid)} · Pendiente: {formatCurrency(pendingAmount)}</p>
+              <ChevronDown size={16} className={`shrink-0 text-[var(--color-ink-muted)] transition-transform ${financialSummaryExpanded ? 'rotate-180' : ''}`} />
             </div>
           </button>
-          <div className={`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 ${financialSummaryExpanded ? 'block' : 'hidden sm:grid'}`}>
+          <div className="grid grid-cols-3 gap-2 sm:gap-3">
+            {[
+              { label: 'Cobrado', mobileLabel: 'Cobrado', value: formatCurrency(totalPaid) },
+              { label: 'Pendiente', mobileLabel: 'Pend.', value: formatCurrency(pendingAmount) },
+              { label: 'Beneficio neto', mobileLabel: 'Neto', value: formatCurrency(netProfit), highlight: true },
+            ].map(({ label, mobileLabel, value, highlight }) => (
+              <div key={label} className={`rounded-lg border p-2.5 sm:p-4 ${highlight ? 'border-[var(--color-primary-200)] bg-[var(--color-red-light)]' : 'border-[var(--color-paper-mid)] bg-[var(--color-surface)]'}`}>
+                <p className="text-[11px] leading-tight text-[var(--color-ink-muted)] sm:text-xs">
+                  <span className="sm:hidden">{mobileLabel}</span>
+                  <span className="hidden sm:inline">{label}</span>
+                </p>
+                <p className={`mt-1 text-sm font-semibold leading-tight break-words sm:text-lg ${highlight ? 'text-[var(--color-primary-600)]' : 'text-[var(--color-ink)]'}`}>{value}</p>
+              </div>
+            ))}
+          </div>
+          <div className={`${financialSummaryExpanded ? 'mt-3 grid' : 'hidden'} grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4`}>
           {[
             { label: 'Ingresos previstos', value: formatCurrency(totalGross) },
             { label: 'IRPF sobre cobrado', value: formatCurrency(totalRetentions) },
             { label: 'Gastos registrados', value: formatCurrency(totalExpenses) },
             { label: 'Cobro bruto/hora', value: projectHours > 0 ? formatCurrencyPerHour(grossHourlyRate) : '—', detail: projectHours > 0 ? `Solo eventos cobrados · ${formatHours(projectHours)} h` : 'Sin eventos cobrados' },
-            { label: 'Beneficio neto', value: formatCurrency(netProfit), highlight: true },
-          ].map(({ label, value, detail, highlight }) => (
-            <div key={label} className={`rounded-lg border p-4 ${highlight ? 'bg-[#fef3f2] border-[var(--color-primary-200)]' : 'bg-white border-gray-200'}`}>
-              <p className="text-xs text-gray-500">{label}</p>
-              <p className={`text-lg font-semibold mt-1 ${highlight ? 'text-[var(--color-primary-600)]' : 'text-gray-900'}`}>{value}</p>
-              {detail && <p className="mt-1 text-xs text-gray-400">{detail}</p>}
+          ].map(({ label, value, detail }) => (
+            <div key={label} className="rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-surface)] p-4">
+              <p className="text-xs text-[var(--color-ink-muted)]">{label}</p>
+              <p className="mt-1 text-base font-semibold text-[var(--color-ink)]">{value}</p>
+              {detail && <p className="mt-1 text-xs text-[var(--color-ink-muted)]">{detail}</p>}
             </div>
           ))}
           </div>
-          {!financialSummaryExpanded && (
-            <button
-              type="button"
-              onClick={() => setFinancialSummaryExpanded(true)}
-              className="w-full sm:hidden mt-2 py-2 text-xs text-[var(--color-primary-500)] font-medium hover:text-[var(--color-primary-600)]"
-            >
-              Ver resumen completo
-            </button>
-          )}
+          <button
+            type="button"
+            onClick={() => setFinancialSummaryExpanded((prev) => !prev)}
+            className="mt-3 text-xs font-medium text-[var(--color-primary-500)] hover:text-[var(--color-primary-600)]"
+          >
+            {financialSummaryExpanded ? 'Ocultar detalle financiero' : 'Ver detalle financiero'}
+          </button>
         </Card>
 
         {/* Eventos asociados */}
@@ -524,28 +557,28 @@ export default function ProjectDetail() {
                 {directIncomes.map((income) => {
                   const isSaving = savingIncomeId === income.id
                   return (
-                    <div key={income.id} className="flex items-center justify-between gap-2 py-2 border-b border-gray-50 last:border-0">
+                    <div key={income.id} className="flex items-center justify-between gap-2 border-b border-[var(--color-paper-mid)] py-2 last:border-0">
                       <button
                         type="button"
                         onClick={() => openEditIncome(income)}
                         className="min-w-0 flex-1 text-left"
                       >
-                        <span className="block truncate text-sm text-gray-900">{incomeConceptLabel(income)}</span>
-                        {!isPaid(income) && (
-                          <span className={`mt-0.5 block text-xs ${incomeDueClass(income)}`}>{formatDueDescription(income.expected_date)}</span>
-                        )}
+                        <span className="block truncate text-sm font-medium text-[var(--color-ink)]">{incomeConceptLabel(income)}</span>
+                        <span className={`mt-0.5 block text-xs ${isPaid(income) ? 'text-[var(--color-green)]' : incomeDueClass(income)}`}>
+                          {isPaid(income) ? 'Cobrado' : formatDueDescription(income.expected_date)}
+                        </span>
                       </button>
-                      <span className="shrink-0 text-sm font-medium text-gray-900">{formatCurrency(income.amount)}</span>
+                      <span className="shrink-0 text-sm font-semibold text-[var(--color-ink)]">{formatCurrency(income.amount)}</span>
                       <button
                         type="button"
                         onClick={() => handleTogglePaid(income)}
                         disabled={Boolean(savingIncomeId)}
                         aria-label={`${isPaid(income) ? 'Marcar como pendiente' : 'Marcar como cobrado'} ${incomeConceptLabel(income)}`}
-                        className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-[#2D6A4F] transition-colors hover:bg-[#F4FBF7] hover:text-[#1F5A42] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2D6A4F] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:text-gray-300 disabled:hover:bg-transparent"
+                        className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-[var(--color-green)] transition-colors hover:bg-[var(--color-green-light)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-green)] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:text-[var(--color-ink-muted)] disabled:hover:bg-transparent"
                       >
                         {isSaving
                           ? <span className="h-4 w-4 animate-spin rounded-full border-2 border-[#2D6A4F] border-t-transparent" />
-                          : isPaid(income) ? <CheckCircle size={18} className="text-green-500" /> : <Circle size={18} />}
+                          : isPaid(income) ? <CheckCircle size={18} /> : <Circle size={18} />}
                       </button>
                     </div>
                   )
@@ -610,10 +643,15 @@ export default function ProjectDetail() {
               {/* Minimalista para móvil */}
               <div className="md:hidden flex flex-col gap-1">
                 {directExpenses.map((expense) => (
-                  <div key={expense.id} onClick={() => openEditExpense(expense)} className="flex items-center justify-between py-2 border-b border-gray-50 last:border-0">
-                    <span className="text-sm text-gray-900 truncate">{expense.concept}</span>
-                    <span className="text-sm font-medium text-gray-900">{formatCurrency(expense.amount)}</span>
-                  </div>
+                  <button key={expense.id} type="button" onClick={() => openEditExpense(expense)} className="flex items-center justify-between gap-3 border-b border-[var(--color-paper-mid)] py-2 text-left last:border-0">
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium text-[var(--color-ink)]">{expense.concept}</span>
+                      <span className="mt-0.5 block truncate text-xs capitalize text-[var(--color-ink-muted)]">
+                        {expense.category} · {formatDate(expense.expense_date)}
+                      </span>
+                    </span>
+                    <span className="shrink-0 text-sm font-semibold text-[var(--color-ink)]">{formatCurrency(expense.amount)}</span>
+                  </button>
                 ))}
               </div>
             </div>
@@ -635,21 +673,28 @@ export default function ProjectDetail() {
       <Modal isOpen={incomeModal} onClose={() => setIncomeModal(false)} title={editingIncome ? 'Editar ingreso' : 'Añadir ingreso'}>
         <form onSubmit={handleSubmitIncome} className="flex flex-col gap-3">
           <Input label="Concepto *" value={incomeForm.concept} onChange={(e) => setIncomeForm((p) => ({ ...p, concept: e.target.value }))} placeholder="Producción general" required />
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <Input label="Importe (€) *" type="text" inputMode="decimal" value={incomeForm.amount} onChange={(e) => setIncomeForm((p) => ({ ...p, amount: e.target.value }))} required />
             <Input label="Retención IRPF (%)" type="text" inputMode="decimal" value={incomeForm.tax_rate} onChange={(e) => setIncomeForm((p) => ({ ...p, tax_rate: e.target.value }))} />
             <Input label="Fecha prevista de cobro" type="date" value={incomeForm.expected_date} onChange={(e) => setIncomeForm((p) => ({ ...p, expected_date: e.target.value, paid_date: p.is_paid && !p.paid_date ? e.target.value : p.paid_date }))} />
             <div className="flex items-center gap-2">
-              <input type="checkbox" id="is_paid" checked={incomeForm.is_paid} onChange={(e) => setIncomeForm((p) => ({ ...p, is_paid: e.target.checked, paid_date: e.target.checked ? (p.paid_date ?? p.expected_date ?? '') : null }))} className="h-5 w-5 rounded border-gray-300 text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]" />
-              <label htmlFor="is_paid" className="text-sm text-gray-700">Ya está cobrado</label>
+              <input type="checkbox" id="is_paid" checked={incomeForm.is_paid} onChange={(e) => setIncomeForm((p) => ({ ...p, is_paid: e.target.checked, paid_date: e.target.checked ? (p.paid_date ?? p.expected_date ?? '') : null }))} className="h-5 w-5 rounded border-[var(--color-paper-mid)] text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]" />
+              <label htmlFor="is_paid" className="text-sm text-[var(--color-ink)]">Ya está cobrado</label>
             </div>
             {incomeForm.is_paid && (
               <Input label="Fecha real de cobro" type="date" value={incomeForm.paid_date ?? ''} onChange={(e) => setIncomeForm((p) => ({ ...p, paid_date: e.target.value }))} />
             )}
           </div>
-          <div className="flex gap-3 justify-end">
-            <Button type="button" variant="secondary" onClick={() => setIncomeModal(false)}>Cancelar</Button>
-            <Button type="submit" disabled={savingIncome}>{editingIncome ? 'Guardar cambios' : 'Añadir ingreso'}</Button>
+          <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-between">
+            {editingIncome && (
+              <Button type="button" variant="ghost" onClick={handleDeleteEditingIncome} className="justify-center text-[var(--color-red)] hover:bg-[var(--color-red-light)]">
+                Eliminar
+              </Button>
+            )}
+            <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+              <Button type="button" variant="secondary" onClick={() => setIncomeModal(false)}>Cancelar</Button>
+              <Button type="submit" disabled={savingIncome}>{editingIncome ? 'Guardar cambios' : 'Añadir ingreso'}</Button>
+            </div>
           </div>
         </form>
       </Modal>
@@ -696,49 +741,56 @@ export default function ProjectDetail() {
       <Modal isOpen={expenseModal} onClose={() => setExpenseModal(false)} title={editingExpense ? 'Editar gasto' : 'Añadir gasto'}>
         <form onSubmit={handleSubmitExpense} className="flex flex-col gap-3">
           <Input label="Concepto *" value={expenseForm.concept} onChange={(e) => setExpenseForm((p) => ({ ...p, concept: e.target.value }))} placeholder="Material de producción" required />
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <Input label="Importe (€) *" type="text" inputMode="decimal" value={expenseForm.amount} onChange={(e) => setExpenseForm((p) => ({ ...p, amount: e.target.value }))} required />
             <Select label="Categoría" value={expenseForm.category} onChange={(e) => setExpenseForm((p) => ({ ...p, category: e.target.value }))}>
               {EXPENSE_CATEGORIES.map((c) => <option key={c.value} value={c.value}>{c.label}</option>)}
             </Select>
             <Input label="Fecha *" type="date" value={expenseForm.expense_date} onChange={(e) => setExpenseForm((p) => ({ ...p, expense_date: e.target.value }))} required />
             <div className="flex items-center gap-2">
-              <input type="checkbox" id="is_deductible" checked={expenseForm.is_deductible} onChange={(e) => setExpenseForm((p) => ({ ...p, is_deductible: e.target.checked }))} className="h-5 w-5 rounded border-gray-300 text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]" />
-              <label htmlFor="is_deductible" className="text-sm text-gray-700">Gasto deducible fiscalmente</label>
+              <input type="checkbox" id="is_deductible" checked={expenseForm.is_deductible} onChange={(e) => setExpenseForm((p) => ({ ...p, is_deductible: e.target.checked }))} className="h-5 w-5 rounded border-[var(--color-paper-mid)] text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]" />
+              <label htmlFor="is_deductible" className="text-sm text-[var(--color-ink)]">Gasto deducible fiscalmente</label>
             </div>
           </div>
-          <div className="flex gap-3 justify-end">
-            <Button type="button" variant="secondary" onClick={() => setExpenseModal(false)}>Cancelar</Button>
-            <Button type="submit" disabled={savingExpense}>{editingExpense ? 'Guardar cambios' : 'Añadir gasto'}</Button>
+          <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-between">
+            {editingExpense && (
+              <Button type="button" variant="ghost" onClick={handleDeleteEditingExpense} className="justify-center text-[var(--color-red)] hover:bg-[var(--color-red-light)]">
+                Eliminar
+              </Button>
+            )}
+            <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+              <Button type="button" variant="secondary" onClick={() => setExpenseModal(false)}>Cancelar</Button>
+              <Button type="submit" disabled={savingExpense}>{editingExpense ? 'Guardar cambios' : 'Añadir gasto'}</Button>
+            </div>
           </div>
         </form>
       </Modal>
 
       {/* Bottom bar para móvil */}
-      <div className="fixed bottom-0 left-0 right-0 z-40 flex gap-1 border-t border-gray-200 bg-white px-2 py-2 shadow-[0_-2px_10px_rgba(0,0,0,0.1)] sm:static sm:border-0 sm:bg-transparent sm:p-0 sm:shadow-none">
-        <button type="button" onClick={() => setQuickIncomeModal(true)} className="flex-1 rounded-lg bg-[var(--color-primary-500)] py-2 text-xs font-medium text-white sm:hidden">
+      <div className="fixed bottom-0 left-0 right-0 z-40 flex gap-1 border-t border-[var(--color-paper-mid)] bg-[var(--color-surface)] px-2 py-2 shadow-[0_-2px_10px_rgba(0,0,0,0.1)] sm:static sm:border-0 sm:bg-transparent sm:p-0 sm:shadow-none">
+        <button type="button" onClick={() => setQuickIncomeModal(true)} className="flex-1 rounded-lg bg-[var(--color-red)] py-2 text-xs font-medium text-white sm:hidden">
           Cobro
         </button>
-        <button type="button" onClick={() => setQuickExpenseModal(true)} className="flex-1 rounded-lg bg-[var(--color-primary-500)] py-2 text-xs font-medium text-white sm:hidden">
+        <button type="button" onClick={() => setQuickExpenseModal(true)} className="flex-1 rounded-lg bg-[var(--color-red)] py-2 text-xs font-medium text-white sm:hidden">
           Gasto
         </button>
-        <button type="button" onClick={() => setEditModal(true)} className="flex-1 rounded-lg bg-[#C94035] py-2 text-xs font-medium text-white sm:hidden">
+        <button type="button" onClick={() => setEditModal(true)} className="flex-1 rounded-lg bg-[var(--color-red)] py-2 text-xs font-medium text-white sm:hidden">
           Editar
         </button>
-        <button type="button" onClick={handleDeleteProject} className="flex-1 rounded-lg border border-red-200 py-2 text-xs font-medium text-red-600 sm:hidden">
+        <button type="button" onClick={handleDeleteProject} className="flex-1 rounded-lg border border-[var(--color-red-light)] py-2 text-xs font-medium text-[var(--color-red)] sm:hidden">
           Eliminar
         </button>
         {/* Desktop - quick modals */}
-        <button type="button" onClick={() => setQuickIncomeModal(true)} className="hidden sm:inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-[#C94035] px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-[#A8342B]">
+        <button type="button" onClick={() => setQuickIncomeModal(true)} className={compactPrimaryActionDesktop}>
           <Plus size={14} /> Ingreso
         </button>
-        <button type="button" onClick={() => setQuickExpenseModal(true)} className="hidden sm:inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-[#C94035] px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-[#A8342B]">
+        <button type="button" onClick={() => setQuickExpenseModal(true)} className={compactPrimaryActionDesktop}>
           <Plus size={14} /> Gasto
         </button>
-        <button type="button" onClick={() => setEditModal(true)} className="hidden sm:inline-flex min-h-9 items-center justify-center gap-2 rounded-lg border border-[#E2D9C2] bg-[#F5EFE0] px-3 py-1.5 text-sm font-medium text-[#211C18] shadow-sm hover:bg-[#EBE3CE]">
+        <button type="button" onClick={() => setEditModal(true)} className={compactSecondaryActionDesktop}>
           <Edit size={14} /> Editar
         </button>
-        <button type="button" onClick={handleDeleteProject} className="hidden sm:inline-flex min-h-9 items-center justify-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium text-[#C94035] hover:bg-red-50">
+        <button type="button" onClick={handleDeleteProject} className={compactDangerActionDesktop}>
           <Trash2 size={14} /> Eliminar
         </button>
       </div>
@@ -757,14 +809,14 @@ export default function ProjectDetail() {
             onChange={(e) => setQuickIncomeForm((p) => ({ ...p, amount: e.target.value }))}
             required
           />
-          <label className="flex items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3">
+          <label className="flex items-center gap-3 rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-surface-alt)] p-3">
             <input
               type="checkbox"
               checked={quickIncomeForm.is_paid}
               onChange={(e) => setQuickIncomeForm((p) => ({ ...p, is_paid: e.target.checked }))}
-              className="h-5 w-5 rounded border-gray-300 text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]"
+              className="h-5 w-5 rounded border-[var(--color-paper-mid)] text-[var(--color-primary-500)] focus:ring-[var(--color-primary-500)]"
             />
-            <span className="text-sm font-medium text-gray-700">Marcar como cobrado</span>
+            <span className="text-sm font-medium text-[var(--color-ink)]">Marcar como cobrado</span>
           </label>
           <div className="flex gap-3 justify-end">
             <Button type="button" variant="secondary" onClick={() => setQuickIncomeModal(false)}>Cancelar</Button>

--- a/src/pages/Projects/ProjectForm.jsx
+++ b/src/pages/Projects/ProjectForm.jsx
@@ -58,8 +58,8 @@ export function ProjectForm({ initialData, onSubmit, onCancel, loading }) {
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       <section className="flex flex-col gap-3">
         <div>
-          <h3 className="text-sm font-semibold text-gray-900">Información básica</h3>
-          <p className="hidden sm:block text-sm text-gray-600 mt-1">Datos generales del contenedor del trabajo.</p>
+          <h3 className="text-sm font-semibold text-[var(--color-ink)]">Información básica</h3>
+          <p className="hidden sm:block text-sm text-[var(--color-ink-muted)] mt-1">Datos generales del contenedor del trabajo.</p>
         </div>
         <Input
           label="Nombre del proyecto *"
@@ -76,7 +76,7 @@ export function ProjectForm({ initialData, onSubmit, onCancel, loading }) {
           onChange={handleChange}
           placeholder="Ayuntamiento de Madrid"
         />
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <Select label="Categoría" name="category" value={form.category} onChange={handleChange}>
             {PROJECT_CATEGORIES.map((c) => (
               <option key={c.value} value={c.value}>{c.label}</option>
@@ -90,12 +90,12 @@ export function ProjectForm({ initialData, onSubmit, onCancel, loading }) {
         </div>
       </section>
 
-      <section className="flex flex-col gap-3 border-t border-gray-100 pt-4">
+      <section className="flex flex-col gap-3 border-t border-[var(--color-paper-mid)] pt-4">
         <div>
-          <h3 className="text-sm font-semibold text-gray-900">Calendario</h3>
-          <p className="hidden sm:block text-sm text-gray-600 mt-1">Rango visible en el calendario interno de proyectos.</p>
+          <h3 className="text-sm font-semibold text-[var(--color-ink)]">Calendario</h3>
+          <p className="hidden sm:block text-sm text-[var(--color-ink-muted)] mt-1">Rango visible en el calendario interno de proyectos.</p>
         </div>
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <Input
             label="Fecha de inicio *"
             type="date"
@@ -114,13 +114,13 @@ export function ProjectForm({ initialData, onSubmit, onCancel, loading }) {
         </div>
       </section>
 
-      <section className="flex flex-col gap-3 border-t border-gray-100 pt-4">
+      <section className="flex flex-col gap-3 border-t border-[var(--color-paper-mid)] pt-4">
         <div>
-          <h3 className="text-sm font-semibold text-gray-900">Notas y color</h3>
-          <p className="hidden sm:block text-sm text-gray-600 mt-1">El color identifica el proyecto y sus rangos en calendario.</p>
+          <h3 className="text-sm font-semibold text-[var(--color-ink)]">Notas y color</h3>
+          <p className="hidden sm:block text-sm text-[var(--color-ink-muted)] mt-1">El color identifica el proyecto y sus rangos en calendario.</p>
         </div>
         <div className="flex flex-col gap-2">
-          <label className="text-sm font-medium text-gray-700">Color en calendario</label>
+          <label className="text-sm font-medium text-[var(--color-ink)]">Color en calendario</label>
           <div className="flex gap-2 flex-wrap">
             {DEFAULT_PROJECT_COLORS.map((color) => (
               <button
@@ -128,7 +128,7 @@ export function ProjectForm({ initialData, onSubmit, onCancel, loading }) {
                 type="button"
                 aria-label={`Usar color ${color}`}
                 onClick={() => setForm((prev) => ({ ...prev, color }))}
-                className={`h-10 w-10 rounded-full transition-transform ${form.color === color ? 'scale-110 ring-2 ring-offset-2 ring-gray-500' : 'hover:scale-105'}`}
+                className={`h-10 w-10 rounded-full transition-transform ${form.color === color ? 'scale-110 ring-2 ring-offset-2 ring-[var(--color-ink-muted)]' : 'hover:scale-105'}`}
                 style={{ backgroundColor: color }}
               />
             ))}
@@ -144,7 +144,7 @@ export function ProjectForm({ initialData, onSubmit, onCancel, loading }) {
         />
       </section>
 
-      {error && <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+      {error && <p className="rounded-lg bg-[var(--color-red-light)] px-3 py-2 text-sm text-[var(--color-red)]">{error}</p>}
 
       <div className="flex flex-col-reverse sm:flex-row gap-3 sm:justify-end pt-1">
         <Button type="button" variant="secondary" onClick={onCancel} className="justify-center">


### PR DESCRIPTION
## Summary

Beta 6 cierra la estabilizacion visual y mobile financiero con rama unica `release/0.1.0-beta.6` hacia `main`.

Scope funcional:
- `CACH-0030`: homogeneizacion visual acotada en componentes, dashboard, work, detalles, calendarios y formularios.
- `CACH-0038`: compactacion mobile financiera acotada en resumenes, ingresos, gastos, modales y acciones principales.

Mejora auxiliar de delivery incluida en Beta 6, fuera del scope funcional de CACH-0030/CACH-0038:
- `cultura-agent-orchestration`: skill portable para decidir entre subagentes nativos de Codex/Claude, OpenCode, revision paralela, ownership y verificacion.

## Cambios principales

- Activa Product Brain de Beta 6 y la rama `release/0.1.0-beta.6`.
- Corrige tokens base en `src/index.css`, incluyendo `--font-mono` y `--color-gray-950`.
- Reduce inconsistencias visuales en `Button`, `Badge`, formularios, dashboard, calendarios y detalles.
- En mobile, los detalles financieros muestran `Cobrado`, `Pendiente` y `Neto` por defecto.
- Ingresos y gastos mobile pasan a filas compactas con edicion por tap.
- El borrado mobile queda dentro de modales de edicion con confirmacion, no en filas.

## Verificacion local

- [x] `npm run pb:check`
- [x] `git diff --check`
- [x] `npm run test`
- [x] `npm run lint`
- [x] `npm run build`

Nota: `npm run build` mantiene el warning conocido de chunk grande (>500 kB), declarado como no bloqueante para Beta 6.

## QA pendiente

- [ ] QA visual autenticada en `/dashboard`, `/work`, detalle de proyecto, detalle de evento y modales ingreso/gasto.
- [ ] QA visual autenticada de calendarios en mobile/desktop.

Intento local con Playwright redirige a `/login` sin sesion, por lo que esta parte requiere sesion autenticada.

## Memoria

Memoria: actualizada

Se actualizo `.memory/topics/portable-skills.md` para registrar la nueva skill operativa `cultura-agent-orchestration` como memoria durable de workflow.

## Release

Closes CACH-0030
Closes CACH-0038