### PR TITLE
Beta 7 — Portabilidad mínima de datos

### DIFF
--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -60,12 +60,12 @@ Sin issues en inbox.
 
 | ID | Titulo | Tipo | Prioridad | Nota |
 |---|---|---|---|---|
-| [[../issues/CACH-B0005|CACH-B0005]] | Importacion, exportacion y portabilidad de datos | feature | p1 | Scope Beta 7: exportacion e importacion CSV minima validada. |
 
 ## Review
 
 | ID | Titulo | Tipo | Prioridad | Nota |
 |---|---|---|---|---|
+| [[../issues/CACH-B0005|CACH-B0005]] | Importacion, exportacion y portabilidad de datos | feature | p1 | Beta 7 lista para smoke autenticado y PR de release. |
 | [[../issues/CACH-0030|CACH-0030]] | Homogeneizar diseno con nueva paleta | chore | p1 | Pendiente QA visual autenticada. |
 | [[../issues/CACH-0038|CACH-0038]] | Compactar mobile financiero y detalles accionables | feature | p1 | Pendiente QA visual autenticada. |
 

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -48,7 +48,6 @@ Sin issues en inbox.
 | [[../issues/CACH-B0001|CACH-B0001]] | Redisenar Trabajos y jerarquia proyecto-evento | feature | p1 | Partir antes de ejecutar. |
 | [[../issues/CACH-B0002|CACH-B0002]] | Simplificar experiencia mobile financiera | feature | p1 | Validacion mobile obligatoria. |
 | [[../issues/CACH-B0004|CACH-B0004]] | Contratantes, facturacion y liquidacion neta | feature | p1 | Evolucion de modelo financiero. |
-| [[../issues/CACH-B0005|CACH-B0005]] | Importacion, exportacion y portabilidad de datos | feature | p1 | Necesario para confianza beta. |
 | [[../issues/CACH-B0006|CACH-B0006]] | Onboarding y acceso beta | feature | p1 | Primera sesion y beta privada. |
 | [[../issues/CACH-B0007|CACH-B0007]] | Calendario unificado e interaccion rapida | feature | p1 | QA visual y responsive. |
 | [[../issues/CACH-B0008|CACH-B0008]] | PWA, notificaciones y offline | feature | p2 | Post confianza basica. |
@@ -59,7 +58,9 @@ Sin issues en inbox.
 | [[../issues/CACH-B0013|CACH-B0013]] | Gestion documental por proyecto/evento | feature | p3 | Post-MVP. |
 ## In progress
 
