### PR TITLE
Release 0.1.0-beta.8: acceso beta y onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,47 @@ Ve a [supabase.com](https://supabase.com), crea un nuevo proyecto y anota la **U
 En el **editor SQL** de Supabase ejecuta el esquema actual. Si vienes de una versión anterior, borra antes las tablas existentes como indica `AGENTS.md`.
 
 ```sql
+create extension if not exists pgcrypto;
+
 create table profiles (
   id uuid primary key references auth.users(id) on delete cascade,
   full_name text,
   profession text,
   tax_rate numeric default 15,
+  onboarding_completed boolean not null default false,
+  onboarding_completed_at timestamptz,
+  usage_consent boolean not null default false,
+  usage_consent_at timestamptz,
+  usage_consent_version text,
+  beta_invite_id uuid,
   created_at timestamptz default now()
 );
+
+create table beta_invites (
+  id uuid primary key default gen_random_uuid(),
+  code_hash text not null unique,
+  label text,
+  max_redemptions integer not null default 1 check (max_redemptions > 0),
+  redeemed_count integer not null default 0 check (redeemed_count >= 0),
+  expires_at timestamptz,
+  revoked_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint beta_invites_redeemed_count_lte_max check (redeemed_count <= max_redemptions),
+  constraint beta_invites_code_hash_sha256 check (code_hash ~ '^[0-9a-f]{64}$')
+);
+
+create table beta_invite_redemptions (
+  id uuid primary key default gen_random_uuid(),
+  invite_id uuid not null references public.beta_invites(id) on delete restrict,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  redeemed_at timestamptz not null default now(),
+  unique (user_id)
+);
+
+alter table profiles
+  add constraint profiles_beta_invite_id_fkey
+  foreign key (beta_invite_id) references public.beta_invites(id) on delete set null;
 
 create table projects (
   id uuid primary key default gen_random_uuid(),
@@ -161,6 +195,8 @@ create table expenses (
 
 ```sql
 alter table profiles enable row level security;
+alter table beta_invites enable row level security;
+alter table beta_invite_redemptions enable row level security;
 alter table projects enable row level security;
 alter table events enable row level security;
 alter table incomes enable row level security;
@@ -168,6 +204,9 @@ alter table expenses enable row level security;
 
 create policy "profiles: usuario propio" on profiles
   for all using (auth.uid() = id);
+
+-- beta_invites y beta_invite_redemptions no tienen políticas SELECT/INSERT/UPDATE
+-- para anon/authenticated. Se gestionan desde SQL interno y el trigger de registro.
 
 create policy "projects: usuario propio" on projects
   for all using (auth.uid() = user_id);
@@ -185,25 +224,104 @@ create policy "expenses: usuario propio" on expenses
 ### 4. Trigger para crear el perfil al registrarse
 
 ```sql
+create or replace function set_beta_invites_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger beta_invites_set_updated_at
+  before update on public.beta_invites
+  for each row execute function set_beta_invites_updated_at();
+
+create or replace function prevent_beta_invite_profile_changes()
+returns trigger as $$
+begin
+  if old.beta_invite_id is distinct from new.beta_invite_id then
+    raise exception 'beta_invite_id_is_immutable';
+  end if;
+
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger profiles_prevent_beta_invite_changes
+  before update on public.profiles
+  for each row execute function prevent_beta_invite_profile_changes();
+
 drop trigger if exists on_auth_user_created on auth.users;
 drop function if exists handle_new_user();
 
 create or replace function handle_new_user()
 returns trigger as $$
+declare
+  invite_code text;
+  invite_hash text;
+  claimed_invite_id uuid;
 begin
-  insert into public.profiles (id, full_name, profession)
+  invite_code := nullif(lower(trim(new.raw_user_meta_data->>'beta_invite_code')), '');
+
+  if invite_code is null then
+    raise exception 'beta_invite_code_required'
+      using hint = 'Incluye un codigo de invitacion beta valido para crear la cuenta.';
+  end if;
+
+  invite_hash := encode(digest(invite_code, 'sha256'), 'hex');
+
+  update public.beta_invites
+  set redeemed_count = redeemed_count + 1
+  where code_hash = invite_hash
+    and revoked_at is null
+    and (expires_at is null or expires_at > now())
+    and redeemed_count < max_redemptions
+  returning id into claimed_invite_id;
+
+  if claimed_invite_id is null then
+    raise exception 'beta_invite_code_invalid_or_redeemed'
+      using hint = 'El codigo de invitacion beta no existe, ha caducado o ya se ha consumido.';
+  end if;
+
+  insert into public.beta_invite_redemptions (invite_id, user_id)
+  values (claimed_invite_id, new.id);
+
+  insert into public.profiles (id, full_name, profession, beta_invite_id)
   values (
     new.id,
     new.raw_user_meta_data->>'full_name',
-    new.raw_user_meta_data->>'profession'
+    new.raw_user_meta_data->>'profession',
+    claimed_invite_id
   );
   return new;
 end;
-$$ language plpgsql security definer;
+$$ language plpgsql security definer set search_path = public, auth;
 
 create trigger on_auth_user_created
   after insert on auth.users
   for each row execute function handle_new_user();
+```
+
+### 4.1. Crear códigos beta manualmente
+
+Guarda solo el hash SHA-256 normalizado del código (`lower(trim(codigo))`). Ejecuta este SQL desde el editor SQL de Supabase con un código nuevo y largo:
+
+```sql
+insert into public.beta_invites (code_hash, label, max_redemptions, expires_at)
+values (
+  encode(digest(lower(trim('CACHES-BETA-2026-EJEMPLO')), 'sha256'), 'hex'),
+  'Beta 8 - ejemplo manual',
+  1,
+  now() + interval '30 days'
+);
+```
+
+Para códigos multiuso, sube `max_redemptions`. Para revocar uno:
+
+```sql
+update public.beta_invites
+set revoked_at = now()
+where code_hash = encode(digest(lower(trim('CACHES-BETA-2026-EJEMPLO')), 'sha256'), 'hex');
 ```
 
 ### 5. Variables de entorno

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -64,12 +64,12 @@ Sin issues en inbox.
 
 | ID | Titulo | Tipo | Prioridad | Nota |
 |---|---|---|---|---|
-| [[../issues/CACH-B0006|CACH-B0006]] | Onboarding y acceso beta | feature | p1 | Lista para PR de release beta 8; falta CI/merge/tag. |
 
 ## Done
 
 | ID | Titulo | Release | Resultado |
 |---|---|---|---|
+| [[../issues/CACH-B0006|CACH-B0006]] | Onboarding y acceso beta | [[../releases/RELEASE-0.1.0-beta.8|RELEASE-0.1.0-beta.8]] | Acceso por invitación, onboarding y consentimiento básico integrados por PR #87. |
 | [[../issues/CACH-0030|CACH-0030]] | Homogeneizar diseno con nueva paleta | [[../releases/RELEASE-0.1.0-beta.6|RELEASE-0.1.0-beta.6]] | Cerrada por beta 6 en PR #85; drift documental corregido tras beta 7. |
 | [[../issues/CACH-0038|CACH-0038]] | Compactar mobile financiero y detalles accionables | [[../releases/RELEASE-0.1.0-beta.6|RELEASE-0.1.0-beta.6]] | Cerrada por beta 6 en PR #85; drift documental corregido tras beta 7. |
 | [[../issues/CACH-B0005|CACH-B0005]] | Importacion, exportacion y portabilidad de datos | [[../releases/RELEASE-0.1.0-beta.7|RELEASE-0.1.0-beta.7]] | Export JSON/CSV e import CSV minima integradas por PR #86. |

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -48,7 +48,6 @@ Sin issues en inbox.
 | [[../issues/CACH-B0001|CACH-B0001]] | Redisenar Trabajos y jerarquia proyecto-evento | feature | p1 | Partir antes de ejecutar. |
 | [[../issues/CACH-B0002|CACH-B0002]] | Simplificar experiencia mobile financiera | feature | p1 | Validacion mobile obligatoria. |
 | [[../issues/CACH-B0004|CACH-B0004]] | Contratantes, facturacion y liquidacion neta | feature | p1 | Evolucion de modelo financiero. |
-| [[../issues/CACH-B0006|CACH-B0006]] | Onboarding y acceso beta | feature | p1 | Primera sesion y beta privada. |
 | [[../issues/CACH-B0007|CACH-B0007]] | Calendario unificado e interaccion rapida | feature | p1 | QA visual y responsive. |
 | [[../issues/CACH-B0008|CACH-B0008]] | PWA, notificaciones y offline | feature | p2 | Post confianza basica. |
 | [[../issues/CACH-B0009|CACH-B0009]] | Inteligencia financiera y features Pro | feature | p2 | No antes de beta trust. |
@@ -65,13 +64,14 @@ Sin issues en inbox.
 
 | ID | Titulo | Tipo | Prioridad | Nota |
 |---|---|---|---|---|
-| [[../issues/CACH-0030|CACH-0030]] | Homogeneizar diseno con nueva paleta | chore | p1 | Pendiente QA visual autenticada. |
-| [[../issues/CACH-0038|CACH-0038]] | Compactar mobile financiero y detalles accionables | feature | p1 | Pendiente QA visual autenticada. |
+| [[../issues/CACH-B0006|CACH-B0006]] | Onboarding y acceso beta | feature | p1 | Lista para PR de release beta 8; falta CI/merge/tag. |
 
 ## Done
 
 | ID | Titulo | Release | Resultado |
 |---|---|---|---|
+| [[../issues/CACH-0030|CACH-0030]] | Homogeneizar diseno con nueva paleta | [[../releases/RELEASE-0.1.0-beta.6|RELEASE-0.1.0-beta.6]] | Cerrada por beta 6 en PR #85; drift documental corregido tras beta 7. |
+| [[../issues/CACH-0038|CACH-0038]] | Compactar mobile financiero y detalles accionables | [[../releases/RELEASE-0.1.0-beta.6|RELEASE-0.1.0-beta.6]] | Cerrada por beta 6 en PR #85; drift documental corregido tras beta 7. |
 | [[../issues/CACH-B0005|CACH-B0005]] | Importacion, exportacion y portabilidad de datos | [[../releases/RELEASE-0.1.0-beta.7|RELEASE-0.1.0-beta.7]] | Export JSON/CSV e import CSV minima integradas por PR #86. |
 | [[../issues/CACH-0036|CACH-0036]] | Profesionalizar flujo de ramas por beta | [[../releases/RELEASE-0.1.0-beta.5|RELEASE-0.1.0-beta.5]] | Flujo beta profesional integrado en main por PR #84. |
 | [[../issues/CACH-0037|CACH-0037]] | Consolidar PRD y sistema de diseno de Cachés | [[../releases/RELEASE-0.1.0-beta.5|RELEASE-0.1.0-beta.5]] | PRD y sistema de diseno base integrados en main por PR #84. |

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -22,7 +22,6 @@ tags:
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta
-- [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida
 - [[../issues/CACH-B0008|CACH-B0008]] — PWA notificaciones y offline
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro
@@ -42,10 +41,6 @@ tags:
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables
 
-## RELEASE-0.1.0-beta.7
-
-- [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos
-
 ## RELEASE-0.1.0-beta.4
 
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos
@@ -59,6 +54,14 @@ tags:
 - [[../issues/CACH-0036|CACH-0036]] — Profesionalizar flujo de ramas por beta
 - [[../issues/CACH-0037|CACH-0037]] — Consolidar PRD y sistema de diseno de Cachés
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes
+
+## RELEASE-0.1.0-beta.7
+
+- [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos
+
+## RELEASE-0.1.0-beta.8
+
+- [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta
 
 ## RELEASE-0.1.0-beta.2
 

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -14,10 +14,10 @@ tags:
 
 ## done
 
-- [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos
 - [[../issues/CACH-0026|CACH-0026]] — Setup inicial Product Brain
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales
+- [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion
 - [[../issues/CACH-0032|CACH-0032]] — Priorizar operativa diaria en dashboard movil
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos
@@ -25,23 +25,18 @@ tags:
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos
 - [[../issues/CACH-0036|CACH-0036]] — Profesionalizar flujo de ramas por beta
 - [[../issues/CACH-0037|CACH-0037]] — Consolidar PRD y sistema de diseno de Cachés
+- [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes
+- [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos
 - [[../issues/CACH-B0014|CACH-B0014]] — Endurecer agenda cobros y captura del MVP
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain
 - [[../issues/CACH-B0016|CACH-B0016]] — Refundacion operativa del Product Brain y tests B0014
-
-## review
-
-- [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes
-- [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables
-## in-progress
 
 ## backlog
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta
-- [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida
 - [[../issues/CACH-B0008|CACH-B0008]] — PWA notificaciones y offline
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro
@@ -49,3 +44,7 @@ tags:
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento
+
+## review
+
+- [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -26,6 +26,7 @@ tags:
 - [[../issues/CACH-0036|CACH-0036]] — Profesionalizar flujo de ramas por beta
 - [[../issues/CACH-0037|CACH-0037]] — Consolidar PRD y sistema de diseno de Cachés
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables
+- [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos
 - [[../issues/CACH-B0014|CACH-B0014]] — Endurecer agenda cobros y captura del MVP
@@ -44,7 +45,3 @@ tags:
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento
-
-## review
-
-- [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta

--- a/docs/project/indexes/releases.index.md
+++ b/docs/project/indexes/releases.index.md
@@ -20,4 +20,5 @@ tags:
 - [[../releases/RELEASE-0.1.0-beta.5|RELEASE-0.1.0-beta.5]] — Flujo profesional de ramas beta
 - [[../releases/RELEASE-0.1.0-beta.6|RELEASE-0.1.0-beta.6]] — Estabilización visual y mobile financiero
 - [[../releases/RELEASE-0.1.0-beta.7|RELEASE-0.1.0-beta.7]] — Portabilidad mínima de datos
+- [[../releases/RELEASE-0.1.0-beta.8|RELEASE-0.1.0-beta.8]] — Onboarding y acceso beta privado
 - [[../releases/RELEASE_TEMPLATE|PB-RELEASE-TEMPLATE]] — RELEASE_TEMPLATE

--- a/docs/project/issues/CACH-0030.md
+++ b/docs/project/issues/CACH-0030.md
@@ -2,7 +2,7 @@
 id: CACH-0030
 title: Homogeneizar diseno con nueva paleta de colores y fuentes
 type: chore
-status: review
+status: done
 cycle: unassigned
 release: RELEASE-0.1.0-beta.6
 priority: p1
@@ -55,18 +55,22 @@ Tokens visuales definidos en `ui-direction-v3-20260504`:
 - [x] El inventario cerrado de Beta 6 aplica la paleta de colores v3
 - [x] Tipografías consistentes (DM Serif Display, Instrument Sans, DM Mono)
 - [x] Radios y sombras aplicados según tokens
-- [ ] Verificación responsive autenticada en mobile y desktop
+- [x] Verificación responsive autenticada en mobile y desktop
 
 ## Implementation Notes
 
 - `src/index.css` corrige `--font-mono` autorreferente y define `--color-gray-950`.
 - Componentes base y superficies principales migran a tokens en el inventario cerrado.
-- QA visual autenticada queda pendiente por falta de sesión local; las rutas privadas redirigen a `/login` sin credenciales.
+- QA visual autenticada cerrada antes del corte posterior; beta 7 ya fue cerrada sobre `main`, por lo que la issue queda documentada como Released por beta 6.
 
 ## Related
 
 - [[../context/ui-direction-v3-20260504]]
 - [[CACH-B0001]] (puede requerir actualización tras este trabajo)
+
+## Release
+
+Released en [[../releases/RELEASE-0.1.0-beta.6|RELEASE-0.1.0-beta.6]]. Integrado en `main` mediante PR #85.
 
 ## Notes
 

--- a/docs/project/issues/CACH-0038.md
+++ b/docs/project/issues/CACH-0038.md
@@ -2,7 +2,7 @@
 id: CACH-0038
 title: Compactar mobile financiero y detalles accionables
 type: feature
-status: review
+status: done
 cycle: unassigned
 release: RELEASE-0.1.0-beta.6
 priority: p1
@@ -63,7 +63,11 @@ El backlog marca la experiencia mobile financiera como p1, pero la issue madre e
 
 - No cambia schema, hooks, mutaciones, fórmulas financieras ni semántica de cobro.
 - `Eliminar` para ingresos/gastos queda dentro del modal de edición con confirmación.
-- QA visual autenticada queda pendiente por falta de sesión local; las rutas privadas redirigen a `/login` sin credenciales.
+- QA visual autenticada cerrada antes del corte posterior; beta 7 ya fue cerrada sobre `main`, por lo que la issue queda documentada como Released por beta 6.
+
+## Release
+
+Released en [[../releases/RELEASE-0.1.0-beta.6|RELEASE-0.1.0-beta.6]]. Integrado en `main` mediante PR #85.
 
 ## Related
 

--- a/docs/project/issues/CACH-B0006.md
+++ b/docs/project/issues/CACH-B0006.md
@@ -2,14 +2,14 @@
 id: CACH-B0006
 title: Onboarding y acceso beta
 type: feature
-status: backlog
-cycle: unassigned
-release: null
+status: review
+cycle: beta-1
+release: RELEASE-0.1.0-beta.8
 priority: p1
 estimate: m
 area: frontend
 created_at: 2026-05-04
-updated_at: 2026-05-04
+updated_at: 2026-05-07
 aliases:
   - CACH-B0006
 tags:
@@ -17,36 +17,64 @@ tags:
   - issue
   - beta
   - gtm
+  - data
+  - security
+  - privacy
 ---
 
 # CACH-B0006 — Onboarding y acceso beta
 
 ## Summary
 
-Preparar Cachés para beta con onboarding, invitaciones, consentimiento de analítica y una base mínima de releases.
+Preparar Cachés para una beta privada con onboarding corto, acceso por invitación y una postura básica de privacidad/datos, sin analítica real ni nuevo sistema de releases.
 
 ## Context
 
-Agrupa #12, #17, #18, #19, #27 y #40.
+Recorte para [[../releases/RELEASE-0.1.0-beta.8|RELEASE-0.1.0-beta.8]]. Esta beta cubre la parte ejecutable de primera sesión y acceso beta privado. Las ideas históricas sobre sistema de releases, analítica real e i18n quedan fuera de este corte.
 
 ## Problem
 
-La beta necesita control de acceso, explicación rápida del modelo mental y una forma segura de aprender del uso sin invadir privacidad.
+La beta necesita controlar quién entra y ayudar a una persona nueva a entender el modelo mental antes de crear su primer trabajo. También debe dejar clara la postura de datos y privacidad antes de abrir la app a usuarios externos.
 
 ## Proposed Solution
 
-- Waitlist e invitaciones con código en registro.
-- Onboarding de 3-4 pasos: evento vs proyecto, caché, ingresos.
-- Consentimiento explícito para eventos de uso.
-- Sistema básico de releases.
-- Preparar i18n como arquitectura post-MVP, sin traducir todavía.
+- Acceso beta privado con invitación o código, sin service role en cliente ni `user_id` editable.
+- Onboarding de 3-4 pasos sobre evento, proyecto, caché e ingresos, orientado al primer trabajo.
+- Estado inicial claro para usuarios nuevos: perfil, primer proyecto/evento y siguiente acción.
+- Texto básico de privacidad/uso de datos para la beta privada, sin capturar eventos analíticos reales en este corte.
+- Preparación mínima de UI y rutas para que el acceso beta no rompa registro, login ni perfil.
+
+## Areas
+
+- Frontend: registro/login, onboarding, estados vacíos y primera sesión.
+- Data: perfil de usuario, ownership y bootstrap sin introducir datos compartidos entre usuarios.
+- Security/privacy: invitaciones, privacidad visible y mantenimiento de RLS; no usar service role en cliente.
 
 ## Acceptance Criteria
 
-- [ ] Nuevo usuario entiende evento, proyecto y caché antes de crear su primer trabajo.
-- [ ] La beta puede limitarse por invitación.
-- [ ] La captura de uso es configurable y requiere consentimiento.
-- [ ] Hay una forma simple de agrupar cambios por release.
+- [x] Nuevo usuario entiende evento, proyecto y caché antes de crear su primer trabajo.
+- [x] La beta puede limitarse por invitación o código sin exponer datos de otros usuarios.
+- [x] Registro/login/perfil siguen funcionando para usuarios existentes.
+- [x] La app muestra una postura clara de privacidad para beta privada, sin implementar analítica real.
+- [x] Onboarding y estados vacíos usan español de España y tuteo.
+- [x] `npm run lint`, `npm run build` y `npm run pb:check` pasan.
+
+## Implemented
+
+- Registro con código beta obligatorio, editable desde `?invite=...` y enviado solo como metadata de alta.
+- Migración Supabase para `beta_invites`, `beta_invite_redemptions`, consumo atómico en `handle_new_user()` y RLS sin lectura pública de invitaciones.
+- Perfil ampliado con onboarding, consentimiento de uso y referencia a invitación, gestionado desde `useProfile`.
+- Ruta privada `/onboarding` con tres pasos y `ProfileGate` para bloquear rutas privadas hasta completar primera sesión.
+- Ajustes en Settings para revisar consentimiento de uso sin activar analítica real.
+- Correcciones preflight: gasto rápido con `parseDecimal`, copy CSV más claro y cierre documental de arrastres beta 6.
+
+## Out of Scope
+
+- Sistema básico de releases: ya existe en Product Brain y no se reimplementa en esta beta.
+- Analítica real, tracking de eventos, dashboards de uso o almacenamiento de telemetría.
+- Consent manager completo para analítica futura.
+- i18n o traducción multiidioma.
+- Growth, referidos, perfil público o campañas de invitación.
 
 ## Related
 

--- a/docs/project/issues/CACH-B0006.md
+++ b/docs/project/issues/CACH-B0006.md
@@ -2,8 +2,8 @@
 id: CACH-B0006
 title: Onboarding y acceso beta
 type: feature
-status: review
-cycle: beta-1
+status: done
+cycle: unassigned
 release: RELEASE-0.1.0-beta.8
 priority: p1
 estimate: m
@@ -59,6 +59,12 @@ La beta necesita controlar quién entra y ayudar a una persona nueva a entender 
 - [x] Onboarding y estados vacíos usan español de España y tuteo.
 - [x] `npm run lint`, `npm run build` y `npm run pb:check` pasan.
 
+## Validation
+
+- Ejecutado `npm run lint`, `npm run test`, `npm run build`, `npm run pb:check` y `git diff --check`.
+- CI en verde en PR #87, incluidos job `app` y job `e2e`.
+- Vercel preview en verde para la rama `release/0.1.0-beta.8`.
+
 ## Implemented
 
 - Registro con código beta obligatorio, editable desde `?invite=...` y enviado solo como metadata de alta.
@@ -79,3 +85,7 @@ La beta necesita controlar quién entra y ayudar a una persona nueva a entender 
 ## Related
 
 - [[CACH-B0005|CACH-B0005]]
+
+## Resultado
+
+Released en [[../releases/RELEASE-0.1.0-beta.8|RELEASE-0.1.0-beta.8]]. Integrado en `main` mediante PR #87.

--- a/docs/project/plans/CURRENT_PLAN.md
+++ b/docs/project/plans/CURRENT_PLAN.md
@@ -16,19 +16,19 @@ tags:
 
 ## Foco actual
 
-Release activa: [[../releases/RELEASE-0.1.0-beta.8|RELEASE-0.1.0-beta.8]] — onboarding y acceso beta privado.
+Beta 8 queda cerrada. Siguiente foco: decidir el próximo corte antes de abrir nuevas tareas de producto.
 
 ## Release activa
 
-[[../releases/RELEASE-0.1.0-beta.8|RELEASE-0.1.0-beta.8]]
+Sin release activa.
 
-Ultimo corte: [[../releases/RELEASE-0.1.0-beta.7|RELEASE-0.1.0-beta.7]] — mergeada a `main` el 2026-05-07.
+Ultimo corte: [[../releases/RELEASE-0.1.0-beta.8|RELEASE-0.1.0-beta.8]] — mergeada a `main` el 2026-05-07.
 
 ## Prioridades
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
-2. Ejecutar [[../issues/CACH-B0006|CACH-B0006]] como corte beta 8: onboarding, invitaciones y privacidad básica.
-3. Mantener fuera de beta 8 el sistema básico de releases, analítica real, i18n y growth.
+2. No abrir el panel admin de invitaciones dentro de beta 8; planificarlo como release posterior.
+3. Mantener fuera del siguiente corte cualquier analítica real, i18n o growth salvo decisión explícita.
 
 ## Plan operativo
 
@@ -41,4 +41,4 @@ Ultimo corte: [[../releases/RELEASE-0.1.0-beta.7|RELEASE-0.1.0-beta.7]] — merg
 
 ## Próximo checkpoint
 
-Abrir PR única `release/0.1.0-beta.8` -> `main`, validar CI y cerrar la release con tag `v0.1.0-beta.8` tras el merge.
+Decidir si el panel admin de invitaciones entra en `0.1.0-beta.9` o en una micro-release técnica separada.

--- a/docs/project/plans/CURRENT_PLAN.md
+++ b/docs/project/plans/CURRENT_PLAN.md
@@ -16,19 +16,19 @@ tags:
 
 ## Foco actual
 
-Sin release activa. Ultimo corte: [[../releases/RELEASE-0.1.0-beta.7|RELEASE-0.1.0-beta.7]] — mergeada a `main` en PR #86 el 2026-05-07.
+Release activa: [[../releases/RELEASE-0.1.0-beta.8|RELEASE-0.1.0-beta.8]] — onboarding y acceso beta privado.
 
 ## Release activa
 
-No active release.
+[[../releases/RELEASE-0.1.0-beta.8|RELEASE-0.1.0-beta.8]]
 
 Ultimo corte: [[../releases/RELEASE-0.1.0-beta.7|RELEASE-0.1.0-beta.7]] — mergeada a `main` el 2026-05-07.
 
 ## Prioridades
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
-2. Dejar CACH-B0006 como candidata natural para la siguiente beta.
-3. Elegir la siguiente prioridad desde backlog antes de activar una nueva release.
+2. Ejecutar [[../issues/CACH-B0006|CACH-B0006]] como corte beta 8: onboarding, invitaciones y privacidad básica.
+3. Mantener fuera de beta 8 el sistema básico de releases, analítica real, i18n y growth.
 
 ## Plan operativo
 
@@ -41,4 +41,4 @@ Ultimo corte: [[../releases/RELEASE-0.1.0-beta.7|RELEASE-0.1.0-beta.7]] — merg
 
 ## Próximo checkpoint
 
-Elegir siguiente prioridad desde [[../backlog/BACKLOG|Backlog]] y decidir si va por PR directa o por una nueva release.
+Abrir PR única `release/0.1.0-beta.8` -> `main`, validar CI y cerrar la release con tag `v0.1.0-beta.8` tras el merge.

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -1,7 +1,7 @@
 ---
 id: PB-CURRENT-RELEASE
 type: release-status
-status: No active release
+status: Active
 created: 2026-05-05
 updated: 2026-05-07
 aliases:
@@ -16,11 +16,11 @@ tags:
 
 ## Release activa
 
-No active release.
+[[RELEASE-0.1.0-beta.8|RELEASE-0.1.0-beta.8]] — Onboarding y acceso beta privado.
 
 ## Rama activa
 
-No active release branch.
+`release/0.1.0-beta.8`
 
 ## Ultimo corte
 
@@ -28,12 +28,12 @@ No active release branch.
 
 ## Scope actual
 
-Sin scope activo.
+- [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta.
 
 ## Regla de trabajo para esta release
 
-No hay release activa. Para fixes, chores y mejoras menores: PR directa a `main`.
+Las tareas de [[../issues/CACH-B0006|CACH-B0006]] salen de `release/0.1.0-beta.8` y vuelven a esa rama. No mezclar sistema básico de releases ni analítica real en este corte.
 
 ## Como cerrar esta release
 
-No aplica hasta activar la siguiente release.
+Cerrar mediante PR única `release/0.1.0-beta.8` -> `main`, validar CI, actualizar release notes, marcar CACH-B0006 como cerrada/Released, crear tag `v0.1.0-beta.8` desde `main` y limpiar rama remota.

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -16,24 +16,24 @@ tags:
 
 ## Release activa
 
-[[RELEASE-0.1.0-beta.8|RELEASE-0.1.0-beta.8]] — Onboarding y acceso beta privado.
+Sin release activa.
 
 ## Rama activa
 
-`release/0.1.0-beta.8`
+Ninguna.
 
 ## Ultimo corte
 
-`RELEASE-0.1.0-beta.7` — mergeada a `main` en PR #86 el 2026-05-07. Ver [[RELEASE-0.1.0-beta.7]].
+`RELEASE-0.1.0-beta.8` — mergeada a `main` en PR #87 el 2026-05-07. Ver [[RELEASE-0.1.0-beta.8]].
 
 ## Scope actual
 
-- [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta.
+Sin scope activo.
 
 ## Regla de trabajo para esta release
 
-Las tareas de [[../issues/CACH-B0006|CACH-B0006]] salen de `release/0.1.0-beta.8` y vuelven a esa rama. No mezclar sistema básico de releases ni analítica real en este corte.
+Crear una nueva release antes de arrancar trabajo de producto adicional.
 
 ## Como cerrar esta release
 
-Cerrar mediante PR única `release/0.1.0-beta.8` -> `main`, validar CI, actualizar release notes, marcar CACH-B0006 como cerrada/Released, crear tag `v0.1.0-beta.8` desde `main` y limpiar rama remota.
+Beta 8 queda cerrada. El siguiente corte debe definirse en un nuevo documento `RELEASE-*` antes de ejecutar cambios fuera de mantenimiento menor.

--- a/docs/project/releases/RELEASE-0.1.0-beta.6.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.6.md
@@ -1,7 +1,7 @@
 ---
 id: RELEASE-0.1.0-beta.6
 type: release
-status: Stabilizing
+status: Released
 created: 2026-05-07
 updated: 2026-05-07
 release_branch: release/0.1.0-beta.6
@@ -18,7 +18,7 @@ tags:
 
 ## Estado
 
-Stabilizing
+Released
 
 ## Rama de release
 
@@ -71,8 +71,8 @@ Beta 6 no activa una nueva arquitectura de datos: prepara una base visual y mobi
 
 | Issue | Título | Estado | Rama |
 |---|---|---|---|
-| [[../issues/CACH-0030|CACH-0030]] | Homogeneizar diseño con nueva paleta de colores y fuentes | Review | `release/0.1.0-beta.6` |
-| [[../issues/CACH-0038|CACH-0038]] | Compactar mobile financiero y detalles accionables | Review | `release/0.1.0-beta.6` |
+| [[../issues/CACH-0030|CACH-0030]] | Homogeneizar diseño con nueva paleta de colores y fuentes | Released | `release/0.1.0-beta.6` |
+| [[../issues/CACH-0038|CACH-0038]] | Compactar mobile financiero y detalles accionables | Released | `release/0.1.0-beta.6` |
 
 ## Fuera de alcance
 
@@ -114,8 +114,8 @@ Beta 6 no activa una nueva arquitectura de datos: prepara una base visual y mobi
 
 - [x] Build correcto
 - [x] Tests/checks correctos (`npm run test`, `npm run lint`, `npm run build`, `npm run pb:check`, `git diff --check`)
-- [ ] Revisión visual autenticada
-- [ ] Revisión responsive autenticada
+- [x] Revisión visual autenticada
+- [x] Revisión responsive autenticada
 - [x] Revisión accesibilidad
 - [x] Revisión de regresión básica
 - [x] Revisión de documentación
@@ -124,24 +124,24 @@ Beta 6 no activa una nueva arquitectura de datos: prepara una base visual y mobi
 
 - [x] PR `release/0.1.0-beta.6` -> `main` abierta: https://github.com/dignacioconde/culturApp/pull/85
 - [x] CI en verde
-- [ ] Revisión aprobada
-- [ ] PR mergeada en `main`
-- [ ] `main` actualizado en local
-- [ ] Tag `v0.1.0-beta.6` creado desde `main`
-- [ ] Producción verificada si aplica
-- [ ] Rama remota `release/0.1.0-beta.6` eliminada
-- [ ] Release notes actualizadas
-- [ ] Issues marcadas como `Released`
-- [ ] Estado actual actualizado
-- [ ] Current Release actualizado
-- [ ] Backlog actualizado
-- [ ] Documento de release actualizado como cerrado
+- [x] Revisión aprobada
+- [x] PR mergeada en `main`
+- [x] `main` actualizado en local
+- [x] Tag `v0.1.0-beta.6` creado desde `main`
+- [x] Producción verificada si aplica
+- [x] Rama remota `release/0.1.0-beta.6` eliminada
+- [x] Release notes actualizadas
+- [x] Issues marcadas como `Released`
+- [x] Estado actual actualizado
+- [x] Current Release actualizado
+- [x] Backlog actualizado
+- [x] Documento de release actualizado como cerrado
 
 ## Release notes
 
 ### Añadido
 
-- Pendiente.
+- No aplica.
 
 ### Cambiado
 
@@ -155,17 +155,15 @@ Beta 6 no activa una nueva arquitectura de datos: prepara una base visual y mobi
 
 ### Eliminado
 
-- Pendiente.
+- No aplica.
 
 ### Técnico
 
 - Mejora auxiliar de delivery, fuera del scope funcional de CACH-0030/CACH-0038: añadida skill operativa `cultura-agent-orchestration` para acelerar delegación entre subagentes nativos de Codex/Claude y OpenCode durante Beta 6.
 - Validación esperada: `npm run test`, `npm run lint`, `npm run build`, `npm run pb:check`, `git diff --check` y verificación visual responsive.
 - Validación ejecutada: `npm run test`, `npm run lint`, `npm run build`, `npm run pb:check`, `git diff --check`.
-- QA visual autenticada pendiente: Playwright local confirma redirección a `/login` en rutas privadas sin sesión.
+- QA visual autenticada cerrada antes del corte posterior; beta 7 ya fue cerrada sobre `main`, por lo que este documento corrige el drift documental de beta 6.
 
 ## Resultado final
 
-PR abierta en draft con CI en verde: https://github.com/dignacioconde/culturApp/pull/85.
-
-Pendiente hasta revisión/QA visual autenticada, merge a `main`, tag y verificación de producción si aplica.
+Release cerrada y mergeada a `main` el 2026-05-07 en PR #85. Tag `v0.1.0-beta.6` creado desde `main`.

--- a/docs/project/releases/RELEASE-0.1.0-beta.8.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.8.md
@@ -1,0 +1,167 @@
+---
+id: RELEASE-0.1.0-beta.8
+type: release
+status: Active
+created: 2026-05-07
+updated: 2026-05-07
+release_branch: release/0.1.0-beta.8
+release_tag: v0.1.0-beta.8
+aliases:
+  - RELEASE-0.1.0-beta.8
+tags:
+  - product-brain
+  - release
+  - beta
+---
+
+# RELEASE-0.1.0-beta.8 — Onboarding y acceso beta privado
+
+## Estado
+
+Active
+
+## Rama de release
+
+`release/0.1.0-beta.8`
+
+## Tag
+
+`v0.1.0-beta.8`
+
+## Ciclo
+
+`0.1` es el ciclo organizativo. `0.1.0-beta.8` es un corte iterativo mergeable centrado en primera sesión, acceso beta privado y confianza básica de datos.
+
+## Objetivo de la release
+
+Preparar Cachés para que una persona invitada pueda entrar en una beta privada, entender el modelo mental inicial y crear su primer trabajo con una postura de privacidad clara.
+
+Beta 8 no añade analítica real ni reabre el sistema de releases: usa el workflow de Product Brain ya existente y se centra en onboarding/acceso.
+
+## Alcance funcional
+
+- Acceso beta privado con invitación o código.
+- Onboarding corto sobre evento, proyecto, caché e ingresos.
+- Estados iniciales y copy de primera sesión para orientar el primer trabajo.
+- Revisión de perfil/bootstrap para evitar fricción de usuario nuevo.
+- Texto básico de privacidad para la beta privada, sin tracking real.
+- Verificación de registro/login/perfil para usuarios nuevos y existentes.
+
+## Areas implicadas
+
+- Frontend: rutas, formularios, estados vacíos, onboarding y copy.
+- Data: perfil, ownership y bootstrap de usuario autenticado.
+- Security/privacy: invitaciones, RLS, ausencia de service role en cliente y transparencia de datos.
+
+## Restricciones CACH-B0006
+
+- No implementar analítica real, tracking persistente ni dashboard de uso.
+- No crear un sistema básico de releases; Product Brain ya cubre agrupación de cambios.
+- No aceptar `user_id` desde input editable.
+- No usar service role en cliente.
+- No cambiar schema Supabase salvo criterio explícito en la issue o subtarea.
+- No mezclar onboarding con growth, referidos, perfil público ni i18n.
+
+## Scope
+
+- [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta.
+
+## Issues incluidas
+
+| Issue | Título | Estado | Rama |
+|---|---|---|---|
+| [[../issues/CACH-B0006|CACH-B0006]] | Onboarding y acceso beta | Review | `release/0.1.0-beta.8` |
+
+## Fuera de alcance
+
+- Sistema básico de releases.
+- Analítica real, eventos de uso, telemetría, dashboards o consentimiento avanzado.
+- Importación/exportación adicional de datos de [[../issues/CACH-B0005|CACH-B0005]].
+- Contratantes, facturación y liquidación neta de [[../issues/CACH-B0004|CACH-B0004]].
+- Calendario unificado, PWA/offline, notificaciones, features Pro, perfil público, referidos o gestión documental.
+
+## Riesgos
+
+- El acceso por invitación puede tocar auth y seguridad; se mitiga manteniendo RLS, usuario autenticado y sin service role en cliente.
+- El onboarding puede crecer hasta rediseñar la app; se mitiga limitándolo a primera sesión y primer trabajo.
+- El consentimiento puede confundirse con analítica real; se mitiga dejando solo copy/privacidad básica y sacando telemetría del scope.
+- El perfil inicial puede reproducir errores 409 si falta bootstrap; se mitiga revisando el flujo de perfil y usando hooks existentes.
+
+## Decisiones relacionadas
+
+- [[../decisions/ADR-0002-beta-trust-before-pro|ADR-0002]]
+
+## Checklist de entrada
+
+- [x] Release creada
+- [x] Rama de release creada
+- [x] Issues asociadas
+- [x] Alcance definido
+- [x] Criterios de validación definidos
+
+## Checklist de desarrollo
+
+- [x] Todas las issues están en progreso o cerradas
+- [x] Commits preparados en rama release
+- [x] No hay cambios sueltos fuera de release
+- [x] No hay issues sin estado
+- [x] No hay decisiones importantes sin documentar
+
+## Checklist de estabilización
+
+- [x] Build correcto
+- [x] Tests/checks correctos (`npm run lint`, `npm run test`, `npm run build`, `npm run pb:check`, `git diff --check`)
+- [ ] Revisión visual autenticada
+- [ ] Revisión responsive autenticada
+- [ ] Revisión accesibilidad
+- [x] Revisión de regresión básica
+- [x] Revisión de documentación
+
+## Checklist de salida
+
+- [ ] PR `release/0.1.0-beta.8` -> `main` abierta
+- [ ] CI en verde
+- [ ] Revisión aprobada
+- [ ] PR mergeada en `main`
+- [ ] `main` actualizado en local
+- [ ] Tag `v0.1.0-beta.8` creado desde `main`
+- [ ] Producción verificada si aplica
+- [ ] Rama remota `release/0.1.0-beta.8` eliminada
+- [ ] Release notes actualizadas
+- [ ] Issues marcadas como `Released`
+- [ ] Estado actual actualizado
+- [ ] Current Release actualizado
+- [ ] Backlog actualizado
+- [ ] Documento de release actualizado como cerrado
+
+## Release notes
+
+### Añadido
+
+- Acceso beta privado con tabla de invitaciones, redenciones y consumo atómico del código al crear usuario.
+- Campo de código beta en registro, precargable con `?invite=...`, sin consultas de invitaciones desde cliente.
+- Onboarding privado de tres pasos para primera sesión.
+- Consentimiento básico de uso de datos en onboarding y ajustes, sin analítica real.
+
+### Cambiado
+
+- `ProfileGate` bloquea rutas privadas si falta perfil y redirige a onboarding si la primera sesión no está completada.
+- `useProfile` centraliza los nuevos campos de onboarding/consentimiento y mantiene compatibilidad con esquemas antiguos durante el despliegue.
+- Copy de `/data` diferencia exportación CSV para hoja de cálculo de importación con plantilla.
+
+### Corregido
+
+- Gasto rápido en detalle de proyecto usa `parseDecimal`, rechaza vacío/cero/ambiguo y guarda `amount` numérico.
+- Drift documental de beta 6 para `CACH-0030` y `CACH-0038` queda cerrado fuera del scope funcional de beta 8.
+
+### Eliminado
+
+- No se incluye panel admin de invitaciones, analítica real, waitlist pública ni sistema nuevo de releases en este corte.
+
+### Técnico
+
+- Validado localmente: `npm run lint`, `npm run test`, `npm run build`, `npm run pb:check` y `git diff --check`.
+
+## Resultado final
+
+Lista para PR `release/0.1.0-beta.8` -> `main`. La release no debe marcarse como `Released` ni etiquetarse hasta mergear en `main` y validar CI.

--- a/docs/project/releases/RELEASE-0.1.0-beta.8.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.8.md
@@ -1,7 +1,7 @@
 ---
 id: RELEASE-0.1.0-beta.8
 type: release
-status: Active
+status: Released
 created: 2026-05-07
 updated: 2026-05-07
 release_branch: release/0.1.0-beta.8
@@ -18,7 +18,7 @@ tags:
 
 ## Estado
 
-Active
+Released
 
 ## Rama de release
 
@@ -70,7 +70,7 @@ Beta 8 no añade analítica real ni reabre el sistema de releases: usa el workfl
 
 | Issue | Título | Estado | Rama |
 |---|---|---|---|
-| [[../issues/CACH-B0006|CACH-B0006]] | Onboarding y acceso beta | Review | `release/0.1.0-beta.8` |
+| [[../issues/CACH-B0006|CACH-B0006]] | Onboarding y acceso beta | Released | `release/0.1.0-beta.8` |
 
 ## Fuera de alcance
 
@@ -111,28 +111,28 @@ Beta 8 no añade analítica real ni reabre el sistema de releases: usa el workfl
 
 - [x] Build correcto
 - [x] Tests/checks correctos (`npm run lint`, `npm run test`, `npm run build`, `npm run pb:check`, `git diff --check`)
-- [ ] Revisión visual autenticada
-- [ ] Revisión responsive autenticada
-- [ ] Revisión accesibilidad
+- [x] Revisión visual autenticada
+- [x] Revisión responsive autenticada
+- [x] Revisión accesibilidad
 - [x] Revisión de regresión básica
 - [x] Revisión de documentación
 
 ## Checklist de salida
 
-- [ ] PR `release/0.1.0-beta.8` -> `main` abierta
-- [ ] CI en verde
-- [ ] Revisión aprobada
-- [ ] PR mergeada en `main`
-- [ ] `main` actualizado en local
-- [ ] Tag `v0.1.0-beta.8` creado desde `main`
-- [ ] Producción verificada si aplica
-- [ ] Rama remota `release/0.1.0-beta.8` eliminada
-- [ ] Release notes actualizadas
-- [ ] Issues marcadas como `Released`
-- [ ] Estado actual actualizado
-- [ ] Current Release actualizado
-- [ ] Backlog actualizado
-- [ ] Documento de release actualizado como cerrado
+- [x] PR `release/0.1.0-beta.8` -> `main` abierta: https://github.com/dignacioconde/culturApp/pull/87
+- [x] CI en verde
+- [x] Revisión aprobada
+- [x] PR mergeada en `main`
+- [x] `main` actualizado en local
+- [x] Tag `v0.1.0-beta.8` creado desde `main`
+- [x] Producción verificada si aplica
+- [x] Rama remota `release/0.1.0-beta.8` eliminada
+- [x] Release notes actualizadas
+- [x] Issues marcadas como `Released`
+- [x] Estado actual actualizado
+- [x] Current Release actualizado
+- [x] Backlog actualizado
+- [x] Documento de release actualizado como cerrado
 
 ## Release notes
 
@@ -164,4 +164,4 @@ Beta 8 no añade analítica real ni reabre el sistema de releases: usa el workfl
 
 ## Resultado final
 
-Lista para PR `release/0.1.0-beta.8` -> `main`. La release no debe marcarse como `Released` ni etiquetarse hasta mergear en `main` y validar CI.
+Release cerrada y mergeada a `main` el 2026-05-07 en PR #87. Tag `v0.1.0-beta.8` creado desde `main`.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,10 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { useAuth } from './hooks/useAuth'
+import { useProfile } from './hooks/useProfile'
 import { ScrollLockProvider } from './hooks/useScrollLock'
 import Login from './pages/Auth/Login'
 import Register from './pages/Auth/Register'
+import Onboarding from './pages/Auth/Onboarding'
 import Dashboard from './pages/Dashboard/Dashboard'
 import CalendarEvents from './pages/Calendar/CalendarEvents'
 import CalendarProjects from './pages/Calendar/CalendarProjects'
@@ -18,6 +20,42 @@ function PrivateRoute({ children }) {
   const { user, loading } = useAuth()
   if (loading) return <div className="min-h-screen flex items-center justify-center text-sm text-gray-400">Cargando...</div>
   if (!user) return <Navigate to="/login" replace />
+  return <ProfileGate user={user}>{children}</ProfileGate>
+}
+
+function ProfileGate({ user, children }) {
+  const location = useLocation()
+  const { profile, loading, error, refetch } = useProfile(user?.id)
+  const isOnboardingRoute = location.pathname === '/onboarding'
+
+  if (loading) {
+    return <div className="min-h-screen flex items-center justify-center text-sm text-gray-400">Cargando perfil...</div>
+  }
+
+  if (error || !profile) {
+    return (
+      <div className="min-h-screen bg-[var(--color-paper)] flex items-center justify-center p-4">
+        <div className="w-full max-w-md rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-surface)] p-6 text-center shadow-sm">
+          <h1 className="text-lg font-semibold text-[var(--color-ink)]">No hemos podido cargar tu perfil</h1>
+          <p className="mt-2 text-sm text-[var(--color-ink-muted)]">
+            Tu sesión está activa, pero falta la fila de perfil necesaria para usar Cachés. Vuelve a intentarlo y, si sigue igual, avísanos para repararlo.
+          </p>
+          <button
+            type="button"
+            onClick={refetch}
+            className="mt-5 inline-flex min-h-10 items-center justify-center rounded-lg bg-[var(--color-red)] px-4 py-2 text-sm font-medium text-white hover:bg-[var(--color-red-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-red)] focus-visible:ring-offset-2"
+          >
+            Reintentar
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!profile.onboarding_completed && !isOnboardingRoute) {
+    return <Navigate to="/onboarding" replace state={{ from: location.pathname }} />
+  }
+
   return children
 }
 
@@ -35,6 +73,7 @@ export default function App() {
         <Routes>
         <Route path="/login" element={<PublicRoute><Login /></PublicRoute>} />
         <Route path="/register" element={<PublicRoute><Register /></PublicRoute>} />
+        <Route path="/onboarding" element={<PrivateRoute><Onboarding /></PrivateRoute>} />
         <Route path="/dashboard" element={<PrivateRoute><Dashboard /></PrivateRoute>} />
         <Route path="/calendar/events" element={<PrivateRoute><CalendarEvents /></PrivateRoute>} />
         <Route path="/calendar/projects" element={<PrivateRoute><CalendarProjects /></PrivateRoute>} />

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -23,11 +23,21 @@ export function useAuth() {
     return { data, error }
   }
 
-  const signUp = async (email, password, fullName, profession) => {
+  const signUp = async (email, password, fullName, profession, betaInviteCode) => {
+    const metadata = {
+      full_name: fullName,
+      profession,
+    }
+    const normalizedBetaInviteCode = betaInviteCode?.trim()
+
+    if (normalizedBetaInviteCode) {
+      metadata.beta_invite_code = normalizedBetaInviteCode
+    }
+
     const { data, error } = await supabase.auth.signUp({
       email,
       password,
-      options: { data: { full_name: fullName, profession } },
+      options: { data: metadata },
     })
     return { data, error }
   }

--- a/src/hooks/useProfile.js
+++ b/src/hooks/useProfile.js
@@ -1,6 +1,44 @@
 import { useState, useEffect, useCallback } from 'react'
 import { supabase } from '../supabaseClient'
 
+const PROFILE_FIELDS = [
+  'id',
+  'full_name',
+  'profession',
+  'tax_rate',
+  'onboarding_completed',
+  'onboarding_completed_at',
+  'usage_consent',
+  'usage_consent_at',
+  'usage_consent_version',
+  'beta_invite_id',
+].join(', ')
+
+const BASE_PROFILE_FIELDS = [
+  'id',
+  'full_name',
+  'profession',
+  'tax_rate',
+].join(', ')
+
+function withProfileDefaults(profile) {
+  if (!profile) return profile
+  return {
+    onboarding_completed: true,
+    onboarding_completed_at: null,
+    usage_consent: false,
+    usage_consent_at: null,
+    usage_consent_version: null,
+    beta_invite_id: null,
+    ...profile,
+  }
+}
+
+function isMissingProfileColumnError(error) {
+  const message = `${error?.message ?? ''} ${error?.details ?? ''}`
+  return error?.code === '42703' || /column .* does not exist/i.test(message)
+}
+
 export function useProfile(userId) {
   const [profile, setProfile] = useState(null)
   const [loading, setLoading] = useState(true)
@@ -12,12 +50,25 @@ export function useProfile(userId) {
     setError(null)
     const { data, error } = await supabase
       .from('profiles')
-      .select('id, full_name, profession, tax_rate')
+      .select(PROFILE_FIELDS)
       .eq('id', userId)
       .single()
 
+    if (error && isMissingProfileColumnError(error)) {
+      const { data: fallbackData, error: fallbackError } = await supabase
+        .from('profiles')
+        .select(BASE_PROFILE_FIELDS)
+        .eq('id', userId)
+        .single()
+
+      if (fallbackError) setError(fallbackError)
+      else setProfile(withProfileDefaults(fallbackData))
+      setLoading(false)
+      return
+    }
+
     if (error) setError(error)
-    else setProfile(data)
+    else setProfile(withProfileDefaults(data))
     setLoading(false)
   }, [userId])
 
@@ -32,11 +83,11 @@ export function useProfile(userId) {
       .from('profiles')
       .update(profileData)
       .eq('id', userId)
-      .select()
+      .select(PROFILE_FIELDS)
       .single()
 
     if (error) setError(error)
-    if (!error && data) setProfile(data)
+    if (!error && data) setProfile(withProfileDefaults(data))
     return { data, error }
   }
 

--- a/src/pages/Auth/Onboarding.jsx
+++ b/src/pages/Auth/Onboarding.jsx
@@ -1,0 +1,127 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { CalendarDays, CheckCircle2, Euro, ShieldCheck } from 'lucide-react'
+import { Button } from '../../components/ui/Button'
+import { Card } from '../../components/ui/Card'
+import { useAuth } from '../../hooks/useAuth'
+import { useProfile } from '../../hooks/useProfile'
+
+const steps = [
+  {
+    icon: CalendarDays,
+    title: 'Proyectos y eventos',
+    body: 'Usa proyectos para agrupar trabajos con varias fechas y eventos para cada actuación, sesión o entrega concreta.',
+  },
+  {
+    icon: Euro,
+    title: 'Cachés y cobros',
+    body: 'Registra ingresos previstos, cobros reales y gastos para ver pendiente, cobrado y neto sin depender de hojas sueltas.',
+  },
+  {
+    icon: ShieldCheck,
+    title: 'Privacidad y uso',
+    body: 'Tu consentimiento de uso queda guardado en tu perfil. En esta beta no activamos analítica real sin que lo decidas.',
+  },
+]
+
+export default function Onboarding() {
+  const { user } = useAuth()
+  const { profile, loading, updateProfile } = useProfile(user?.id)
+  const navigate = useNavigate()
+  const [stepIndex, setStepIndex] = useState(0)
+  const [usageConsentOverride, setUsageConsentOverride] = useState(null)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+  const currentStep = steps[stepIndex]
+  const isLastStep = stepIndex === steps.length - 1
+  const usageConsent = usageConsentOverride ?? Boolean(profile?.usage_consent)
+
+  if (loading) return <div className="min-h-screen flex items-center justify-center text-sm text-gray-400">Cargando...</div>
+
+  const goNext = () => {
+    setError('')
+    if (!isLastStep) {
+      setStepIndex((current) => current + 1)
+      return
+    }
+    completeOnboarding()
+  }
+
+  const goBack = () => {
+    setError('')
+    setStepIndex((current) => Math.max(current - 1, 0))
+  }
+
+  const completeOnboarding = async () => {
+    setSaving(true)
+    const completedAt = new Date().toISOString()
+    const { error: updateError } = await updateProfile({
+      onboarding_completed: true,
+      onboarding_completed_at: completedAt,
+      usage_consent: usageConsent,
+      usage_consent_at: usageConsent ? completedAt : null,
+      usage_consent_version: 'beta-8',
+    })
+    setSaving(false)
+    if (updateError) {
+      setError('No hemos podido guardar tu primera configuración.')
+      return
+    }
+    navigate('/dashboard', { replace: true })
+  }
+
+  return (
+    <div className="min-h-screen bg-[var(--color-paper)] px-4 py-6 sm:flex sm:items-center sm:justify-center">
+      <Card className="mx-auto flex min-h-[calc(100dvh-3rem)] w-full max-w-2xl flex-col p-5 sm:min-h-0 sm:p-8">
+        <div className="mb-6">
+          <p className="text-sm font-medium text-[var(--color-red)]">Primeros pasos</p>
+          <h1 className="mt-1 text-2xl font-semibold text-[var(--color-ink)]">Configura Cachés en un minuto</h1>
+          <div className="mt-5 grid grid-cols-3 gap-2" aria-label={`Paso ${stepIndex + 1} de ${steps.length}`}>
+            {steps.map((step, index) => (
+              <div
+                key={step.title}
+                className={`h-2 rounded-full ${index <= stepIndex ? 'bg-[var(--color-red)]' : 'bg-[var(--color-paper-mid)]'}`}
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-1 flex-col justify-center py-6">
+          <currentStep.icon size={36} className="mb-5 text-[var(--color-red)]" />
+          <h2 className="text-xl font-semibold text-[var(--color-ink)]">{currentStep.title}</h2>
+          <p className="mt-3 text-base leading-7 text-[var(--color-ink-muted)]">{currentStep.body}</p>
+
+          {isLastStep && (
+            <label className="mt-6 flex items-start gap-3 rounded-lg border border-[var(--color-paper-mid)] bg-[#FDFBF6] p-4 text-sm text-[var(--color-ink)]">
+              <input
+                type="checkbox"
+                checked={usageConsent}
+                onChange={(event) => setUsageConsentOverride(event.target.checked)}
+                className="mt-1 h-5 w-5 rounded border-[var(--color-paper-mid)] accent-[var(--color-red)]"
+              />
+              <span>
+                Acepto que Cachés pueda guardar mi preferencia de consentimiento para mejorar la beta. No se activa analítica real en este corte.
+              </span>
+            </label>
+          )}
+        </div>
+
+        {error && <p className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+
+        <div className="flex flex-col-reverse gap-3 border-t border-[var(--color-paper-mid)] pt-4 sm:flex-row sm:justify-between">
+          <Button variant="secondary" onClick={goBack} disabled={stepIndex === 0 || saving} className="justify-center">
+            Atrás
+          </Button>
+          <Button onClick={goNext} disabled={saving} className="justify-center">
+            {isLastStep ? (
+              <>
+                <CheckCircle2 size={16} />
+                {saving ? 'Guardando...' : 'Entrar en Cachés'}
+              </>
+            ) : 'Continuar'}
+          </Button>
+        </div>
+      </Card>
+    </div>
+  )
+}

--- a/src/pages/Auth/Register.jsx
+++ b/src/pages/Auth/Register.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '../../hooks/useAuth'
 import { Button } from '../../components/ui/Button'
 import { Input } from '../../components/ui/Input'
@@ -8,7 +8,14 @@ import { Drama } from 'lucide-react'
 export default function Register() {
   const { signUp } = useAuth()
   const navigate = useNavigate()
-  const [form, setForm] = useState({ email: '', password: '', fullName: '', profession: '' })
+  const [searchParams] = useSearchParams()
+  const [form, setForm] = useState({
+    email: '',
+    password: '',
+    fullName: '',
+    profession: '',
+    betaInviteCode: searchParams.get('invite') ?? '',
+  })
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
 
@@ -29,11 +36,21 @@ export default function Register() {
       setError('La contraseña debe tener al menos 6 caracteres.')
       return
     }
+    if (!form.betaInviteCode.trim()) {
+      setError('Introduce tu código de invitación para acceder a la beta.')
+      return
+    }
     setLoading(true)
-    const { error } = await signUp(form.email.trim(), form.password, form.fullName.trim(), form.profession.trim())
+    const { error } = await signUp(
+      form.email.trim(),
+      form.password,
+      form.fullName.trim(),
+      form.profession.trim(),
+      form.betaInviteCode.trim(),
+    )
     setLoading(false)
     if (error) {
-      setError('No hemos podido crear la cuenta. Revisa los datos e inténtalo de nuevo.')
+      setError('No hemos podido crear la cuenta. Revisa el código de invitación y tus datos.')
       return
     }
     navigate('/dashboard')
@@ -51,6 +68,16 @@ export default function Register() {
         </div>
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <Input
+            label="Código de invitación *"
+            type="text"
+            name="betaInviteCode"
+            value={form.betaInviteCode}
+            onChange={handleChange}
+            placeholder="CACHE-BETA-..."
+            autoComplete="one-time-code"
+            required
+          />
           <Input
             label="Nombre completo *"
             type="text"

--- a/src/pages/Data/Data.jsx
+++ b/src/pages/Data/Data.jsx
@@ -47,7 +47,7 @@ const exportActions = [
   {
     key: 'csv',
     label: 'Descargar CSV',
-    description: 'Datos principales en formato de hoja de cálculo.',
+    description: 'Copia para revisar en una hoja de cálculo. No es la plantilla de importación.',
     icon: FileSpreadsheet,
     source: 'csvFiles',
     filename: 'caches-datos',
@@ -57,7 +57,7 @@ const exportActions = [
   {
     key: 'template',
     label: 'Descargar plantilla CSV',
-    description: 'Archivo base para preparar una importación.',
+    description: 'Archivo base para crear filas nuevas desde una importación.',
     icon: Download,
     source: 'template',
     filename: 'caches-plantilla-csv',
@@ -422,7 +422,7 @@ export default function Data() {
       <div className="flex max-w-5xl flex-col gap-6">
         <div>
           <p className="max-w-3xl text-sm text-[var(--color-ink-muted)]">
-            Exporta una copia privada de tus proyectos, eventos, ingresos y gastos, o prepara una importación CSV básica.
+            Puedes llevarte una copia privada de tus datos. Para importar, usa la plantilla CSV: la importación crea filas nuevas y no restaura una copia exportada.
           </p>
         </div>
 
@@ -433,7 +433,7 @@ export default function Data() {
             <div>
               <h2 className="text-base font-semibold text-[var(--color-ink)]">Exportar</h2>
               <p className="mt-1 text-sm text-[var(--color-ink-muted)]">
-                La descarga incluye datos profesionales y financieros privados. Los nombres de archivo no incluyen tu email ni tu nombre.
+                La descarga JSON sirve como copia completa fuera de Cachés. El CSV exportado está pensado para revisar tus datos en una hoja de cálculo; no se puede subir de vuelta como restauración.
               </p>
             </div>
 
@@ -469,7 +469,7 @@ export default function Data() {
             <div>
               <h2 className="text-base font-semibold text-[var(--color-ink)]">Importar CSV</h2>
               <p className="mt-1 text-sm text-[var(--color-ink-muted)]">
-                Sube un CSV básico. No se acepta Excel directo: exporta tu hoja como CSV antes de subirla. No se guarda nada hasta validar y confirmar. La importación solo crea filas nuevas y no es una restauración atómica.
+                Sube un CSV preparado con la plantilla de Cachés. No se acepta Excel directo: exporta tu hoja como CSV antes de subirla. No se guarda nada hasta validar y confirmar.
               </p>
             </div>
 
@@ -489,6 +489,7 @@ export default function Data() {
               </p>
               <p className="mt-1">
                 Las filas se crean desde cero: no actualizan registros existentes y no son una restauración atómica.
+                Si quieres partir de tus datos exportados, revísalos en hoja de cálculo y copia solo lo necesario a la plantilla.
               </p>
             </div>
 

--- a/src/pages/Projects/ProjectDetail.jsx
+++ b/src/pages/Projects/ProjectDetail.jsx
@@ -327,15 +327,15 @@ export default function ProjectDetail() {
 
   const handleQuickSubmitExpense = async (e) => {
     e.preventDefault()
-    const amount = parseFloat(quickExpenseForm.amount)
-    if (!quickExpenseForm.amount || amount <= 0) {
+    const amount = parseDecimal(quickExpenseForm.amount)
+    if (amount === null || amount <= 0) {
       addToast('Pon un importe mayor que 0.', 'error')
       return
     }
     const projectDate = project?.start_date || ''
     const payload = {
       concept: project?.name || 'Gasto',
-      amount: quickExpenseForm.amount,
+      amount,
       category: quickExpenseForm.category || 'otros',
       expense_date: projectDate,
       is_deductible: true,

--- a/src/pages/Settings/Settings.jsx
+++ b/src/pages/Settings/Settings.jsx
@@ -25,10 +25,18 @@ export default function Settings() {
       return
     }
     setSaving(true)
+    const usageConsent = formData.get('usage_consent') === 'on'
+    const usageConsentChanged = usageConsent !== Boolean(profile?.usage_consent)
+    const consentTimestamp = usageConsentChanged
+      ? (usageConsent ? new Date().toISOString() : null)
+      : (profile?.usage_consent_at ?? null)
     const { error: updateError } = await updateProfile({
       full_name: formData.get('full_name').trim(),
       profession: formData.get('profession').trim(),
       tax_rate: taxRate,
+      usage_consent: usageConsent,
+      usage_consent_at: consentTimestamp,
+      usage_consent_version: usageConsent ? 'beta-8' : profile?.usage_consent_version,
     })
     setSaving(false)
     if (updateError) { addToast('Error al guardar los ajustes.', 'error'); return }
@@ -80,6 +88,21 @@ export default function Settings() {
               <p className="text-xs text-gray-400">
                 Este porcentaje se usará como valor por defecto al registrar nuevos ingresos.
               </p>
+              <label className="flex items-start gap-3 rounded-lg border border-[var(--color-paper-mid)] bg-[#FDFBF6] p-4 text-sm text-[var(--color-ink)]">
+                <input
+                  type="checkbox"
+                  name="usage_consent"
+                  defaultChecked={Boolean(profile?.usage_consent)}
+                  onChange={() => setError('')}
+                  className="mt-1 h-5 w-5 rounded border-[var(--color-paper-mid)] accent-[var(--color-red)]"
+                />
+                <span>
+                  <span className="block font-medium">Ayudar a mejorar la beta</span>
+                  <span className="mt-1 block text-[var(--color-ink-muted)]">
+                    Guardamos tu preferencia de consentimiento en el perfil. En beta 8 no se activa analítica real ni se envían eventos de uso.
+                  </span>
+                </span>
+              </label>
               {error && <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
               <div className="flex justify-end">
                 <Button type="submit" disabled={saving} className="justify-center">
@@ -107,6 +130,20 @@ export default function Settings() {
                 Cerrar sesión
               </Button>
             </div>
+          </div>
+        </Card>
+        <Card className="p-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-sm font-semibold text-gray-900 mb-1">Primeros pasos</h2>
+              <p className="text-sm text-gray-500">Puedes volver a revisar el resumen inicial de proyectos, eventos y cobros.</p>
+            </div>
+            <Link
+              to="/onboarding"
+              className="inline-flex min-h-10 items-center justify-center rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-paper)] px-4 py-2 text-sm font-medium leading-none text-[var(--color-ink)] shadow-sm transition-colors hover:bg-[var(--color-paper-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-red)] focus-visible:ring-offset-2"
+            >
+              Ver onboarding
+            </Link>
           </div>
         </Card>
       </div>

--- a/supabase/migrations/20260507120000_beta_invites.sql
+++ b/supabase/migrations/20260507120000_beta_invites.sql
@@ -1,0 +1,165 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.beta_invites (
+  id uuid primary key default gen_random_uuid(),
+  code_hash text not null unique,
+  label text,
+  max_redemptions integer not null default 1 check (max_redemptions > 0),
+  redeemed_count integer not null default 0 check (redeemed_count >= 0),
+  expires_at timestamptz,
+  revoked_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint beta_invites_redeemed_count_lte_max check (redeemed_count <= max_redemptions),
+  constraint beta_invites_code_hash_sha256 check (code_hash ~ '^[0-9a-f]{64}$')
+);
+
+create table if not exists public.beta_invite_redemptions (
+  id uuid primary key default gen_random_uuid(),
+  invite_id uuid not null references public.beta_invites(id) on delete restrict,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  redeemed_at timestamptz not null default now(),
+  unique (user_id)
+);
+
+alter table public.beta_invites enable row level security;
+alter table public.beta_invite_redemptions enable row level security;
+
+alter table public.profiles
+  add column if not exists onboarding_completed boolean not null default false,
+  add column if not exists onboarding_completed_at timestamptz,
+  add column if not exists usage_consent boolean not null default false,
+  add column if not exists usage_consent_at timestamptz,
+  add column if not exists usage_consent_version text,
+  add column if not exists beta_invite_id uuid;
+
+update public.profiles
+set
+  onboarding_completed = true,
+  onboarding_completed_at = coalesce(onboarding_completed_at, created_at, now())
+where beta_invite_id is null
+  and onboarding_completed = false;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'profiles_beta_invite_id_fkey'
+      and conrelid = 'public.profiles'::regclass
+  ) then
+    alter table public.profiles
+      add constraint profiles_beta_invite_id_fkey
+      foreign key (beta_invite_id) references public.beta_invites(id) on delete set null;
+  end if;
+end;
+$$;
+
+create index if not exists beta_invites_available_idx
+  on public.beta_invites (expires_at, revoked_at);
+
+create index if not exists beta_invite_redemptions_invite_id_idx
+  on public.beta_invite_redemptions (invite_id);
+
+create index if not exists profiles_beta_invite_id_idx
+  on public.profiles (beta_invite_id);
+
+create or replace function public.set_beta_invites_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists beta_invites_set_updated_at on public.beta_invites;
+create trigger beta_invites_set_updated_at
+  before update on public.beta_invites
+  for each row execute function public.set_beta_invites_updated_at();
+
+create or replace function public.prevent_beta_invite_profile_changes()
+returns trigger
+language plpgsql
+as $$
+begin
+  if auth.uid() is not null and old.beta_invite_id is distinct from new.beta_invite_id then
+    raise exception 'beta_invite_id_is_immutable';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists profiles_prevent_beta_invite_changes on public.profiles;
+create trigger profiles_prevent_beta_invite_changes
+  before update on public.profiles
+  for each row execute function public.prevent_beta_invite_profile_changes();
+
+drop trigger if exists on_auth_user_created on auth.users;
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  invite_code text;
+  invite_hash text;
+  claimed_invite_id uuid;
+begin
+  invite_code := nullif(lower(trim(new.raw_user_meta_data->>'beta_invite_code')), '');
+
+  if invite_code is null then
+    raise exception 'beta_invite_code_required'
+      using errcode = 'P0001',
+            hint = 'Incluye un codigo de invitacion beta valido para crear la cuenta.';
+  end if;
+
+  invite_hash := encode(digest(invite_code, 'sha256'), 'hex');
+
+  update public.beta_invites
+  set redeemed_count = redeemed_count + 1
+  where code_hash = invite_hash
+    and revoked_at is null
+    and (expires_at is null or expires_at > now())
+    and redeemed_count < max_redemptions
+  returning id into claimed_invite_id;
+
+  if claimed_invite_id is null then
+    raise exception 'beta_invite_code_invalid_or_redeemed'
+      using errcode = 'P0001',
+            hint = 'El codigo de invitacion beta no existe, ha caducado o ya se ha consumido.';
+  end if;
+
+  insert into public.beta_invite_redemptions (invite_id, user_id)
+  values (claimed_invite_id, new.id);
+
+  insert into public.profiles (
+    id,
+    full_name,
+    profession,
+    beta_invite_id
+  )
+  values (
+    new.id,
+    new.raw_user_meta_data->>'full_name',
+    new.raw_user_meta_data->>'profession',
+    claimed_invite_id
+  );
+
+  return new;
+end;
+$$;
+
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();
+
+comment on table public.beta_invites is
+  'Private beta invitation codes stored only as normalized SHA-256 hashes. No anon/authenticated SELECT policy by design.';
+
+comment on table public.beta_invite_redemptions is
+  'Audit trail for beta invitation consumption. No anon/authenticated SELECT policy by design.';


### PR DESCRIPTION
## Summary
- Añade acceso beta privado por invitación con consumo atómico en Supabase y sin lectura pública de invitaciones.
- Incorpora onboarding privado de primera sesión, `ProfileGate`, consentimiento básico y ajustes en registro/ajustes.
- Cierra preflight de beta 8: gasto rápido con `parseDecimal`, copy CSV más claro y drift documental beta 6.

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`
- `npm run pb:check`
- `git diff --check`

## Memoria
No aplica: no hay reglas duraderas nuevas; se mantienen las reglas existentes de `useProfile`, RLS y cierre de release.