-Sin issues en progreso.
+| ID | Titulo | Tipo | Prioridad | Nota |
+|---|---|---|---|---|
+| [[../issues/CACH-B0005|CACH-B0005]] | Importacion, exportacion y portabilidad de datos | feature | p1 | Scope Beta 7: exportacion e importacion CSV minima validada. |
 
 ## Review
 

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -22,7 +22,6 @@ tags:
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta
-- [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida
 - [[../issues/CACH-B0008|CACH-B0008]] — PWA notificaciones y offline
@@ -42,6 +41,10 @@ tags:
 
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables
+
+## RELEASE-0.1.0-beta.7
+
+- [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos
 
 ## RELEASE-0.1.0-beta.4
 

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -33,12 +33,14 @@ tags:
 
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables
+## in-progress
+
+- [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos
 ## backlog
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta
-- [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida
 - [[../issues/CACH-B0008|CACH-B0008]] — PWA notificaciones y offline

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -31,11 +31,11 @@ tags:
 
 ## review
 
+- [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables
 ## in-progress
 
-- [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos
 ## backlog
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento

--- a/docs/project/indexes/releases.index.md
+++ b/docs/project/indexes/releases.index.md
@@ -19,4 +19,5 @@ tags:
 - [[../releases/RELEASE-0.1.0-beta.4|RELEASE-0.1.0-beta.4]] — Planificacion anual de proyectos
 - [[../releases/RELEASE-0.1.0-beta.5|RELEASE-0.1.0-beta.5]] — Flujo profesional de ramas beta
 - [[../releases/RELEASE-0.1.0-beta.6|RELEASE-0.1.0-beta.6]] — Estabilización visual y mobile financiero
+- [[../releases/RELEASE-0.1.0-beta.7|RELEASE-0.1.0-beta.7]] — Portabilidad mínima de datos
 - [[../releases/RELEASE_TEMPLATE|PB-RELEASE-TEMPLATE]] — RELEASE_TEMPLATE

--- a/docs/project/issues/CACH-B0005.md
+++ b/docs/project/issues/CACH-B0005.md
@@ -2,14 +2,14 @@
 id: CACH-B0005
 title: Importacion exportacion y portabilidad de datos
 type: feature
-status: backlog
+status: in-progress
 cycle: unassigned
-release: null
+release: RELEASE-0.1.0-beta.7
 priority: p1
 estimate: m
 area: db
 created_at: 2026-05-04
-updated_at: 2026-05-04
+updated_at: 2026-05-07
 aliases:
   - CACH-B0005
 tags:
@@ -40,12 +40,26 @@ Antes de pedir confianza a usuarios beta, Cachés debe permitir sacar sus datos 
 - Validación de datos antes de persistir.
 - Estrategia clara para errores, duplicados y campos incompletos.
 
+## Beta 7 Scope
+
+- Exportar datos propios de proyectos, eventos, ingresos y gastos.
+- Importar CSV básico validado antes de persistir.
+- Mantener `user_id` derivado de sesión autenticada, nunca del archivo.
+- Documentar límites de formato, duplicados y campos incompletos.
+- Dejar onboarding, invitaciones y analítica para [[CACH-B0006|CACH-B0006]].
+
 ## Acceptance Criteria
 
 - [ ] Un usuario puede exportar sus datos completos.
 - [ ] Un usuario puede importar un CSV básico validado.
 - [ ] Los errores de importación se muestran antes de guardar.
 - [ ] La exportación no filtra datos de otros usuarios.
+
+## Validation
+
+- Ejecutar `npm run test`, `npm run lint`, `npm run build` y `npm run pb:check`.
+- Smoke autenticado: exportar datos, importar CSV válido, importar CSV con errores y confirmar que no se persisten filas inválidas.
+- Revisar que la importación ignora o rechaza cualquier `user_id` de archivo.
 
 ## Related
 

--- a/docs/project/issues/CACH-B0005.md
+++ b/docs/project/issues/CACH-B0005.md
@@ -2,7 +2,7 @@
 id: CACH-B0005
 title: Importacion exportacion y portabilidad de datos
 type: feature
-status: in-progress
+status: review
 cycle: unassigned
 release: RELEASE-0.1.0-beta.7
 priority: p1
@@ -23,7 +23,7 @@ tags:
 
 ## Summary
 
-Crear garantías de portabilidad antes de beta: exportar todos los datos e importar desde CSV/Excel/Google Sheets o notas.
+Crear garantías de portabilidad antes de beta: exportar los datos operativos y ofrecer una importación CSV mínima, validada y explícitamente limitada.
 
 ## Context
 
@@ -36,30 +36,37 @@ Antes de pedir confianza a usuarios beta, Cachés debe permitir sacar sus datos 
 ## Proposed Solution
 
 - Exportación JSON/CSV de proyectos, eventos, ingresos y gastos.
-- Importación mínima CSV con mapeo de columnas.
+- Importación mínima CSV con plantilla fija y claves locales.
 - Validación de datos antes de persistir.
-- Estrategia clara para errores, duplicados y campos incompletos.
+- Estrategia clara para errores, duplicados, campos incompletos y guardado no atómico.
 
 ## Beta 7 Scope
 
-- Exportar datos propios de proyectos, eventos, ingresos y gastos.
-- Importar CSV básico validado antes de persistir.
+- Exportar datos operativos propios de proyectos, eventos, ingresos y gastos.
+- Importar CSV básico validado antes de persistir, sin prometer restore completo ni transacción multi-tabla.
 - Mantener `user_id` derivado de sesión autenticada, nunca del archivo.
-- Documentar límites de formato, duplicados y campos incompletos.
+- Usar `project_key` y `event_key` locales para relaciones; no aceptar UUIDs crudos del archivo.
+- Documentar límites de formato, duplicados, campos incompletos, tamaño y filas.
 - Dejar onboarding, invitaciones y analítica para [[CACH-B0006|CACH-B0006]].
+- Dejar Excel/XLSX, Google Sheets directo, notas libres, mapeo avanzado, importación idempotente y restore JSON fuera de Beta 7.
 
 ## Acceptance Criteria
 
-- [ ] Un usuario puede exportar sus datos completos.
-- [ ] Un usuario puede importar un CSV básico validado.
-- [ ] Los errores de importación se muestran antes de guardar.
-- [ ] La exportación no filtra datos de otros usuarios.
+- [x] Un usuario puede exportar sus datos operativos en JSON y CSV por entidad.
+- [x] Un usuario puede importar un CSV básico con plantilla fija, `project_key` y `event_key`.
+- [x] Los errores de importación se muestran antes de guardar.
+- [x] La exportación no filtra datos de otros usuarios.
+- [x] La importación rechaza `id`, `user_id`, `created_at`, `project_id` y `event_id` del archivo.
+- [x] La importación comunica que es create-only y no atómica.
+- [x] Exportación e importación CSV mitigan fórmulas de hoja de cálculo.
 
 ## Validation
 
-- Ejecutar `npm run test`, `npm run lint`, `npm run build` y `npm run pb:check`.
-- Smoke autenticado: exportar datos, importar CSV válido, importar CSV con errores y confirmar que no se persisten filas inválidas.
+- Ejecutado `npm run test`, `npm run lint`, `npm run build` y `npm run pb:check`.
+- Ejecutado `git diff --check`.
+- Smoke autenticado: exportar datos, importar CSV válido, importar CSV con errores y confirmar que no se guarda nada antes de validar.
 - Revisar que la importación ignora o rechaza cualquier `user_id` de archivo.
+- Revisar límites: 1 MB, 500 filas, columnas esperadas y errores acotados.
 
 ## Related
 

--- a/docs/project/plans/CURRENT_PLAN.md
+++ b/docs/project/plans/CURRENT_PLAN.md
@@ -16,19 +16,19 @@ tags:
 
 ## Foco actual
 
-Release activa: [[../releases/RELEASE-0.1.0-beta.6|RELEASE-0.1.0-beta.6]] — estabilización visual y mobile financiero.
+Release activa: [[../releases/RELEASE-0.1.0-beta.7|RELEASE-0.1.0-beta.7]] — portabilidad mínima de datos.
 
 ## Release activa
 
-[[../releases/RELEASE-0.1.0-beta.6|RELEASE-0.1.0-beta.6]]
+[[../releases/RELEASE-0.1.0-beta.7|RELEASE-0.1.0-beta.7]]
 
-Ultimo corte: [[../releases/RELEASE-0.1.0-beta.5|RELEASE-0.1.0-beta.5]] — mergeada a `main` el 2026-05-07.
+Ultimo corte preparado: [[../releases/RELEASE-0.1.0-beta.6|RELEASE-0.1.0-beta.6]] — PR #85 abierta el 2026-05-07 y pendiente de cierre final.
 
 ## Prioridades
 
-1. Ejecutar CACH-0030 y CACH-0038 desde `release/0.1.0-beta.6`.
+1. Ejecutar CACH-B0005 desde `release/0.1.0-beta.7`.
 2. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
-3. Dejar CACH-B0005 y CACH-B0006 como candidatas naturales para las siguientes betas, no para este corte visual/mobile.
+3. Dejar CACH-B0006 como candidata natural para la beta siguiente, no para este corte de portabilidad.
 
 ## Plan operativo
 
@@ -41,4 +41,4 @@ Ultimo corte: [[../releases/RELEASE-0.1.0-beta.5|RELEASE-0.1.0-beta.5]] — merg
 
 ## Próximo checkpoint
 
-Completar CACH-0030 y CACH-0038, validar la release y abrir PR única `release/0.1.0-beta.6` -> `main`.
+Partir CACH-B0005 en implementación verificable, validar exportación/importación y abrir PR única `release/0.1.0-beta.7` -> `main`.

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -16,27 +16,26 @@ tags:
 
 ## Release activa
 
-[[RELEASE-0.1.0-beta.6|RELEASE-0.1.0-beta.6]] — Estabilización visual y mobile financiero.
+[[RELEASE-0.1.0-beta.7|RELEASE-0.1.0-beta.7]] — Portabilidad mínima de datos.
 
 ## Rama activa
 
-`release/0.1.0-beta.6`
+`release/0.1.0-beta.7`
 
 ## Ultimo corte
 
-`RELEASE-0.1.0-beta.5` — mergeada a `main` en PR #84 el 2026-05-07. Ver [[RELEASE-0.1.0-beta.5]].
+`RELEASE-0.1.0-beta.6` — preparada en PR #85 el 2026-05-07 y pendiente de cierre final. Ver [[RELEASE-0.1.0-beta.6]].
 
 ## Scope actual
 
-- [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseño con nueva paleta de colores y fuentes.
-- [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables.
+- [[../issues/CACH-B0005|CACH-B0005]] — Importacion, exportacion y portabilidad de datos.
 
 ## Regla de trabajo para esta release
 
-Beta 6 usa rama de release activa y PR única a `main`.
+Beta 7 usa rama de release activa y PR única a `main`.
 
-Las ramas de tarea salen de `release/0.1.0-beta.6` y se integran con squash en la release. No añadir tareas fuera de CACH-0030/CACH-0038 sin actualizar primero el documento de release.
+Las ramas de tarea salen de `release/0.1.0-beta.7` y se integran con squash en la release. No añadir tareas fuera de CACH-B0005 sin actualizar primero el documento de release.
 
 ## Como cerrar esta release
 
-Abrir PR `release/0.1.0-beta.6` -> `main`, esperar CI en verde, mergear, crear tag `v0.1.0-beta.6` desde `main`, verificar producción si aplica y limpiar la rama remota de release.
+Abrir PR `release/0.1.0-beta.7` -> `main`, esperar CI en verde, mergear, crear tag `v0.1.0-beta.7` desde `main`, verificar producción si aplica y limpiar la rama remota de release.

--- a/docs/project/releases/RELEASE-0.1.0-beta.7.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.7.md
@@ -34,25 +34,27 @@ Active
 
 ## Objetivo de la release
 
-Dar al usuario una garantía básica de salida de datos antes de ampliar onboarding o acceso beta: exportar su información y validar una importación CSV mínima sin persistir datos incorrectos.
+Dar al usuario una garantía básica de salida de datos antes de ampliar onboarding o acceso beta: exportar sus datos operativos y validar una importación CSV mínima antes de guardar.
 
 Beta 7 debe mejorar confianza sin rediseñar el modelo de datos ni abrir todavía invitaciones, analítica o onboarding completo.
 
 ## Alcance funcional
 
-- Exportar datos propios de proyectos, eventos, ingresos y gastos.
-- Ofrecer una importación CSV mínima con validación previa.
+- Exportar datos operativos propios de proyectos, eventos, ingresos y gastos.
+- Ofrecer una importación CSV mínima con plantilla fija, claves locales y validación previa.
 - Mostrar errores de importación antes de guardar.
 - Mantener la separación por usuario y el uso de hooks existentes.
-- Documentar límites conocidos de formato, duplicados y campos incompletos.
+- Documentar límites conocidos de formato, duplicados, campos incompletos, tamaño, filas y guardado no atómico.
 
 ## Restricciones CACH-B0005
 
 - No usar service role ni saltarse RLS desde cliente.
 - No aceptar `user_id` editable ni importado desde archivo.
+- No aceptar `id`, `created_at`, `project_id` ni `event_id` desde CSV.
 - No cambiar schema Supabase salvo issue nueva y criterio explícito.
 - No mezclar portabilidad con onboarding, invitaciones o analítica.
 - No prometer compatibilidad completa con Excel/Google Sheets si la beta solo cubre CSV básico.
+- No prometer restore completo, importación idempotente ni transacción multi-tabla.
 
 ## Scope
 
@@ -62,7 +64,7 @@ Beta 7 debe mejorar confianza sin rediseñar el modelo de datos ni abrir todaví
 
 | Issue | Título | Estado | Rama |
 |---|---|---|---|
-| [[../issues/CACH-B0005|CACH-B0005]] | Importacion, exportacion y portabilidad de datos | In progress | `release/0.1.0-beta.7` |
+| [[../issues/CACH-B0005|CACH-B0005]] | Importacion, exportacion y portabilidad de datos | Review | `release/0.1.0-beta.7` |
 
 ## Fuera de alcance
 
@@ -70,12 +72,14 @@ Beta 7 debe mejorar confianza sin rediseñar el modelo de datos ni abrir todaví
 - Contratantes, facturación y liquidación neta de [[../issues/CACH-B0004|CACH-B0004]].
 - Calendario unificado, PWA/offline, notificaciones o features Pro.
 - Importadores avanzados con mapeo persistente, plantillas múltiples o sincronización con Google Sheets.
+- Excel/XLSX directo, notas libres, restore JSON, update/merge/idempotencia y RPC transaccional.
 
 ## Riesgos
 
-- La importación puede tocar contratos de datos sensibles; se mitiga manteniendo validación previa y `user_id` desde sesión autenticada.
+- La importación puede tocar contratos de datos sensibles; se mitiga manteniendo validación previa, `user_id` desde sesión autenticada y rechazo de UUIDs crudos.
 - Exportar datos incompletos puede generar falsa confianza; se mitiga enumerando claramente entidades incluidas y límites.
 - CSV puede crecer en complejidad si se intenta cubrir todos los formatos reales; se mitiga con una plantilla mínima verificable.
+- El guardado cliente no es atómico; se mitiga comunicándolo en UI y mostrando fallos parciales si ocurren tras validar.
 
 ## Decisiones relacionadas
 
@@ -99,13 +103,13 @@ Beta 7 debe mejorar confianza sin rediseñar el modelo de datos ni abrir todaví
 
 ## Checklist de estabilización
 
-- [ ] Build correcto
-- [ ] Tests/checks correctos (`npm run test`, `npm run lint`, `npm run build`, `npm run pb:check`, `git diff --check`)
+- [x] Build correcto
+- [x] Tests/checks correctos (`npm run test`, `npm run lint`, `npm run build`, `npm run pb:check`, `git diff --check`)
 - [ ] Revisión visual autenticada
 - [ ] Revisión responsive autenticada
 - [ ] Revisión accesibilidad
 - [ ] Revisión de regresión básica
-- [ ] Revisión de documentación
+- [x] Revisión de documentación
 
 ## Checklist de salida
 
@@ -117,7 +121,7 @@ Beta 7 debe mejorar confianza sin rediseñar el modelo de datos ni abrir todaví
 - [ ] Tag `v0.1.0-beta.7` creado desde `main`
 - [ ] Producción verificada si aplica
 - [ ] Rama remota `release/0.1.0-beta.7` eliminada
-- [ ] Release notes actualizadas
+- [x] Release notes actualizadas
 - [ ] Issues marcadas como `Released`
 - [ ] Estado actual actualizado
 - [ ] Current Release actualizado
@@ -128,24 +132,30 @@ Beta 7 debe mejorar confianza sin rediseñar el modelo de datos ni abrir todaví
 
 ### Añadido
 
-- Pendiente.
+- Página privada `Tus datos` enlazada desde Ajustes y la navegación principal.
+- Exportación de proyectos, eventos, ingresos y gastos en backup JSON y CSV por entidad.
+- Plantilla CSV descargable con ejemplos, claves locales `project_key`/`event_key`, previsualización y validación antes de guardar.
+- Importación CSV create-only, no atómica, con informe de guardado parcial si una escritura falla tras validar.
 
 ### Cambiado
 
-- Pendiente.
+- La portabilidad queda limitada a datos operativos; no incluye auth, email, restore JSON, Excel/XLSX ni sincronización externa.
 
 ### Corregido
 
-- Pendiente.
+- La importación rechaza cabeceras de ownership, IDs y FKs crudas del archivo.
+- Exportación e importación CSV mitigan fórmulas de hoja de cálculo.
 
 ### Eliminado
 
-- Pendiente.
+- No aplica.
 
 ### Técnico
 
-- Validación esperada: `npm run test`, `npm run lint`, `npm run build`, `npm run pb:check`, `git diff --check` y smoke autenticado de exportación/importación.
+- Validación ejecutada: `npm run test`, `npm run lint`, `npm run build`, `npm run pb:check` y `git diff --check`.
+- Pendiente de cierre: smoke autenticado de exportación/importación en `/data`.
+- E2E Playwright no cuenta como bloqueo mientras no exista seed/auth estable; la cobertura principal de esta beta vive en Vitest y smoke autenticado manual.
 
 ## Resultado final
 
-Pendiente hasta cerrar la release.
+Implementación de CACH-B0005 lista para PR de release. Queda pendiente smoke autenticado, CI, merge/tag y verificación final de producción si aplica.

--- a/docs/project/releases/RELEASE-0.1.0-beta.7.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.7.md
@@ -1,0 +1,151 @@
+---
+id: RELEASE-0.1.0-beta.7
+type: release
+status: Active
+created: 2026-05-07
+updated: 2026-05-07
+release_branch: release/0.1.0-beta.7
+release_tag: v0.1.0-beta.7
+aliases:
+  - RELEASE-0.1.0-beta.7
+tags:
+  - product-brain
+  - release
+  - beta
+---
+
+# RELEASE-0.1.0-beta.7 — Portabilidad mínima de datos
+
+## Estado
+
+Active
+
+## Rama de release
+
+`release/0.1.0-beta.7`
+
+## Tag
+
+`v0.1.0-beta.7`
+
+## Ciclo
+
+`0.1` es el ciclo organizativo. `0.1.0-beta.7` es un corte iterativo mergeable centrado en confianza de datos y portabilidad mínima.
+
+## Objetivo de la release
+
+Dar al usuario una garantía básica de salida de datos antes de ampliar onboarding o acceso beta: exportar su información y validar una importación CSV mínima sin persistir datos incorrectos.
+
+Beta 7 debe mejorar confianza sin rediseñar el modelo de datos ni abrir todavía invitaciones, analítica o onboarding completo.
+
+## Alcance funcional
+
+- Exportar datos propios de proyectos, eventos, ingresos y gastos.
+- Ofrecer una importación CSV mínima con validación previa.
+- Mostrar errores de importación antes de guardar.
+- Mantener la separación por usuario y el uso de hooks existentes.
+- Documentar límites conocidos de formato, duplicados y campos incompletos.
+
+## Restricciones CACH-B0005
+
+- No usar service role ni saltarse RLS desde cliente.
+- No aceptar `user_id` editable ni importado desde archivo.
+- No cambiar schema Supabase salvo issue nueva y criterio explícito.
+- No mezclar portabilidad con onboarding, invitaciones o analítica.
+- No prometer compatibilidad completa con Excel/Google Sheets si la beta solo cubre CSV básico.
+
+## Scope
+
+- [[../issues/CACH-B0005|CACH-B0005]] — Importacion, exportacion y portabilidad de datos.
+
+## Issues incluidas
+
+| Issue | Título | Estado | Rama |
+|---|---|---|---|
+| [[../issues/CACH-B0005|CACH-B0005]] | Importacion, exportacion y portabilidad de datos | In progress | `release/0.1.0-beta.7` |
+
+## Fuera de alcance
+
+- Onboarding, invitaciones, consentimiento de analítica y acceso beta de [[../issues/CACH-B0006|CACH-B0006]].
+- Contratantes, facturación y liquidación neta de [[../issues/CACH-B0004|CACH-B0004]].
+- Calendario unificado, PWA/offline, notificaciones o features Pro.
+- Importadores avanzados con mapeo persistente, plantillas múltiples o sincronización con Google Sheets.
+
+## Riesgos
+
+- La importación puede tocar contratos de datos sensibles; se mitiga manteniendo validación previa y `user_id` desde sesión autenticada.
+- Exportar datos incompletos puede generar falsa confianza; se mitiga enumerando claramente entidades incluidas y límites.
+- CSV puede crecer en complejidad si se intenta cubrir todos los formatos reales; se mitiga con una plantilla mínima verificable.
+
+## Decisiones relacionadas
+
+- [[../decisions/ADR-0002-beta-trust-before-pro|ADR-0002]]
+
+## Checklist de entrada
+
+- [x] Release creada
+- [x] Rama de release creada
+- [x] Issues asociadas
+- [x] Alcance definido
+- [x] Criterios de validación definidos
+
+## Checklist de desarrollo
+
+- [ ] Todas las issues están en progreso o cerradas
+- [ ] Commits integrados en rama release
+- [ ] No hay cambios sueltos fuera de release
+- [ ] No hay issues sin estado
+- [ ] No hay decisiones importantes sin documentar
+
+## Checklist de estabilización
+
+- [ ] Build correcto
+- [ ] Tests/checks correctos (`npm run test`, `npm run lint`, `npm run build`, `npm run pb:check`, `git diff --check`)
+- [ ] Revisión visual autenticada
+- [ ] Revisión responsive autenticada
+- [ ] Revisión accesibilidad
+- [ ] Revisión de regresión básica
+- [ ] Revisión de documentación
+
+## Checklist de salida
+
+- [ ] PR `release/0.1.0-beta.7` -> `main` abierta
+- [ ] CI en verde
+- [ ] Revisión aprobada
+- [ ] PR mergeada en `main`
+- [ ] `main` actualizado en local
+- [ ] Tag `v0.1.0-beta.7` creado desde `main`
+- [ ] Producción verificada si aplica
+- [ ] Rama remota `release/0.1.0-beta.7` eliminada
+- [ ] Release notes actualizadas
+- [ ] Issues marcadas como `Released`
+- [ ] Estado actual actualizado
+- [ ] Current Release actualizado
+- [ ] Backlog actualizado
+- [ ] Documento de release actualizado como cerrado
+
+## Release notes
+
+### Añadido
+
+- Pendiente.
+
+### Cambiado
+
+- Pendiente.
+
+### Corregido
+
+- Pendiente.
+
+### Eliminado
+
+- Pendiente.
+
+### Técnico
+
+- Validación esperada: `npm run test`, `npm run lint`, `npm run build`, `npm run pb:check`, `git diff --check` y smoke autenticado de exportación/importación.
+
+## Resultado final
+
+Pendiente hasta cerrar la release.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import ProjectList from './pages/Projects/ProjectList'
 import ProjectDetail from './pages/Projects/ProjectDetail'
 import Work from './pages/Work/Work'
 import Settings from './pages/Settings/Settings'
+import Data from './pages/Data/Data'
 
 function PrivateRoute({ children }) {
   const { user, loading } = useAuth()
@@ -43,6 +44,7 @@ export default function App() {
         <Route path="/projects/:id" element={<PrivateRoute><ProjectDetail /></PrivateRoute>} />
         <Route path="/work" element={<PrivateRoute><Work /></PrivateRoute>} />
         <Route path="/settings" element={<PrivateRoute><Settings /></PrivateRoute>} />
+        <Route path="/data" element={<PrivateRoute><Data /></PrivateRoute>} />
         <Route path="/calendar" element={<Navigate to="/calendar/events" replace />} />
         <Route path="*" element={<Navigate to="/dashboard" replace />} />
       </Routes>

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,11 +1,12 @@
 import { NavLink, useLocation } from 'react-router-dom'
-import { Drama, LayoutDashboard, CalendarDays, CalendarRange, Briefcase, Settings } from 'lucide-react'
+import { Database, Drama, LayoutDashboard, CalendarDays, CalendarRange, Briefcase, Settings } from 'lucide-react'
 
 const navItems = [
   { to: '/work', icon: Briefcase, label: 'Trabajos', activePaths: ['/work', '/projects', '/events'] },
   { to: '/dashboard', icon: LayoutDashboard, label: 'Dashboard' },
   { to: '/calendar/events', icon: CalendarDays, label: 'Cal. eventos' },
   { to: '/calendar/projects', icon: CalendarRange, label: 'Cal. proyectos' },
+  { to: '/data', icon: Database, label: 'Tus datos' },
   { to: '/settings', icon: Settings, label: 'Ajustes' },
 ]
 

--- a/src/hooks/useDataPortability.js
+++ b/src/hooks/useDataPortability.js
@@ -1,0 +1,180 @@
+import { useCallback, useState } from 'react'
+import { supabase } from '../supabaseClient'
+import {
+  buildBackupJson,
+  buildCsvFiles,
+  buildExportSummary,
+  hasImportErrors,
+  validateCsvImport,
+} from '../lib/portability/index.ts'
+
+function portabilityError(message) {
+  return { message }
+}
+
+function emptyInserted() {
+  return { projects: 0, events: 0, incomes: 0, expenses: 0 }
+}
+
+export async function exportPortableData(client, userId) {
+  if (!userId) return { data: null, error: portabilityError('Necesitas una sesión activa para exportar datos.') }
+
+  try {
+    const [projectsResult, eventsResult, incomesResult, expensesResult] = await Promise.all([
+      client.from('projects').select('*').eq('user_id', userId).order('start_date', { ascending: true }),
+      client.from('events').select('*').eq('user_id', userId).order('start_datetime', { ascending: true }),
+      client.from('incomes').select('*').eq('user_id', userId).order('expected_date', { ascending: true }),
+      client.from('expenses').select('*').eq('user_id', userId).order('expense_date', { ascending: true }),
+    ])
+
+    const firstError = [projectsResult, eventsResult, incomesResult, expensesResult].find((result) => result.error)?.error
+    if (firstError) return { data: null, error: firstError }
+
+    const entities = {
+      projects: projectsResult.data ?? [],
+      events: eventsResult.data ?? [],
+      incomes: incomesResult.data ?? [],
+      expenses: expensesResult.data ?? [],
+    }
+
+    return {
+      data: {
+        backupJson: buildBackupJson(entities),
+        csvFiles: buildCsvFiles(entities),
+        summary: buildExportSummary(entities),
+      },
+      error: null,
+    }
+  } catch (error) {
+    return { data: null, error }
+  }
+}
+
+export async function commitPortableImport(client, userId, preview) {
+  if (!userId) return { data: null, error: portabilityError('Necesitas una sesión activa para importar datos.') }
+  if (hasImportErrors(preview)) {
+    return { data: { inserted: emptyInserted(), failures: [] }, error: portabilityError('Corrige los errores del CSV antes de importar.') }
+  }
+
+  const inserted = emptyInserted()
+  const failures = []
+  const projectIds = new Map()
+  const eventIds = new Map()
+
+  try {
+    for (const project of preview.projects) {
+      const { data, error } = await client
+        .from('projects')
+        .insert({ ...project.payload, user_id: userId })
+        .select('id')
+        .single()
+
+      if (error) {
+        failures.push({ row: project.row, entity: 'project', error })
+      } else {
+        inserted.projects += 1
+        projectIds.set(project.key, data.id)
+      }
+    }
+
+    for (const event of preview.events) {
+      const projectId = event.project_key ? projectIds.get(event.project_key) : null
+      if (event.project_key && !projectId) {
+        failures.push({ row: event.row, entity: 'event', error: portabilityError('No se ha podido resolver el proyecto importado.') })
+        continue
+      }
+
+      const { data, error } = await client
+        .from('events')
+        .insert({ ...event.payload, project_id: projectId, user_id: userId })
+        .select('id')
+        .single()
+
+      if (error) {
+        failures.push({ row: event.row, entity: 'event', error })
+      } else {
+        inserted.events += 1
+        eventIds.set(event.key, data.id)
+      }
+    }
+
+    for (const income of preview.incomes) {
+      const projectId = income.link.type === 'project' ? projectIds.get(income.link.key) : null
+      const eventId = income.link.type === 'event' ? eventIds.get(income.link.key) : null
+      if ((income.link.type === 'project' && !projectId) || (income.link.type === 'event' && !eventId)) {
+        failures.push({ row: income.row, entity: 'income', error: portabilityError('No se ha podido resolver el vínculo importado.') })
+        continue
+      }
+
+      const { error } = await client
+        .from('incomes')
+        .insert({ ...income.payload, project_id: projectId, event_id: eventId, user_id: userId })
+
+      if (error) failures.push({ row: income.row, entity: 'income', error })
+      else inserted.incomes += 1
+    }
+
+    for (const expense of preview.expenses) {
+      const projectId = expense.link.type === 'project' ? projectIds.get(expense.link.key) : null
+      const eventId = expense.link.type === 'event' ? eventIds.get(expense.link.key) : null
+      if ((expense.link.type === 'project' && !projectId) || (expense.link.type === 'event' && !eventId)) {
+        failures.push({ row: expense.row, entity: 'expense', error: portabilityError('No se ha podido resolver el vínculo importado.') })
+        continue
+      }
+
+      const { error } = await client
+        .from('expenses')
+        .insert({ ...expense.payload, project_id: projectId, event_id: eventId, user_id: userId })
+
+      if (error) failures.push({ row: expense.row, entity: 'expense', error })
+      else inserted.expenses += 1
+    }
+
+    return {
+      data: { inserted, failures },
+      error: failures.length > 0 ? portabilityError('La importación terminó con errores en algunas filas.') : null,
+    }
+  } catch (error) {
+    return { data: { inserted, failures }, error }
+  }
+}
+
+export function useDataPortability(userId) {
+  const [exporting, setExporting] = useState(false)
+  const [importing, setImporting] = useState(false)
+  const loading = exporting || importing
+
+  const exportData = useCallback(async () => {
+    setExporting(true)
+    try {
+      return await exportPortableData(supabase, userId)
+    } finally {
+      setExporting(false)
+    }
+  }, [userId])
+
+  const validateImportFile = useCallback(async (file) => {
+    if (!file) return { preview: null, error: portabilityError('Selecciona un archivo CSV.') }
+    if (file.size > 1024 * 1024) {
+      return { preview: null, error: portabilityError('El archivo supera el límite de 1 MB.') }
+    }
+
+    try {
+      const text = await file.text()
+      return validateCsvImport(text, { fileSize: file.size })
+    } catch (error) {
+      return { preview: null, error }
+    }
+  }, [])
+
+  const commitImport = useCallback(async (preview) => {
+    setImporting(true)
+    try {
+      return await commitPortableImport(supabase, userId, preview)
+    } finally {
+      setImporting(false)
+    }
+  }, [userId])
+
+  return { loading, exporting, importing, exportData, validateImportFile, commitImport }
+}

--- a/src/hooks/useDataPortability.test.ts
+++ b/src/hooks/useDataPortability.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../supabaseClient', () => ({ supabase: {} }))
+
+const { commitPortableImport, exportPortableData } = await import('./useDataPortability.js')
+
+function createExportClient(rowsByTable = {}) {
+  const calls = []
+
+  return {
+    calls,
+    from(table) {
+      const chain = {
+        select(columns) {
+          calls.push({ table, method: 'select', columns })
+          return chain
+        },
+        eq(column, value) {
+          calls.push({ table, method: 'eq', column, value })
+          return chain
+        },
+        order(column, options) {
+          calls.push({ table, method: 'order', column, options })
+          return Promise.resolve({ data: rowsByTable[table] ?? [], error: null })
+        },
+      }
+      return chain
+    },
+  }
+}
+
+function createImportClient() {
+  const inserts = []
+  const ids = { projects: 0, events: 0 }
+
+  return {
+    inserts,
+    from(table) {
+      return {
+        insert(payload) {
+          inserts.push({ table, payload })
+
+          if (table === 'projects' || table === 'events') {
+            ids[table] += 1
+            const id = `${table}-${ids[table]}`
+            return {
+              select(columns) {
+                return {
+                  async single() {
+                    return { data: { id, columns }, error: null }
+                  },
+                }
+              },
+            }
+          }
+
+          return Promise.resolve({ error: null })
+        },
+      }
+    },
+  }
+}
+
+describe('data portability Supabase contract', () => {
+  it('exporta cada entidad filtrando siempre por user_id autenticado', async () => {
+    const client = createExportClient({
+      projects: [{ id: 'p1', user_id: 'u1', name: 'Proyecto' }],
+      events: [{ id: 'e1', user_id: 'u1', name: 'Evento' }],
+      incomes: [{ id: 'i1', user_id: 'u1', amount: 100 }],
+      expenses: [{ id: 'x1', user_id: 'u1', amount: 10 }],
+    })
+
+    const { data, error } = await exportPortableData(client, 'auth-user')
+
+    expect(error).toBeNull()
+    expect(data.summary).toEqual({ projects: 1, events: 1, incomes: 1, expenses: 1 })
+    expect(client.calls.filter((call) => call.method === 'eq')).toEqual([
+      { table: 'projects', method: 'eq', column: 'user_id', value: 'auth-user' },
+      { table: 'events', method: 'eq', column: 'user_id', value: 'auth-user' },
+      { table: 'incomes', method: 'eq', column: 'user_id', value: 'auth-user' },
+      { table: 'expenses', method: 'eq', column: 'user_id', value: 'auth-user' },
+    ])
+  })
+
+  it('importa create-only sobreescribiendo ownership y resolviendo claves locales', async () => {
+    const client = createImportClient()
+    const preview = {
+      valid: true,
+      errors: [],
+      hiddenErrorCount: 0,
+      projects: [{
+        row: 2,
+        key: 'p1',
+        payload: {
+          name: 'Proyecto',
+          start_date: '2026-05-01',
+          user_id: 'csv-user',
+        },
+      }],
+      events: [{
+        row: 3,
+        key: 'e1',
+        project_key: 'p1',
+        payload: {
+          name: 'Evento',
+          start_datetime: '2026-05-02T06:00:00.000Z',
+          project_id: 'raw-project-id',
+          user_id: 'csv-user',
+        },
+      }],
+      incomes: [{
+        row: 4,
+        link: { type: 'event', key: 'e1' },
+        payload: {
+          concept: 'Caché',
+          amount: 100,
+          project_id: 'raw-project-id',
+          event_id: 'raw-event-id',
+          user_id: 'csv-user',
+        },
+      }],
+      expenses: [{
+        row: 5,
+        link: { type: 'project', key: 'p1' },
+        payload: {
+          concept: 'Material',
+          amount: 10,
+          project_id: 'raw-project-id',
+          event_id: 'raw-event-id',
+          user_id: 'csv-user',
+        },
+      }],
+    }
+
+    const { data, error } = await commitPortableImport(client, 'auth-user', preview)
+
+    expect(error).toBeNull()
+    expect(data.inserted).toEqual({ projects: 1, events: 1, incomes: 1, expenses: 1 })
+    expect(client.inserts).toEqual([
+      {
+        table: 'projects',
+        payload: expect.objectContaining({ name: 'Proyecto', user_id: 'auth-user' }),
+      },
+      {
+        table: 'events',
+        payload: expect.objectContaining({ name: 'Evento', project_id: 'projects-1', user_id: 'auth-user' }),
+      },
+      {
+        table: 'incomes',
+        payload: expect.objectContaining({ concept: 'Caché', project_id: null, event_id: 'events-1', user_id: 'auth-user' }),
+      },
+      {
+        table: 'expenses',
+        payload: expect.objectContaining({ concept: 'Material', project_id: 'projects-1', event_id: null, user_id: 'auth-user' }),
+      },
+    ])
+  })
+})

--- a/src/lib/portability/csv.test.ts
+++ b/src/lib/portability/csv.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { escapeFormulaText, isFormulaLike, parseCsv, serializeCsv } from './csv'
+
+describe('parseCsv', () => {
+  it('parsea punto y coma, comillas, BOM, CRLF y campos multilínea', () => {
+    const csv = '\uFEFFname;notes\r\n"Proyecto; especial";"Línea 1\r\nLínea ""dos"""\r\n'
+
+    const parsed = parseCsv(csv)
+
+    expect(parsed.headers).toEqual(['name', 'notes'])
+    expect(parsed.rows).toHaveLength(1)
+    expect(parsed.rows[0].values).toEqual(['Proyecto; especial', 'Línea 1\nLínea "dos"'])
+  })
+})
+
+describe('serializeCsv', () => {
+  it('escapa punto y coma, comillas y saltos de línea', () => {
+    const csv = serializeCsv(['name', 'notes'], [
+      { name: 'Proyecto; especial', notes: 'Línea 1\nLínea "dos"' },
+    ])
+
+    expect(csv).toBe('name;notes\r\n"Proyecto; especial";"Línea 1\nLínea ""dos"""\r\n')
+  })
+
+  it('protege textos con aspecto de fórmula en exportación', () => {
+    expect(isFormulaLike(' =1+1')).toBe(true)
+    expect(isFormulaLike('\tSUM(A1:A2)')).toBe(true)
+    expect(escapeFormulaText('-10')).toBe("'-10")
+    expect(serializeCsv(['name'], [{ name: '@usuario' }])).toContain("'@usuario")
+  })
+})

--- a/src/lib/portability/csv.ts
+++ b/src/lib/portability/csv.ts
@@ -1,0 +1,112 @@
+export const CSV_DELIMITER = ';'
+
+export type CsvRow = {
+  rowNumber: number
+  values: string[]
+}
+
+export type CsvParseResult = {
+  headers: string[]
+  rows: CsvRow[]
+}
+
+export function isFormulaLike(value: unknown): boolean {
+  const raw = String(value ?? '')
+  if (raw.startsWith('\t') || raw.startsWith('\r')) return true
+  return /^[=+\-@]/.test(raw.trimStart())
+}
+
+export function escapeFormulaText(value: unknown): string {
+  const raw = String(value ?? '')
+  return isFormulaLike(raw) ? `'${raw}` : raw
+}
+
+export function parseCsv(text: string): CsvParseResult {
+  const input = String(text ?? '').replace(/^\uFEFF/, '')
+  const records: string[][] = []
+  let field = ''
+  let record: string[] = []
+  let inQuotes = false
+  let line = 1
+
+  const pushRecord = () => {
+    record.push(field)
+    field = ''
+    records.push(record)
+    record = []
+  }
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i]
+    const next = input[i + 1]
+
+    if (inQuotes) {
+      if (char === '"' && next === '"') {
+        field += '"'
+        i += 1
+      } else if (char === '"') {
+        inQuotes = false
+      } else {
+        if (char === '\n') line += 1
+        if (char === '\r') {
+          line += 1
+          if (next === '\n') i += 1
+          field += '\n'
+        } else {
+          field += char
+        }
+      }
+      continue
+    }
+
+    if (char === '"' && field === '') {
+      inQuotes = true
+    } else if (char === CSV_DELIMITER) {
+      record.push(field)
+      field = ''
+    } else if (char === '\n') {
+      pushRecord()
+      line += 1
+    } else if (char === '\r') {
+      pushRecord()
+      line += 1
+      if (next === '\n') i += 1
+    } else {
+      field += char
+    }
+  }
+
+  if (field !== '' || record.length > 0 || input.length > 0) {
+    record.push(field)
+    records.push(record)
+  }
+
+  while (records.length > 0 && records[records.length - 1].every((cell) => cell === '')) {
+    records.pop()
+  }
+
+  const [headers = [], ...dataRows] = records
+  return {
+    headers,
+    rows: dataRows.map((values, index) => ({
+      rowNumber: index + 2,
+      values,
+    })),
+  }
+}
+
+function serializeCell(value: unknown): string {
+  const raw = escapeFormulaText(value)
+  if (raw.includes(CSV_DELIMITER) || raw.includes('"') || raw.includes('\n') || raw.includes('\r')) {
+    return `"${raw.replace(/"/g, '""')}"`
+  }
+  return raw
+}
+
+export function serializeCsv(headers: string[], rows: Record<string, unknown>[]): string {
+  const lines = [
+    headers.map(serializeCell).join(CSV_DELIMITER),
+    ...rows.map((row) => headers.map((header) => serializeCell(row[header])).join(CSV_DELIMITER)),
+  ]
+  return `${lines.join('\r\n')}\r\n`
+}

--- a/src/lib/portability/exportData.test.ts
+++ b/src/lib/portability/exportData.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { buildBackupJson, buildCsvFiles, buildExportSummary } from './exportData'
+
+describe('export portability helpers', () => {
+  it('crea backup JSON sin user_id y con ids de fila', () => {
+    const backup = JSON.parse(buildBackupJson({
+      projects: [{ id: 'p1', user_id: 'u1', name: 'Proyecto', start_date: '2026-05-01' }],
+      events: [],
+      incomes: [],
+      expenses: [],
+    }, new Date('2026-05-07T10:00:00.000Z')))
+
+    expect(backup.version).toBe(1)
+    expect(backup.exported_at).toBe('2026-05-07T10:00:00.000Z')
+    expect(backup.entities.projects[0]).toEqual({ id: 'p1', name: 'Proyecto', start_date: '2026-05-01' })
+  })
+
+  it('crea CSVs por entidad sin user_id y con texto formula-safe', () => {
+    const csvFiles = buildCsvFiles({
+      projects: [{ id: 'p1', user_id: 'u1', name: '+Proyecto', start_date: '2026-05-01' }],
+      events: [{ id: 'e1', user_id: 'u1', project_id: 'p1', name: 'Evento', start_datetime: '2026-05-10T06:00:00.000Z' }],
+      incomes: [{ id: 'i1', user_id: 'u1', event_id: 'e1', concept: 'Caché', amount: 100 }],
+      expenses: [{ id: 'x1', user_id: 'u1', project_id: 'p1', concept: 'Material', amount: 10 }],
+    })
+
+    expect(csvFiles.projects.content).not.toContain('user_id')
+    expect(csvFiles.projects.content).toContain("'+Proyecto")
+    expect(csvFiles.events.content).toContain('project_id')
+    expect(csvFiles.incomes.content).toContain('event_id')
+  })
+
+  it('resume recuentos por entidad', () => {
+    expect(buildExportSummary({
+      projects: [{ id: 'p1' }],
+      events: [{ id: 'e1' }, { id: 'e2' }],
+      incomes: [],
+      expenses: [{ id: 'x1' }],
+    })).toEqual({ projects: 1, events: 2, incomes: 0, expenses: 1 })
+  })
+})

--- a/src/lib/portability/exportData.ts
+++ b/src/lib/portability/exportData.ts
@@ -1,0 +1,118 @@
+import { serializeCsv } from './csv'
+
+export const BACKUP_VERSION = 1
+
+export const PROJECT_CSV_HEADERS = [
+  'id',
+  'name',
+  'client',
+  'category',
+  'status',
+  'start_date',
+  'end_date',
+  'color',
+  'notes',
+  'created_at',
+] as const
+
+export const EVENT_CSV_HEADERS = [
+  'id',
+  'project_id',
+  'name',
+  'client',
+  'category',
+  'status',
+  'start_datetime',
+  'end_datetime',
+  'color',
+  'notes',
+  'created_at',
+] as const
+
+export const INCOME_CSV_HEADERS = [
+  'id',
+  'project_id',
+  'event_id',
+  'concept',
+  'amount',
+  'tax_rate',
+  'expected_date',
+  'paid_date',
+  'is_paid',
+  'created_at',
+] as const
+
+export const EXPENSE_CSV_HEADERS = [
+  'id',
+  'project_id',
+  'event_id',
+  'concept',
+  'amount',
+  'category',
+  'expense_date',
+  'is_deductible',
+  'created_at',
+] as const
+
+type EntityRows = {
+  projects: Record<string, unknown>[]
+  events: Record<string, unknown>[]
+  incomes: Record<string, unknown>[]
+  expenses: Record<string, unknown>[]
+}
+
+function withoutUserId(row: Record<string, unknown>): Record<string, unknown> {
+  const { user_id: _userId, ...rest } = row
+  return rest
+}
+
+function pick(headers: readonly string[], row: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(headers.map((header) => [header, row[header] ?? '']))
+}
+
+export function buildBackupJson(entities: EntityRows, exportedAt = new Date()): string {
+  return JSON.stringify({
+    version: BACKUP_VERSION,
+    exported_at: exportedAt.toISOString(),
+    entities: {
+      projects: entities.projects.map(withoutUserId),
+      events: entities.events.map(withoutUserId),
+      incomes: entities.incomes.map(withoutUserId),
+      expenses: entities.expenses.map(withoutUserId),
+    },
+  }, null, 2)
+}
+
+export function buildCsvFiles(entities: EntityRows) {
+  return {
+    projects: {
+      filename: 'caches-projects.csv',
+      headers: [...PROJECT_CSV_HEADERS],
+      content: serializeCsv([...PROJECT_CSV_HEADERS], entities.projects.map((row) => pick(PROJECT_CSV_HEADERS, row))),
+    },
+    events: {
+      filename: 'caches-events.csv',
+      headers: [...EVENT_CSV_HEADERS],
+      content: serializeCsv([...EVENT_CSV_HEADERS], entities.events.map((row) => pick(EVENT_CSV_HEADERS, row))),
+    },
+    incomes: {
+      filename: 'caches-incomes.csv',
+      headers: [...INCOME_CSV_HEADERS],
+      content: serializeCsv([...INCOME_CSV_HEADERS], entities.incomes.map((row) => pick(INCOME_CSV_HEADERS, row))),
+    },
+    expenses: {
+      filename: 'caches-expenses.csv',
+      headers: [...EXPENSE_CSV_HEADERS],
+      content: serializeCsv([...EXPENSE_CSV_HEADERS], entities.expenses.map((row) => pick(EXPENSE_CSV_HEADERS, row))),
+    },
+  }
+}
+
+export function buildExportSummary(entities: EntityRows) {
+  return {
+    projects: entities.projects.length,
+    events: entities.events.length,
+    incomes: entities.incomes.length,
+    expenses: entities.expenses.length,
+  }
+}

--- a/src/lib/portability/importValidation.test.ts
+++ b/src/lib/portability/importValidation.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import { IMPORT_HEADERS, MAX_DISPLAYED_ERRORS, validateCsvImport } from './importValidation'
+
+function csvRow(values: Record<string, string> = {}) {
+  return IMPORT_HEADERS.map((header) => values[header] ?? '').join(';')
+}
+
+function importCsv(rows: string[]) {
+  return `${IMPORT_HEADERS.join(';')}\n${rows.join('\n')}\n`
+}
+
+describe('validateCsvImport', () => {
+  it('genera un preview válido con payloads saneados y fechas Madrid en ISO UTC', () => {
+    const { preview, error } = validateCsvImport(importCsv([
+      csvRow({
+        entity: 'project',
+        project_key: 'p1',
+        name: '  Proyecto  ',
+        start_date: '2026-05-01',
+        end_date: '2026-05-20',
+      }),
+      csvRow({
+        entity: 'event',
+        project_key: 'p1',
+        event_key: 'e1',
+        name: 'Evento',
+        start_datetime: '2026-05-16 22:00',
+        end_datetime: '2026-05-16 23:30',
+      }),
+      csvRow({
+        entity: 'income',
+        event_key: 'e1',
+        concept: 'Caché',
+        amount: '1.234,56',
+        tax_rate: '15,5',
+        expected_date: '2026-05-30',
+        is_paid: 'sí',
+      }),
+      csvRow({
+        entity: 'expense',
+        project_key: 'p1',
+        concept: 'Transporte',
+        amount: '45,10',
+        expense_date: '2026-05-12',
+        is_deductible: 'no',
+      }),
+    ]))
+
+    expect(error).toBeNull()
+    expect(preview.valid).toBe(true)
+    expect(preview.summary).toEqual({ project: 1, event: 1, income: 1, expense: 1 })
+    expect(preview.projects[0].payload).not.toHaveProperty('user_id')
+    expect(preview.events[0].payload.start_datetime).toBe('2026-05-16T20:00:00.000Z')
+    expect(preview.incomes[0].payload.amount).toBe(1234.56)
+    expect(preview.incomes[0].payload.tax_rate).toBe(15.5)
+    expect(preview.incomes[0]).not.toHaveProperty('project_id')
+    expect(preview.expenses[0].payload.is_deductible).toBe(false)
+  })
+
+  it('rechaza cabeceras prohibidas antes de planificar filas', () => {
+    const headers = [...IMPORT_HEADERS, 'id'].join(';')
+    const { preview, error } = validateCsvImport(`${headers}\n${csvRow({ entity: 'project', project_key: 'p1', name: 'Proyecto', start_date: '2026-05-01' })};raw-id\n`)
+
+    expect(error?.message).toContain('plantilla')
+    expect(preview.valid).toBe(false)
+    expect(preview.errors.some((item) => item.column === 'id')).toBe(true)
+    expect(preview.projects).toHaveLength(0)
+  })
+
+  it('rechaza valores con aspecto de fórmula en importación', () => {
+    const { preview, error } = validateCsvImport(importCsv([
+      csvRow({
+        entity: 'project',
+        project_key: 'p1',
+        name: '=IMPORTXML("https://example.com")',
+        start_date: '2026-05-01',
+      }),
+    ]))
+
+    expect(error).toBeTruthy()
+    expect(preview.valid).toBe(false)
+    expect(preview.errors[0].message).toContain('fórmulas')
+  })
+
+  it('valida claves únicas y relaciones sin aceptar FKs crudas', () => {
+    const { preview } = validateCsvImport(importCsv([
+      csvRow({ entity: 'project', project_key: 'p1', name: 'Uno', start_date: '2026-05-01' }),
+      csvRow({ entity: 'project', project_key: 'p1', name: 'Dos', start_date: '2026-05-02' }),
+      csvRow({ entity: 'event', event_key: 'e1', project_key: 'missing', name: 'Evento', start_datetime: '2026-05-10 08:00' }),
+      csvRow({ entity: 'income', project_key: 'p1', event_key: 'e1', concept: 'Caché', amount: '100' }),
+      csvRow({ entity: 'expense', project_key: '00000000-0000-0000-0000-000000000000', concept: 'Gasto', amount: '10' }),
+    ]))
+
+    expect(preview.valid).toBe(false)
+    expect(preview.errors.some((item) => item.message.includes('duplicado'))).toBe(true)
+    expect(preview.errors.some((item) => item.message.includes('exactamente un'))).toBe(true)
+    expect(preview.errors.some((item) => item.message.includes('00000000-0000-0000-0000-000000000000'))).toBe(true)
+  })
+
+  it('rechaza fechas, datetimes y decimales inválidos', () => {
+    const { preview } = validateCsvImport(importCsv([
+      csvRow({ entity: 'project', project_key: 'p1', name: 'Proyecto', start_date: '2026-02-30' }),
+      csvRow({ entity: 'event', event_key: 'e1', name: 'Evento', start_datetime: '2026-05-10T08:00' }),
+      csvRow({ entity: 'income', project_key: 'p1', concept: 'Caché', amount: '0', tax_rate: '120' }),
+    ]))
+
+    expect(preview.valid).toBe(false)
+    expect(preview.errors.some((item) => item.column === 'start_date')).toBe(true)
+    expect(preview.errors.some((item) => item.column === 'start_datetime')).toBe(true)
+    expect(preview.errors.some((item) => item.column === 'amount')).toBe(true)
+    expect(preview.errors.some((item) => item.column === 'tax_rate')).toBe(true)
+  })
+
+  it('aplica límites de tamaño, filas, columnas, celda y errores visibles', () => {
+    const tooLarge = validateCsvImport(importCsv([]), { fileSize: 1024 * 1024 + 1 })
+    expect(tooLarge.error?.message).toContain('1 MB')
+
+    const tooManyRows = validateCsvImport(importCsv(Array.from({ length: 501 }, (_, index) =>
+      csvRow({ entity: 'project', project_key: `p${index}`, name: 'Proyecto', start_date: '2026-05-01' }),
+    )))
+    expect(tooManyRows.error?.message).toContain('500')
+
+    const manyFormulaRows = validateCsvImport(importCsv(Array.from({ length: MAX_DISPLAYED_ERRORS + 5 }, (_, index) =>
+      csvRow({ entity: 'project', project_key: `p${index}`, name: '=x', start_date: '2026-05-01' }),
+    )))
+    expect(manyFormulaRows.preview.errors).toHaveLength(MAX_DISPLAYED_ERRORS)
+    expect(manyFormulaRows.preview.hiddenErrorCount).toBeGreaterThan(0)
+
+    const longCell = validateCsvImport(importCsv([
+      csvRow({ entity: 'project', project_key: 'p1', name: 'x'.repeat(5001), start_date: '2026-05-01' }),
+    ]))
+    expect(longCell.preview.errors.some((item) => item.message.includes('5000'))).toBe(true)
+
+    const headers = [...IMPORT_HEADERS, ...Array.from({ length: 10 }, (_, index) => `extra_${index}`)]
+    const tooManyColumns = validateCsvImport(`${headers.join(';')}\n${headers.map(() => '').join(';')}\n`)
+    expect(tooManyColumns.preview.errors.some((item) => item.message.includes('30 columnas'))).toBe(true)
+  })
+})

--- a/src/lib/portability/importValidation.ts
+++ b/src/lib/portability/importValidation.ts
@@ -1,0 +1,512 @@
+import { parseDecimal } from '../decimal'
+import { DEFAULT_TZ, fromLocalInputValue, toIsoUtc } from '../datetime'
+import { isFormulaLike, parseCsv } from './csv'
+
+export const IMPORT_HEADERS = [
+  'entity',
+  'project_key',
+  'event_key',
+  'concept',
+  'name',
+  'client',
+  'category',
+  'status',
+  'start_date',
+  'end_date',
+  'start_datetime',
+  'end_datetime',
+  'amount',
+  'tax_rate',
+  'expected_date',
+  'paid_date',
+  'is_paid',
+  'expense_date',
+  'is_deductible',
+  'color',
+  'notes',
+] as const
+
+export const FORBIDDEN_IMPORT_HEADERS = ['id', 'user_id', 'created_at', 'project_id', 'event_id'] as const
+export const MAX_IMPORT_BYTES = 1024 * 1024
+export const MAX_IMPORT_ROWS = 500
+export const MAX_IMPORT_COLUMNS = 30
+export const MAX_IMPORT_CELL_LENGTH = 5000
+export const MAX_DISPLAYED_ERRORS = 100
+
+type Entity = 'project' | 'event' | 'income' | 'expense'
+
+export type ImportError = {
+  row: number
+  column?: string
+  message: string
+}
+
+export type ImportProject = {
+  row: number
+  key: string
+  payload: {
+    name: string
+    client: string | null
+    category: string
+    status: string
+    start_date: string
+    end_date: string | null
+    color: string
+    notes: string | null
+  }
+}
+
+export type ImportEvent = {
+  row: number
+  key: string
+  project_key: string | null
+  payload: {
+    name: string
+    client: string | null
+    category: string
+    status: string
+    start_datetime: string
+    end_datetime: string | null
+    color: string
+    notes: string | null
+  }
+}
+
+export type ImportFinanceRow = {
+  row: number
+  link: { type: 'project' | 'event'; key: string }
+  payload: {
+    concept: string
+    amount: number
+    tax_rate?: number
+    expected_date?: string | null
+    paid_date?: string | null
+    is_paid?: boolean
+    category?: string
+    expense_date?: string | null
+    is_deductible?: boolean
+  }
+}
+
+export type ImportPreview = {
+  valid: boolean
+  projects: ImportProject[]
+  events: ImportEvent[]
+  incomes: ImportFinanceRow[]
+  expenses: ImportFinanceRow[]
+  errors: ImportError[]
+  hiddenErrorCount: number
+  summary: Record<Entity, number>
+}
+
+type ParsedImportRow = {
+  row: number
+  values: string[]
+  record: Record<string, string>
+  entity: Entity | null
+}
+
+function emptyPreview(errors: ImportError[] = []): ImportPreview {
+  return {
+    valid: errors.length === 0,
+    projects: [],
+    events: [],
+    incomes: [],
+    expenses: [],
+    errors: errors.slice(0, MAX_DISPLAYED_ERRORS),
+    hiddenErrorCount: Math.max(0, errors.length - MAX_DISPLAYED_ERRORS),
+    summary: { project: 0, event: 0, income: 0, expense: 0 },
+  }
+}
+
+function normalizeHeader(header: string): string {
+  return header.trim().toLowerCase()
+}
+
+function compact(value: string | null | undefined): string {
+  return String(value ?? '').trim()
+}
+
+function optionalText(value: string | null | undefined): string | null {
+  const trimmed = compact(value)
+  return trimmed === '' ? null : trimmed
+}
+
+function withDefault(value: string | null | undefined, fallback: string): string {
+  const trimmed = compact(value)
+  return trimmed === '' ? fallback : trimmed
+}
+
+function isValidDate(value: string): boolean {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (!match) return false
+  const [, year, month, day] = match.map(Number)
+  const date = new Date(Date.UTC(year, month - 1, day))
+  return date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
+}
+
+function localDatetimeParts(value: string): { normalized: string; minutes: number } | null {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2})$/)
+  if (!match) return null
+  const [, year, month, day, hour, minute] = match.map(Number)
+  if (!isValidDate(`${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`)) return null
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null
+  return {
+    normalized: `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}T${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`,
+    minutes: Date.UTC(year, month - 1, day, hour, minute),
+  }
+}
+
+function toMadridIso(value: string): string | null {
+  const parts = localDatetimeParts(value)
+  if (!parts) return null
+  return toIsoUtc(fromLocalInputValue(parts.normalized, DEFAULT_TZ))
+}
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean | null {
+  const raw = compact(value).toLowerCase()
+  if (raw === '') return fallback
+  if (['true', '1', 'yes', 'si', 'sí', 'paid', 'pagado'].includes(raw)) return true
+  if (['false', '0', 'no', 'unpaid', 'pendiente'].includes(raw)) return false
+  return null
+}
+
+function addError(errorsByRow: Map<number, ImportError[]>, row: number, column: string | undefined, message: string) {
+  const errors = errorsByRow.get(row) ?? []
+  errors.push({ row, column, message })
+  errorsByRow.set(row, errors)
+}
+
+function rowHasErrors(errorsByRow: Map<number, ImportError[]>, row: number): boolean {
+  return (errorsByRow.get(row)?.length ?? 0) > 0
+}
+
+function allErrors(errorsByRow: Map<number, ImportError[]>): ImportError[] {
+  return [...errorsByRow.values()].flat().slice(0, MAX_DISPLAYED_ERRORS)
+}
+
+function countHiddenErrors(errorsByRow: Map<number, ImportError[]>): number {
+  const count = [...errorsByRow.values()].reduce((total, errors) => total + errors.length, 0)
+  return Math.max(0, count - MAX_DISPLAYED_ERRORS)
+}
+
+function validateDateField(
+  errorsByRow: Map<number, ImportError[]>,
+  row: number,
+  record: Record<string, string>,
+  column: string,
+  required = false,
+): string | null {
+  const value = compact(record[column])
+  if (value === '') {
+    if (required) addError(errorsByRow, row, column, 'Campo obligatorio.')
+    return null
+  }
+  if (!isValidDate(value)) {
+    addError(errorsByRow, row, column, 'Usa una fecha YYYY-MM-DD válida.')
+    return null
+  }
+  return value
+}
+
+function validateAmount(errorsByRow: Map<number, ImportError[]>, row: number, rawAmount: string | undefined): number | null {
+  const amount = parseDecimal(compact(rawAmount), 'es-ES')
+  if (amount === null || amount <= 0) {
+    addError(errorsByRow, row, 'amount', 'El importe debe ser un número positivo.')
+    return null
+  }
+  return amount
+}
+
+function validateTaxRate(errorsByRow: Map<number, ImportError[]>, row: number, rawRate: string | undefined): number {
+  const value = compact(rawRate)
+  if (value === '') return 15
+  const taxRate = parseDecimal(value, 'es-ES')
+  if (taxRate === null || taxRate < 0 || taxRate > 100) {
+    addError(errorsByRow, row, 'tax_rate', 'La retención debe estar entre 0 y 100.')
+    return 15
+  }
+  return taxRate
+}
+
+export function validateCsvImport(text: string, options: { fileSize?: number } = {}): { preview: ImportPreview; error: Error | null } {
+  const byteSize = options.fileSize ?? new Blob([text]).size
+  if (byteSize > MAX_IMPORT_BYTES) {
+    return { preview: emptyPreview(), error: new Error('El archivo supera el límite de 1 MB.') }
+  }
+
+  const parsed = parseCsv(text)
+  const headers = parsed.headers.map(normalizeHeader)
+  const errorsByRow = new Map<number, ImportError[]>()
+
+  if (headers.length === 0) {
+    return { preview: emptyPreview(), error: new Error('El CSV no tiene cabecera.') }
+  }
+
+  if (headers.length > MAX_IMPORT_COLUMNS) {
+    addError(errorsByRow, 1, undefined, `El archivo no puede tener más de ${MAX_IMPORT_COLUMNS} columnas.`)
+  }
+
+  if (parsed.rows.length > MAX_IMPORT_ROWS) {
+    return { preview: emptyPreview(), error: new Error(`El archivo no puede tener más de ${MAX_IMPORT_ROWS} filas.`) }
+  }
+
+  for (const forbiddenHeader of FORBIDDEN_IMPORT_HEADERS) {
+    if (headers.includes(forbiddenHeader)) {
+      addError(errorsByRow, 1, forbiddenHeader, `La cabecera ${forbiddenHeader} no se puede importar.`)
+    }
+  }
+
+  for (const requiredHeader of IMPORT_HEADERS) {
+    if (!headers.includes(requiredHeader)) {
+      addError(errorsByRow, 1, requiredHeader, `Falta la cabecera ${requiredHeader}.`)
+    }
+  }
+
+  for (const header of headers) {
+    if (![...IMPORT_HEADERS, ...FORBIDDEN_IMPORT_HEADERS].includes(header as never)) {
+      addError(errorsByRow, 1, header, `Cabecera no reconocida: ${header}.`)
+    }
+  }
+
+  if (rowHasErrors(errorsByRow, 1)) {
+    const preview = emptyPreview(allErrors(errorsByRow))
+    preview.hiddenErrorCount = countHiddenErrors(errorsByRow)
+    preview.valid = false
+    return { preview, error: new Error('El CSV no cumple la plantilla de importación.') }
+  }
+
+  const rows: ParsedImportRow[] = parsed.rows.map(({ rowNumber, values }) => {
+    const record = Object.fromEntries(headers.map((header, index) => [header, values[index] ?? '']))
+    return {
+      row: rowNumber,
+      values,
+      record,
+      entity: compact(record.entity) as Entity,
+    }
+  })
+
+  const summary: Record<Entity, number> = { project: 0, event: 0, income: 0, expense: 0 }
+  const projectKeyRows = new Map<string, number[]>()
+  const eventKeyRows = new Map<string, number[]>()
+
+  rows.forEach((row) => {
+    if (row.values?.length > MAX_IMPORT_COLUMNS) {
+      addError(errorsByRow, row.row, undefined, `La fila no puede tener más de ${MAX_IMPORT_COLUMNS} columnas.`)
+    }
+    if (row.values.length > headers.length) {
+      addError(errorsByRow, row.row, undefined, 'La fila tiene más celdas que cabeceras.')
+    }
+  })
+
+  for (const row of rows) {
+    for (const [column, value] of Object.entries(row.record)) {
+      if (value.length > MAX_IMPORT_CELL_LENGTH) {
+        addError(errorsByRow, row.row, column, `La celda supera ${MAX_IMPORT_CELL_LENGTH} caracteres.`)
+      }
+      if (value !== '' && isFormulaLike(value)) {
+        addError(errorsByRow, row.row, column, 'No se aceptan valores que parezcan fórmulas.')
+      }
+    }
+
+    if (!['project', 'event', 'income', 'expense'].includes(compact(row.record.entity))) {
+      addError(errorsByRow, row.row, 'entity', 'Entidad no reconocida.')
+      row.entity = null
+      continue
+    }
+
+    summary[row.entity as Entity] += 1
+
+    if (row.entity === 'project') {
+      const projectKey = compact(row.record.project_key)
+      if (projectKey === '') addError(errorsByRow, row.row, 'project_key', 'project_key es obligatorio.')
+      else projectKeyRows.set(projectKey, [...(projectKeyRows.get(projectKey) ?? []), row.row])
+    }
+
+    if (row.entity === 'event') {
+      const eventKey = compact(row.record.event_key)
+      if (eventKey === '') addError(errorsByRow, row.row, 'event_key', 'event_key es obligatorio.')
+      else eventKeyRows.set(eventKey, [...(eventKeyRows.get(eventKey) ?? []), row.row])
+    }
+  }
+
+  const duplicateProjectKeys = new Set([...projectKeyRows.entries()].filter(([, rowNumbers]) => rowNumbers.length > 1).map(([key]) => key))
+  const duplicateEventKeys = new Set([...eventKeyRows.entries()].filter(([, rowNumbers]) => rowNumbers.length > 1).map(([key]) => key))
+
+  for (const key of duplicateProjectKeys) {
+    for (const row of projectKeyRows.get(key) ?? []) {
+      addError(errorsByRow, row, 'project_key', `project_key duplicado: ${key}.`)
+    }
+  }
+
+  for (const key of duplicateEventKeys) {
+    for (const row of eventKeyRows.get(key) ?? []) {
+      addError(errorsByRow, row, 'event_key', `event_key duplicado: ${key}.`)
+    }
+  }
+
+  for (const row of rows) {
+    if (row.entity === 'project') {
+      if (compact(row.record.name) === '') addError(errorsByRow, row.row, 'name', 'El nombre es obligatorio.')
+      const startDate = validateDateField(errorsByRow, row.row, row.record, 'start_date', true)
+      const endDate = validateDateField(errorsByRow, row.row, row.record, 'end_date')
+      if (startDate && endDate && endDate < startDate) {
+        addError(errorsByRow, row.row, 'end_date', 'La fecha de fin no puede ser anterior al inicio.')
+      }
+    }
+
+    if (row.entity === 'event') {
+      if (compact(row.record.name) === '') addError(errorsByRow, row.row, 'name', 'El nombre es obligatorio.')
+      const start = localDatetimeParts(compact(row.record.start_datetime))
+      const end = compact(row.record.end_datetime) ? localDatetimeParts(compact(row.record.end_datetime)) : null
+      if (!start) addError(errorsByRow, row.row, 'start_datetime', 'Usa fecha y hora local YYYY-MM-DD HH:mm.')
+      if (compact(row.record.end_datetime) && !end) addError(errorsByRow, row.row, 'end_datetime', 'Usa fecha y hora local YYYY-MM-DD HH:mm.')
+      if (start && end && end.minutes < start.minutes) addError(errorsByRow, row.row, 'end_datetime', 'La fecha de fin no puede ser anterior al inicio.')
+    }
+
+    if (row.entity === 'income' || row.entity === 'expense') {
+      if (compact(row.record.concept) === '') addError(errorsByRow, row.row, 'concept', 'El concepto es obligatorio.')
+      validateAmount(errorsByRow, row.row, row.record.amount)
+      const hasProjectKey = compact(row.record.project_key) !== ''
+      const hasEventKey = compact(row.record.event_key) !== ''
+      if (hasProjectKey === hasEventKey) {
+        addError(errorsByRow, row.row, 'project_key', 'Indica exactamente un project_key o un event_key.')
+      }
+      if (row.entity === 'income') {
+        validateTaxRate(errorsByRow, row.row, row.record.tax_rate)
+        validateDateField(errorsByRow, row.row, row.record, 'expected_date')
+        validateDateField(errorsByRow, row.row, row.record, 'paid_date')
+        if (parseBoolean(row.record.is_paid, false) === null) addError(errorsByRow, row.row, 'is_paid', 'Usa true/false, sí/no o 1/0.')
+      }
+      if (row.entity === 'expense') {
+        validateDateField(errorsByRow, row.row, row.record, 'expense_date')
+        if (parseBoolean(row.record.is_deductible, true) === null) addError(errorsByRow, row.row, 'is_deductible', 'Usa true/false, sí/no o 1/0.')
+      }
+    }
+  }
+
+  const validProjectKeys = new Set(
+    rows
+      .filter((row) => row.entity === 'project' && !rowHasErrors(errorsByRow, row.row))
+      .map((row) => compact(row.record.project_key)),
+  )
+
+  for (const row of rows) {
+    if (row.entity === 'event') {
+      const projectKey = compact(row.record.project_key)
+      if (projectKey && !validProjectKeys.has(projectKey)) {
+        addError(errorsByRow, row.row, 'project_key', `No existe un project_key válido en el archivo: ${projectKey}.`)
+      }
+    }
+  }
+
+  const validEventKeys = new Set(
+    rows
+      .filter((row) => row.entity === 'event' && !rowHasErrors(errorsByRow, row.row))
+      .map((row) => compact(row.record.event_key)),
+  )
+
+  for (const row of rows) {
+    if (row.entity !== 'income' && row.entity !== 'expense') continue
+    const projectKey = compact(row.record.project_key)
+    const eventKey = compact(row.record.event_key)
+    if (projectKey && !validProjectKeys.has(projectKey)) {
+      addError(errorsByRow, row.row, 'project_key', `No existe un project_key válido en el archivo: ${projectKey}.`)
+    }
+    if (eventKey && !validEventKeys.has(eventKey)) {
+      addError(errorsByRow, row.row, 'event_key', `No existe un event_key válido en el archivo: ${eventKey}.`)
+    }
+  }
+
+  const preview: ImportPreview = {
+    valid: false,
+    projects: [],
+    events: [],
+    incomes: [],
+    expenses: [],
+    errors: allErrors(errorsByRow),
+    hiddenErrorCount: countHiddenErrors(errorsByRow),
+    summary,
+  }
+
+  for (const row of rows) {
+    if (!row.entity || rowHasErrors(errorsByRow, row.row)) continue
+    if (row.entity === 'project') {
+      preview.projects.push({
+        row: row.row,
+        key: compact(row.record.project_key),
+        payload: {
+          name: compact(row.record.name),
+          client: optionalText(row.record.client),
+          category: withDefault(row.record.category, 'otros'),
+          status: withDefault(row.record.status, 'draft'),
+          start_date: compact(row.record.start_date),
+          end_date: optionalText(row.record.end_date),
+          color: withDefault(row.record.color, '#4f98a3'),
+          notes: optionalText(row.record.notes),
+        },
+      })
+    }
+
+    if (row.entity === 'event') {
+      preview.events.push({
+        row: row.row,
+        key: compact(row.record.event_key),
+        project_key: optionalText(row.record.project_key),
+        payload: {
+          name: compact(row.record.name),
+          client: optionalText(row.record.client),
+          category: withDefault(row.record.category, 'otros'),
+          status: withDefault(row.record.status, 'draft'),
+          start_datetime: toMadridIso(compact(row.record.start_datetime)) as string,
+          end_datetime: compact(row.record.end_datetime) ? toMadridIso(compact(row.record.end_datetime)) : null,
+          color: withDefault(row.record.color, '#4f98a3'),
+          notes: optionalText(row.record.notes),
+        },
+      })
+    }
+
+    if (row.entity === 'income') {
+      const projectKey = optionalText(row.record.project_key)
+      const eventKey = optionalText(row.record.event_key)
+      preview.incomes.push({
+        row: row.row,
+        link: projectKey ? { type: 'project', key: projectKey } : { type: 'event', key: eventKey as string },
+        payload: {
+          concept: compact(row.record.concept),
+          amount: validateAmount(errorsByRow, row.row, row.record.amount) as number,
+          tax_rate: validateTaxRate(errorsByRow, row.row, row.record.tax_rate),
+          expected_date: optionalText(row.record.expected_date),
+          paid_date: optionalText(row.record.paid_date),
+          is_paid: parseBoolean(row.record.is_paid, false) as boolean,
+        },
+      })
+    }
+
+    if (row.entity === 'expense') {
+      const projectKey = optionalText(row.record.project_key)
+      const eventKey = optionalText(row.record.event_key)
+      preview.expenses.push({
+        row: row.row,
+        link: projectKey ? { type: 'project', key: projectKey } : { type: 'event', key: eventKey as string },
+        payload: {
+          concept: compact(row.record.concept),
+          amount: validateAmount(errorsByRow, row.row, row.record.amount) as number,
+          category: withDefault(row.record.category, 'otros'),
+          expense_date: optionalText(row.record.expense_date),
+          is_deductible: parseBoolean(row.record.is_deductible, true) as boolean,
+        },
+      })
+    }
+  }
+
+  preview.valid = preview.errors.length === 0 && preview.hiddenErrorCount === 0
+  return {
+    preview,
+    error: preview.valid ? null : new Error('El CSV contiene errores de validación.'),
+  }
+}
+
+export function hasImportErrors(preview: ImportPreview | null | undefined): boolean {
+  return !preview || !preview.valid || preview.errors.length > 0 || preview.hiddenErrorCount > 0
+}

--- a/src/lib/portability/index.ts
+++ b/src/lib/portability/index.ts
@@ -1,0 +1,3 @@
+export * from './csv'
+export * from './exportData'
+export * from './importValidation'

--- a/src/pages/Data/Data.jsx
+++ b/src/pages/Data/Data.jsx
@@ -1,0 +1,635 @@
+import { useMemo, useState } from 'react'
+import { AlertCircle, CheckCircle2, Download, FileJson, FileSpreadsheet, Upload } from 'lucide-react'
+import { PageWrapper } from '../../components/layout/PageWrapper'
+import { Card } from '../../components/ui/Card'
+import { Button } from '../../components/ui/Button'
+import { useToast, ToastContainer } from '../../components/ui/Toast'
+import { useAuth } from '../../hooks/useAuth'
+import { useDataPortability } from '../../hooks/useDataPortability'
+
+const MAX_FILE_SIZE_BYTES = 1024 * 1024
+const MAX_ROWS = 500
+const importTemplateHeaders = [
+  'entity',
+  'project_key',
+  'event_key',
+  'concept',
+  'name',
+  'client',
+  'category',
+  'status',
+  'start_date',
+  'end_date',
+  'start_datetime',
+  'end_datetime',
+  'amount',
+  'tax_rate',
+  'expected_date',
+  'paid_date',
+  'is_paid',
+  'expense_date',
+  'is_deductible',
+  'color',
+  'notes',
+]
+
+const exportActions = [
+  {
+    key: 'json',
+    label: 'Descargar copia JSON',
+    description: 'Copia completa para guardar fuera de Cachés.',
+    icon: FileJson,
+    source: 'backupJson',
+    filename: 'caches-datos',
+    extension: 'json',
+    mimeType: 'application/json',
+  },
+  {
+    key: 'csv',
+    label: 'Descargar CSV',
+    description: 'Datos principales en formato de hoja de cálculo.',
+    icon: FileSpreadsheet,
+    source: 'csvFiles',
+    filename: 'caches-datos',
+    extension: 'csv',
+    mimeType: 'text/csv;charset=utf-8',
+  },
+  {
+    key: 'template',
+    label: 'Descargar plantilla CSV',
+    description: 'Archivo base para preparar una importación.',
+    icon: Download,
+    source: 'template',
+    filename: 'caches-plantilla-csv',
+    extension: 'csv',
+    mimeType: 'text/csv;charset=utf-8',
+  },
+]
+
+function getPrivacySafeFilename(action) {
+  const date = new Date().toISOString().slice(0, 10)
+  return `${action.filename}-${date}.${action.extension}`
+}
+
+function buildDownloadBlob(result, action) {
+  const payload = result?.blob ?? result?.content ?? result?.data ?? result
+  const mimeType = result?.mimeType ?? result?.contentType ?? action.mimeType
+
+  if (payload instanceof Blob) {
+    return payload
+  }
+
+  if (payload instanceof ArrayBuffer) {
+    return new Blob([payload], { type: mimeType })
+  }
+
+  if (typeof payload === 'string') {
+    return new Blob([payload], { type: mimeType })
+  }
+
+  return new Blob([JSON.stringify(payload ?? {}, null, 2)], { type: mimeType })
+}
+
+function buildImportTemplateCsv() {
+  const exampleRows = [
+    {
+      entity: 'project',
+      project_key: 'proyecto-1',
+      name: 'Proyecto de ejemplo',
+      category: 'otros',
+      status: 'draft',
+      start_date: '2026-05-01',
+      end_date: '2026-05-31',
+      color: '#4f98a3',
+      notes: 'Fila de ejemplo: puedes eliminarla antes de importar.',
+    },
+    {
+      entity: 'event',
+      project_key: 'proyecto-1',
+      event_key: 'evento-1',
+      name: 'Evento de ejemplo',
+      category: 'otros',
+      status: 'draft',
+      start_datetime: '2026-05-16 20:00',
+      end_datetime: '2026-05-16 21:30',
+      color: '#4f98a3',
+    },
+    {
+      entity: 'income',
+      event_key: 'evento-1',
+      concept: 'Cache ejemplo',
+      amount: '1200,00',
+      tax_rate: '15',
+      expected_date: '2026-05-30',
+      is_paid: 'no',
+    },
+    {
+      entity: 'expense',
+      project_key: 'proyecto-1',
+      concept: 'Gasto ejemplo',
+      amount: '45,50',
+      category: 'otros',
+      expense_date: '2026-05-12',
+      is_deductible: 'si',
+    },
+  ]
+  const lines = [
+    importTemplateHeaders.join(';'),
+    ...exampleRows.map((row) => importTemplateHeaders.map((header) => row[header] ?? '').join(';')),
+  ]
+  return `${lines.join('\r\n')}\r\n`
+}
+
+function downloadBlob(blob, filename) {
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
+  window.setTimeout(() => URL.revokeObjectURL(url), 0)
+}
+
+function getNumberFromPaths(source, paths, fallback = 0) {
+  for (const path of paths) {
+    const value = path.reduce((current, key) => current?.[key], source)
+    if (Number.isFinite(value)) return value
+    if (Array.isArray(value)) return value.length
+  }
+  return fallback
+}
+
+function getValidationSummary(validation) {
+  const visibleErrors = getRowErrors(validation)
+  const visibleErrorRows = new Set(visibleErrors.map((error) => error.row)).size
+  const entitySummaryRows = Object.values(validation?.summary ?? {}).reduce(
+    (total, value) => total + (Number.isFinite(value) ? value : 0),
+    0,
+  )
+  const entityValidRows = ['projects', 'events', 'incomes', 'expenses'].reduce((total, key) => {
+    const rows = validation?.[key]
+    return total + (Array.isArray(rows) ? rows.length : 0)
+  }, 0)
+  const totalRows = getNumberFromPaths(validation, [
+    ['totalRows'],
+    ['rowCount'],
+    ['summary', 'totalRows'],
+    ['summary', 'rowCount'],
+    ['counts', 'totalRows'],
+  ])
+  const validRows = getNumberFromPaths(validation, [
+    ['validRows'],
+    ['validRowCount'],
+    ['summary', 'validRows'],
+    ['summary', 'validRowCount'],
+    ['counts', 'validRows'],
+  ], entityValidRows)
+  const errorRows = getNumberFromPaths(validation, [
+    ['errorRows'],
+    ['invalidRows'],
+    ['invalidRowCount'],
+    ['summary', 'errorRows'],
+    ['summary', 'invalidRows'],
+    ['counts', 'errorRows'],
+  ], visibleErrorRows)
+
+  return {
+    totalRows: totalRows || entitySummaryRows || validRows + errorRows,
+    validRows,
+    errorRows: errorRows || Math.max(totalRows - validRows, 0),
+  }
+}
+
+function getRowErrors(validation) {
+  const rawErrors = validation?.rowErrors ?? validation?.errors ?? validation?.invalidRows ?? []
+  if (!Array.isArray(rawErrors)) return []
+
+  return rawErrors.map((error, index) => {
+    if (typeof error === 'string') {
+      return { row: index + 1, message: error }
+    }
+
+    return {
+      row: error.row ?? error.rowNumber ?? error.line ?? index + 1,
+      field: error.field ?? error.column ?? '',
+      message: error.message ?? error.error ?? 'Fila no válida.',
+    }
+  })
+}
+
+function getImportResultState(result) {
+  const inserted = result?.data?.inserted ?? result?.inserted
+  const failures = result?.data?.failures ?? result?.failures ?? []
+  const hasFailures = Array.isArray(failures) && failures.length > 0
+  const hasError = Boolean(result?.error)
+  if (inserted) {
+    const total = Object.values(inserted).reduce((sum, value) => sum + (Number.isFinite(value) ? value : 0), 0)
+    if (hasFailures || hasError) {
+      return {
+        tone: 'warning',
+        title: 'Importación parcial',
+        message: `${total} filas creadas. ${failures.length} filas fallaron durante el guardado no atómico.`,
+        failures,
+      }
+    }
+    if (total > 0) {
+      return {
+        tone: 'success',
+        title: 'Importación completada',
+        message: `${total} filas importadas correctamente.`,
+        failures: [],
+      }
+    }
+  }
+
+  const created = getNumberFromPaths(result, [
+    ['createdRows'],
+    ['created'],
+    ['insertedRows'],
+    ['summary', 'createdRows'],
+    ['summary', 'created'],
+  ])
+
+  if (hasFailures || hasError) {
+    return {
+      tone: 'warning',
+      title: 'Importación parcial',
+      message: `${created || 0} filas creadas. ${failures.length} filas fallaron durante el guardado no atómico.`,
+      failures,
+    }
+  }
+
+  return {
+    tone: 'success',
+    title: 'Importación completada',
+    message: created ? `${created} filas importadas correctamente.` : 'Importación completada.',
+    failures: [],
+  }
+}
+
+function EmptyHookNotice({ visible }) {
+  if (!visible) return null
+
+  return (
+    <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+      La interfaz ya está preparada, pero la integración de portabilidad todavía no está disponible en esta sesión.
+    </div>
+  )
+}
+
+export default function Data() {
+  const { user } = useAuth()
+  const { toasts, addToast, removeToast } = useToast()
+  const portability = useDataPortability(user?.id) ?? {}
+  const {
+    loading = false,
+    exporting = false,
+    importing = false,
+    exportData,
+    validateImportFile,
+    commitImport,
+  } = portability
+  const [selectedFile, setSelectedFile] = useState(null)
+  const [fileError, setFileError] = useState('')
+  const [validation, setValidation] = useState(null)
+  const [validationError, setValidationError] = useState('')
+  const [validating, setValidating] = useState(false)
+  const [importResult, setImportResult] = useState(null)
+  const [activeExport, setActiveExport] = useState('')
+
+  const hookReady = Boolean(exportData && validateImportFile && commitImport)
+  const summary = useMemo(() => getValidationSummary(validation), [validation])
+  const rowErrors = useMemo(() => getRowErrors(validation), [validation])
+  const canImport = Boolean(validation?.valid === true && summary.validRows > 0 && commitImport && !importing)
+
+  const handleExport = async (action) => {
+    if (action.source === 'template') {
+      const blob = buildDownloadBlob(buildImportTemplateCsv(), action)
+      downloadBlob(blob, getPrivacySafeFilename(action))
+      addToast('Plantilla preparada.')
+      return
+    }
+
+    if (!exportData) {
+      addToast('La exportación todavía no está disponible.', 'error')
+      return
+    }
+
+    setActiveExport(action.key)
+    try {
+      const result = await exportData()
+      if (result?.error) throw result.error
+
+      if (action.source === 'csvFiles') {
+        Object.entries(result?.data?.csvFiles ?? {}).forEach(([key, file]) => {
+          const csvAction = { ...action, filename: `caches-datos-${key}` }
+          const blob = buildDownloadBlob(file?.content ?? '', csvAction)
+          downloadBlob(blob, getPrivacySafeFilename(csvAction))
+        })
+      } else {
+        const blob = buildDownloadBlob(result?.data?.[action.source] ?? result, action)
+        downloadBlob(blob, getPrivacySafeFilename(action))
+      }
+
+      addToast('Descarga preparada.')
+    } catch (error) {
+      console.error(error)
+      addToast('No hemos podido preparar la descarga.', 'error')
+    } finally {
+      setActiveExport('')
+    }
+  }
+
+  const handleFileChange = (event) => {
+    const file = event.target.files?.[0] ?? null
+    setSelectedFile(file)
+    setValidation(null)
+    setValidationError('')
+    setImportResult(null)
+
+    if (!file) {
+      setFileError('')
+      return
+    }
+
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      setFileError('El archivo supera el límite de 1MB.')
+      return
+    }
+
+    if (!file.name.toLowerCase().endsWith('.csv')) {
+      setFileError('Sube un archivo CSV básico, no un Excel directo.')
+      return
+    }
+
+    setFileError('')
+  }
+
+  const handleValidate = async () => {
+    if (!selectedFile || fileError) return
+    if (!validateImportFile) {
+      addToast('La validación de importación todavía no está disponible.', 'error')
+      return
+    }
+
+    setValidating(true)
+    setValidationError('')
+    setValidation(null)
+    setImportResult(null)
+
+    try {
+      const result = await validateImportFile(selectedFile)
+      const preview = result?.preview ?? result
+      const nextSummary = getValidationSummary(preview)
+      if (nextSummary.totalRows > MAX_ROWS) {
+        setValidationError('El CSV supera el límite de 500 filas.')
+        return
+      }
+      setValidation(preview)
+      if (result?.error) {
+        setValidationError(result.error.message ?? 'El CSV contiene errores de validación.')
+      } else {
+        addToast('CSV validado. Revisa el resumen antes de importar.')
+      }
+    } catch (error) {
+      console.error(error)
+      setValidationError('No hemos podido validar el CSV. Revisa el formato y vuelve a intentarlo.')
+    } finally {
+      setValidating(false)
+    }
+  }
+
+  const handleCommitImport = async () => {
+    if (!canImport) return
+
+    try {
+      const result = await commitImport(validation)
+      setImportResult(getImportResultState(result))
+      if (result?.error) {
+        addToast(result.error.message ?? 'La importación terminó con errores.', 'error')
+      } else {
+        addToast('Filas válidas importadas.')
+      }
+    } catch (error) {
+      console.error(error)
+      addToast('No hemos podido importar las filas válidas.', 'error')
+    }
+  }
+
+  return (
+    <PageWrapper title="Tus datos">
+      <div className="flex max-w-5xl flex-col gap-6">
+        <div>
+          <p className="max-w-3xl text-sm text-[var(--color-ink-muted)]">
+            Exporta una copia privada de tus proyectos, eventos, ingresos y gastos, o prepara una importación CSV básica.
+          </p>
+        </div>
+
+        <EmptyHookNotice visible={!hookReady} />
+
+        <Card className="p-5 sm:p-6">
+          <div className="flex flex-col gap-5">
+            <div>
+              <h2 className="text-base font-semibold text-[var(--color-ink)]">Exportar</h2>
+              <p className="mt-1 text-sm text-[var(--color-ink-muted)]">
+                La descarga incluye datos profesionales y financieros privados. Los nombres de archivo no incluyen tu email ni tu nombre.
+              </p>
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-3">
+              {exportActions.map((action) => (
+                <div key={action.key} className="flex min-w-0 flex-col gap-3 rounded-lg border border-[var(--color-paper-mid)] bg-[#FDFBF6] p-4">
+                  <div className="flex items-start gap-3">
+                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[var(--color-paper-dark)] text-[var(--color-ink-muted)]">
+                      <action.icon size={18} />
+                    </span>
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-[var(--color-ink)]">{action.label}</p>
+                      <p className="mt-1 text-xs leading-5 text-[var(--color-ink-muted)]">{action.description}</p>
+                    </div>
+                  </div>
+                  <Button
+                    variant={action.key === 'json' ? 'primary' : 'secondary'}
+                    onClick={() => handleExport(action)}
+                    disabled={loading || exporting || (action.source !== 'template' && !exportData)}
+                    className="w-full justify-center"
+                  >
+                    <Download size={16} />
+                    {activeExport === action.key ? 'Preparando...' : action.label}
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+        </Card>
+
+        <Card className="p-5 sm:p-6">
+          <div className="flex flex-col gap-5">
+            <div>
+              <h2 className="text-base font-semibold text-[var(--color-ink)]">Importar CSV</h2>
+              <p className="mt-1 text-sm text-[var(--color-ink-muted)]">
+                Sube un CSV básico. No se acepta Excel directo: exporta tu hoja como CSV antes de subirla. No se guarda nada hasta validar y confirmar. La importación solo crea filas nuevas y no es una restauración atómica.
+              </p>
+            </div>
+
+            <div className="grid gap-3 text-sm text-[var(--color-ink-muted)] sm:grid-cols-2">
+              <div className="rounded-lg border border-[var(--color-paper-mid)] bg-[#FDFBF6] px-4 py-3">
+                Límite de archivo: <span className="font-medium text-[var(--color-ink)]">1MB</span>
+              </div>
+              <div className="rounded-lg border border-[var(--color-paper-mid)] bg-[#FDFBF6] px-4 py-3">
+                Límite de filas: <span className="font-medium text-[var(--color-ink)]">500 filas</span>
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-[var(--color-paper-mid)] bg-[#FDFBF6] px-4 py-3 text-sm text-[var(--color-ink-muted)]">
+              <p className="font-medium text-[var(--color-ink)]">Formato esperado</p>
+              <p className="mt-1">
+                Usa punto y coma, fechas `YYYY-MM-DD`, eventos como `YYYY-MM-DD HH:mm`, importes con coma o punto decimal y claves locales `project_key` / `event_key`. El CSV no puede traer `id`, `user_id`, `created_at`, `project_id` ni `event_id`.
+              </p>
+              <p className="mt-1">
+                Las filas se crean desde cero: no actualizan registros existentes y no son una restauración atómica.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <label htmlFor="data-import-file" className="text-sm font-medium text-[var(--color-ink)]">Archivo CSV</label>
+              <div className="flex flex-col gap-3 rounded-lg border border-dashed border-[var(--color-paper-mid)] bg-[#FDFBF6] p-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex min-w-0 items-center gap-3">
+                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--color-paper-dark)] text-[var(--color-ink-muted)]">
+                    <Upload size={18} />
+                  </span>
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-[var(--color-ink)]">
+                      {selectedFile?.name ?? 'Selecciona un CSV'}
+                    </p>
+                    <p className="text-xs text-[var(--color-ink-muted)]">
+                      CSV básico, máximo 1MB y 500 filas.
+                    </p>
+                  </div>
+                </div>
+                <input
+                  id="data-import-file"
+                  type="file"
+                  accept=".csv,text/csv"
+                  onChange={handleFileChange}
+                  className="block w-full text-sm text-[var(--color-ink-muted)] file:mr-3 file:min-h-10 file:rounded-lg file:border-0 file:bg-[var(--color-paper-dark)] file:px-3 file:text-sm file:font-medium file:text-[var(--color-ink)] hover:file:bg-[var(--color-paper-mid)] sm:w-auto"
+                />
+              </div>
+              {fileError && <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{fileError}</p>}
+            </div>
+
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Button
+                onClick={handleValidate}
+                disabled={!selectedFile || Boolean(fileError) || validating || !validateImportFile}
+                className="justify-center"
+              >
+                {validating ? 'Validando...' : 'Validar CSV'}
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={handleCommitImport}
+                disabled={!canImport}
+                className="justify-center"
+              >
+                {importing ? 'Importando...' : 'Importar CSV validado'}
+              </Button>
+            </div>
+
+            {validationError && (
+              <div className="flex gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                <AlertCircle size={18} className="mt-0.5 shrink-0" />
+                <p>{validationError}</p>
+              </div>
+            )}
+
+            {validation && (
+              <div className="rounded-lg border border-[var(--color-paper-mid)] bg-[#FDFBF6] p-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <h3 className="text-sm font-semibold text-[var(--color-ink)]">Vista previa de validación</h3>
+                    <p className="mt-1 text-sm text-[var(--color-ink-muted)]">
+                      Revisa los errores antes de importar. No se guardará nada hasta que el CSV completo esté validado.
+                    </p>
+                  </div>
+                  {validation.valid === true && summary.validRows > 0 && (
+                    <div className="flex items-center gap-2 rounded-lg bg-[var(--color-green-light)] px-3 py-2 text-sm font-medium text-[var(--color-green)]">
+                      <CheckCircle2 size={16} />
+                      Lista para importar
+                    </div>
+                  )}
+                </div>
+
+                <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                  <div className="rounded-lg bg-white px-4 py-3">
+                    <p className="text-xs text-[var(--color-ink-muted)]">Filas leídas</p>
+                    <p className="mt-1 text-xl font-semibold text-[var(--color-ink)]">{summary.totalRows}</p>
+                  </div>
+                  <div className="rounded-lg bg-white px-4 py-3">
+                    <p className="text-xs text-[var(--color-ink-muted)]">Filas válidas</p>
+                    <p className="mt-1 text-xl font-semibold text-[var(--color-green)]">{summary.validRows}</p>
+                  </div>
+                  <div className="rounded-lg bg-white px-4 py-3">
+                    <p className="text-xs text-[var(--color-ink-muted)]">Filas con errores</p>
+                    <p className="mt-1 text-xl font-semibold text-[var(--color-red)]">{summary.errorRows}</p>
+                  </div>
+                </div>
+
+                {rowErrors.length > 0 && (
+                  <div className="mt-4 overflow-x-auto">
+                    <table className="w-full min-w-[520px] text-left text-sm">
+                      <thead className="text-xs uppercase text-[var(--color-ink-muted)]">
+                        <tr>
+                          <th className="pb-2 font-medium">Fila</th>
+                          <th className="pb-2 font-medium">Campo</th>
+                          <th className="pb-2 font-medium">Error</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-[var(--color-paper-mid)]">
+                        {rowErrors.slice(0, 20).map((error) => (
+                          <tr key={`${error.row}-${error.field}-${error.message}`}>
+                            <td className="py-2 pr-4 text-[var(--color-ink)]">{error.row}</td>
+                            <td className="py-2 pr-4 text-[var(--color-ink-muted)]">{error.field || '-'}</td>
+                            <td className="py-2 text-red-700">{error.message}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                    {rowErrors.length > 20 && (
+                      <p className="mt-3 text-xs text-[var(--color-ink-muted)]">
+                        Mostrando 20 de {rowErrors.length} errores. Corrige el CSV y vuelve a validarlo.
+                      </p>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {importResult && (
+              <div className={`flex gap-3 rounded-lg border px-4 py-3 text-sm ${
+                importResult.tone === 'warning'
+                  ? 'border-amber-200 bg-amber-50 text-amber-800'
+                  : 'border-green-200 bg-green-50 text-green-700'
+              }`}>
+                {importResult.tone === 'warning'
+                  ? <AlertCircle size={18} className="mt-0.5 shrink-0" />
+                  : <CheckCircle2 size={18} className="mt-0.5 shrink-0" />}
+                <div>
+                  <p className="font-medium">{importResult.title}</p>
+                  <p className="mt-1">{importResult.message}</p>
+                  {importResult.failures.length > 0 && (
+                    <p className="mt-1 text-xs">
+                      Revisa las filas fallidas y repite la importación solo con las filas que falten.
+                    </p>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </Card>
+      </div>
+      <ToastContainer toasts={toasts} onRemove={removeToast} />
+    </PageWrapper>
+  )
+}

--- a/src/pages/Settings/Settings.jsx
+++ b/src/pages/Settings/Settings.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { PageWrapper } from '../../components/layout/PageWrapper'
 import { Card } from '../../components/ui/Card'
 import { Button } from '../../components/ui/Button'
@@ -95,9 +96,17 @@ export default function Settings() {
               <h2 className="text-sm font-semibold text-gray-900 mb-1">Cuenta</h2>
               <p className="text-sm text-gray-500">{user?.email}</p>
             </div>
-            <Button variant="secondary" onClick={signOut} className="justify-center">
-              Cerrar sesión
-            </Button>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Link
+                to="/data"
+                className="inline-flex min-h-10 items-center justify-center rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-paper)] px-4 py-2 text-sm font-medium leading-none text-[var(--color-ink)] shadow-sm transition-colors hover:bg-[var(--color-paper-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-red)] focus-visible:ring-offset-2"
+              >
+                Tus datos
+              </Link>
+              <Button variant="secondary" onClick={signOut} className="justify-center">
+                Cerrar sesión
+              </Button>
+            </div>
           </div>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- Implementa CACH-B0005 con página privada `Tus datos` para exportar e importar datos operativos.
- Añade exportación JSON completa y CSV por entidad para proyectos, eventos, ingresos y gastos.
- Añade importación CSV limitada con plantilla, validación previa, claves locales `project_key`/`event_key`, create-only y aviso de guardado no atómico.
- Actualiza Product Brain y release notes de `RELEASE-0.1.0-beta.7`.

## Seguridad y contrato de datos
- El acceso a Supabase queda encapsulado en `src/hooks/useDataPortability.js`.
- Exportación filtra todas las entidades por `eq('user_id', userId)`.
- Importación sobrescribe `user_id` con el usuario autenticado.
- El CSV de importación rechaza `id`, `user_id`, `created_at`, `project_id` y `event_id`.
- Export/import CSV mitigan fórmula injection.

## Verification
- [x] `npm run test` — 24 files, 130 tests
- [x] `npm run lint`
- [x] `npm run build` — OK, con warning conocido de chunk grande de Vite
- [x] `npm run pb:check`
- [x] `git diff --check`
- [ ] Smoke autenticado en `/data`: export JSON/CSV, importar CSV válido e importar CSV con errores

## Memoria
No aplica: no surgieron preferencias durables nuevas ni gotchas reutilizables que deban persistirse en `.memory/`.