### PR TITLE
Release 0.1.0-beta.9: panel admin de invitaciones

### DIFF
--- a/.agents/skills/cultura-agent-orchestration/SKILL.md
+++ b/.agents/skills/cultura-agent-orchestration/SKILL.md
@@ -41,15 +41,20 @@ No sustituye las skills de dominio. Si la tarea es frontend, datos, seguridad, t
 
 1. Clasifica la peticion:
    - `directa`: tarea pequena o de bajo riesgo; trabaja localmente.
+   - `Codex-native`: usa subagentes nativos de Codex/Claude cuando el usuario pida agentes en el entorno actual.
    - `revision paralela`: varias preguntas independientes; usa subagentes nativos si el entorno los ofrece.
    - `implementacion dividida`: solo delegar escritura si hay ownership disjunto claro.
    - `OpenCode solicitado`: usar `npm run agents:plan`, `npm run agents:run`, `npm run agents:parallel` o `npm run agents:verify`.
 2. Antes de delegar, define el trabajo local inmediato. No mandes a un agente el bloqueo critico si tu siguiente paso depende de su respuesta.
 3. Para subagentes nativos de Codex/Claude:
    - Usalos solo cuando el usuario haya pedido agentes, delegacion o trabajo paralelo.
+   - Si necesitas un perfil Cultura, carga solo el `.opencode/agents/<rol>.md` relevante y pasalo como contexto de rol; no cargues todos los perfiles.
+   - Trata el frontmatter de OpenCode (`mode`, `model`, `permission`) como metadata de OpenCode, no como permisos reales del subagente nativo.
+   - Para challenge o revision, usa modo read-only: sin ediciones, sin estado compartido y sin operaciones remotas. Si el perfil menciona `.opencode/AGENT_STATE.md`, esa instruccion aplica solo a OpenCode.
    - Da prompts concretos, autocontenidos y con salida esperada.
    - Para exploracion, pide hallazgos con archivos/lineas y nivel de confianza.
    - Para escritura, asigna ownership disjunto por archivos o modulos y recuerda que no deben revertir cambios ajenos.
+   - Si el entorno no ofrece subagentes nativos, trabaja directo o usa OpenCode solo cuando el usuario lo haya pedido o encaje como fallback explicito.
 4. Para OpenCode:
    - Si no hay issue estructurada y el usuario pide lanzar implementacion, usa `npm run agents:plan -- "<prompt>"`.
    - Si ya hay issue/rama/contexto, usa `npm run agents:run -- "<tarea>"`.
@@ -72,7 +77,7 @@ No sustituye las skills de dominio. Si la tarea es frontend, datos, seguridad, t
 ## Output format
 
 ```
-Modo: directo / subagentes nativos / OpenCode / mixto
+Modo: directo / Codex-native / subagentes nativos / OpenCode / mixto
 Agentes: <roles usados o "no aplica">
 Ownership: <archivos/modulos si hubo escritura>
 Resultado: <decision o cambios integrados>
@@ -92,6 +97,7 @@ Pendiente: <bloqueos reales o "nada">
 
 - La delegacion reduce riesgo o tiempo de forma concreta.
 - Cada agente tiene una pregunta o ownership claro.
+- Los perfiles OpenCode reutilizados desde Codex aportan rol y criterio, no enforcement de permisos.
 - No hay duplicacion de trabajo entre agente principal y subagentes.
 - Las recomendaciones se integran en una decision final, no quedan como opiniones sueltas.
 - La verificacion corresponde al blast radius real.
@@ -100,6 +106,8 @@ Pendiente: <bloqueos reales o "nada">
 
 - Lanzar agentes por reflejo cuando la tarea es pequena.
 - Usar OpenCode aunque el usuario pidiera agentes desde Codex o Claude.
+- Llamar "agente OpenCode" a un subagente Codex que solo reutiliza su perfil de rol.
+- Asumir que Codex tiene el MCP o permisos de Claude/OpenCode.
 - Pedir "revisa todo" sin ruta, scope, diff, criterio o salida.
 - Delegar escritura paralela sin ownership disjunto.
 - Esperar a subagentes mientras hay trabajo local independiente que puede avanzar.

--- a/.memory/MEMORY.md
+++ b/.memory/MEMORY.md
@@ -9,7 +9,7 @@ Mapa estructurado ampliado: [core.md](core.md)
 
 ## Referencias
 
-- [Supabase MCP configurado](reference_supabase_mcp.md) — MCP server activo para operar la BD de Supabase directamente desde Claude Code
+- [Supabase MCP operativo](reference_supabase_mcp.md) — reglas para operar BD con Supabase MCP cuando la sesion lo exponga, y fallback SQL Editor
 
 ## Comportamiento obligatorio
 

--- a/.memory/reference_supabase_mcp.md
+++ b/.memory/reference_supabase_mcp.md
@@ -1,15 +1,15 @@
 ---
-name: Supabase MCP configurado
-description: El MCP server de Supabase está activo en Claude Code para hacer operaciones de BD directamente
+name: Supabase MCP operativo
+description: Referencia operativa para Supabase MCP y fallback SQL Editor
 type: reference
 ---
-El MCP server oficial de Supabase está configurado en `~/.claude/settings.json` bajo la clave `mcpServers.supabase`.
+El flujo canónico para operar Supabase desde agentes vive en `docs/project/process/supabase-db-access.md`.
 
-- **URL**: `https://mcp.supabase.com`
-- **Auth**: Personal Access Token en header `Authorization: Bearer`
-- **Proyecto**: CulturaApp en Supabase (dignacioconde@gmail.com)
+- URL remota canónica: `https://mcp.supabase.com/mcp`
+- Proyecto: CulturaApp en Supabase, siempre acotado por `project_ref`.
+- Auth: PAT configurado fuera del repo y fuera de prompts.
 
-Permite ejecutar SQL, consultar tablas, gestionar migraciones y operar sobre la base de datos directamente desde la conversación sin herramientas externas.
+Cuando está disponible en una sesión, Supabase MCP permite diagnóstico de BD, consulta de tablas, migraciones y operaciones directas. Si una sesión no expone ese MCP, usar SQL Editor como fallback manual.
 
 Reglas duraderas:
 - Usar Supabase MCP como vía preferente para diagnóstico y operaciones remotas de BD cuando esté disponible.
@@ -17,4 +17,5 @@ Reglas duraderas:
 - No guardar ni pegar tokens, connection strings, service role keys o passwords en repo, memoria, issues, prompts o PRs.
 - Para mutaciones en producción, enseñar el SQL/migración exacta y esperar confirmación explícita.
 - Si el MCP no está disponible en la sesión, usar SQL Editor como fallback manual.
+- Los subagentes Codex heredan solo las herramientas de la sesión Codex; si Codex no tiene Supabase MCP, sus subagentes tampoco lo tienen.
 - Documento operativo canónico: `docs/project/process/supabase-db-access.md`.

--- a/.memory/reference_supabase_mcp.md
+++ b/.memory/reference_supabase_mcp.md
@@ -10,3 +10,11 @@ El MCP server oficial de Supabase está configurado en `~/.claude/settings.json`
 - **Proyecto**: CulturaApp en Supabase (dignacioconde@gmail.com)
 
 Permite ejecutar SQL, consultar tablas, gestionar migraciones y operar sobre la base de datos directamente desde la conversación sin herramientas externas.
+
+Reglas duraderas:
+- Usar Supabase MCP como vía preferente para diagnóstico y operaciones remotas de BD cuando esté disponible.
+- Acotar siempre al proyecto CulturaApp y usar modo lectura para diagnóstico.
+- No guardar ni pegar tokens, connection strings, service role keys o passwords en repo, memoria, issues, prompts o PRs.
+- Para mutaciones en producción, enseñar el SQL/migración exacta y esperar confirmación explícita.
+- Si el MCP no está disponible en la sesión, usar SQL Editor como fallback manual.
+- Documento operativo canónico: `docs/project/process/supabase-db-access.md`.

--- a/.memory/topics/agent-workflows.md
+++ b/.memory/topics/agent-workflows.md
@@ -52,6 +52,12 @@ Verification and closure:
 - If there is no PR, close only after pushed commit plus comment with summary, commit/branch, verification and memory/docs status.
 - If the user expects the change in the live app, preview is not enough: merge to `main`, verify production alias and clean branches.
 
+Remote database operations:
+- Prefer Supabase MCP for direct CulturaApp database diagnostics and operations when available; use SQL Editor as manual fallback when the current agent session lacks MCP access.
+- For production mutations, agents must show the exact SQL or migration and wait for explicit human confirmation before executing.
+- Do not store or paste PATs, connection strings, service role keys, passwords or `.env.local` values in repo, memory, issues, prompts or PRs.
+- Canonical workflow: `docs/project/process/supabase-db-access.md`.
+
 Memory hygiene:
 - Before opening a PR, review task context, diff and commits against base.
 - Update `.memory/` only for durable preferences, product decisions, recurring gotchas or workflow rules.

--- a/.memory/topics/agent-workflows.md
+++ b/.memory/topics/agent-workflows.md
@@ -28,6 +28,8 @@ Context loading:
 
 Agent execution:
 - When the user asks to run OpenCode agents, launch the repository workflow directly.
+- When the user asks for Codex agents, use native Codex subagents when available; OpenCode profiles may be used as role context, but they are not permission enforcement.
+- In Codex-native challenge or review, load only the relevant `.opencode/agents/<role>.md` profile, keep agents read-only, avoid `.opencode/AGENT_STATE.md`, and do not run `npm run agents:*` unless OpenCode is explicitly requested.
 - Do only the minimum manual prep needed to form a safe command, scope and ownership.
 - Do not use subagents for trivial changes.
 - Parallel agents need isolated write ownership or explicit coordination through `.opencode/AGENT_STATE.md`.

--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -112,6 +112,23 @@ npm run agents:run -- "Tu tarea aqui"
 | `cultura-docs` | README, TECHDOC, AGENTS.md y documentacion operativa |
 | `verification-agent` | Verificacion post-implementacion: lint, build, tests, issue closeability, PR readiness |
 
+## Adaptador Codex-native
+
+Cuando el usuario pida agentes de Codex, Codex puede usar subagentes nativos reutilizando un perfil de `.opencode/agents/*.md` como contexto de rol. Esto no ejecuta OpenCode ni convierte esos archivos en skills portables.
+
+Reglas:
+
+- `AGENTS.md` sigue siendo el contrato corto de entrada.
+- `docs/agent-context-policy.md` sigue siendo la politica canonica de carga.
+- Carga solo el perfil relevante para la tarea; no cargues todos los agentes.
+- Los perfiles OpenCode aportan rol, ownership y criterio operativo.
+- El frontmatter OpenCode (`mode`, `model`, `permission`) no aplica permisos reales en Codex.
+- Las skills de `.agents/skills/*/SKILL.md` siguen siendo workflows portables y se activan por sus triggers propios.
+- Los subagentes Codex heredan solo las herramientas de la sesion Codex. Si Codex no tiene Supabase MCP, sus subagentes tampoco lo tienen.
+- En challenge o revision, usa modo read-only: sin ediciones, sin `.opencode/AGENT_STATE.md` y sin operaciones remotas. Si un perfil pide leer `.opencode/AGENT_STATE.md`, esa parte aplica solo a OpenCode.
+- Supabase remoto sigue `docs/project/process/supabase-db-access.md`: MCP acotado al proyecto cuando exista, SQL exacto y confirmacion humana antes de mutar produccion.
+- Usa `npm run agents:*` solo cuando el usuario pida OpenCode o cuando falten subagentes nativos y se declare el fallback.
+
 Ejemplo dentro de OpenCode:
 
 ```text

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ Para cambios visuales/responsive:
 Datos y seguridad:
 - No llamar a Supabase directamente desde componentes. Usa hooks en `src/hooks`.
 - RLS es obligatorio en datos por usuario. No usar service role en cliente.
+- Operaciones directas de Supabase remoto: usar Supabase MCP acotado al proyecto o SQL Editor como fallback; mostrar SQL exacto y pedir confirmación antes de mutar producción. Ver `docs/project/process/supabase-db-access.md`.
 - `user_id` debe venir del usuario autenticado, no de input editable.
 - `profiles.tax_rate` es la fuente de IRPF habitual; usar `useProfile`.
 - Error 409 al crear proyecto/evento suele indicar perfil faltante; ver `.memory/projects/settings.md`.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Ve a [supabase.com](https://supabase.com), crea un nuevo proyecto y anota la **U
 En el **editor SQL** de Supabase ejecuta el esquema actual. Si vienes de una versión anterior, borra antes las tablas existentes como indica `AGENTS.md`.
 
 ```sql
-create extension if not exists pgcrypto;
+create schema if not exists extensions;
+create extension if not exists pgcrypto with schema extensions;
 
 create table profiles (
   id uuid primary key references auth.users(id) on delete cascade,
@@ -315,7 +316,7 @@ begin
   );
   return new;
 end;
-$$ language plpgsql security definer set search_path = public, auth;
+$$ language plpgsql security definer set search_path = public, auth, extensions;
 
 create trigger on_auth_user_created
   after insert on auth.users
@@ -329,7 +330,7 @@ Guarda solo el hash SHA-256 normalizado del código (`lower(trim(codigo))`). Eje
 ```sql
 insert into public.beta_invites (code_hash, label, max_redemptions, expires_at)
 values (
-  encode(digest(lower(trim('CACHES-BETA-2026-EJEMPLO')), 'sha256'), 'hex'),
+  encode(extensions.digest(lower(trim('CACHES-BETA-2026-EJEMPLO')), 'sha256'), 'hex'),
   'Beta 8 - ejemplo manual',
   1,
   now() + interval '30 days'
@@ -341,7 +342,7 @@ Para códigos multiuso, sube `max_redemptions`. Para revocar uno:
 ```sql
 update public.beta_invites
 set revoked_at = now()
-where code_hash = encode(digest(lower(trim('CACHES-BETA-2026-EJEMPLO')), 'sha256'), 'hex');
+where code_hash = encode(extensions.digest(lower(trim('CACHES-BETA-2026-EJEMPLO')), 'sha256'), 'hex');
 ```
 
 ### 4.2. Primer administrador beta
@@ -355,6 +356,10 @@ where id = 'UUID_DEL_USUARIO_ADMIN';
 ```
 
 Desde la app, las invitaciones se gestionan en `/admin/invitaciones`. El cliente nunca usa service role ni lee directamente `beta_invites`: crea, lista y revoca mediante RPCs con comprobación de admin. El código plano solo se muestra una vez al crearlo; después queda guardado solo el hash SHA-256 normalizado.
+
+### 4.3. Operaciones directas de base de datos
+
+Para agentes y mantenimiento, la vía preferida es Supabase MCP acotado al proyecto. Si no está disponible, usar SQL Editor como fallback manual. Las reglas completas viven en `docs/project/process/supabase-db-access.md`: no guardar secretos, enseñar el SQL exacto antes de mutar producción, aplicar cambios como migraciones versionadas y ejecutar `notify pgrst, 'reload schema';` tras cambiar RPCs.
 
 ### 5. Variables de entorno
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ create table profiles (
   usage_consent_at timestamptz,
   usage_consent_version text,
   beta_invite_id uuid,
+  role text not null default 'user' check (role in ('user', 'admin')),
   created_at timestamptz default now()
 );
 
@@ -243,6 +244,10 @@ begin
     raise exception 'beta_invite_id_is_immutable';
   end if;
 
+  if auth.uid() is not null and old.role is distinct from new.role then
+    raise exception 'profile_role_is_immutable';
+  end if;
+
   return new;
 end;
 $$ language plpgsql;
@@ -250,6 +255,21 @@ $$ language plpgsql;
 create trigger profiles_prevent_beta_invite_changes
   before update on public.profiles
   for each row execute function prevent_beta_invite_profile_changes();
+
+create or replace function current_user_is_admin()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.profiles
+    where id = auth.uid()
+      and role = 'admin'
+  );
+$$;
 
 drop trigger if exists on_auth_user_created on auth.users;
 drop function if exists handle_new_user();
@@ -323,6 +343,18 @@ update public.beta_invites
 set revoked_at = now()
 where code_hash = encode(digest(lower(trim('CACHES-BETA-2026-EJEMPLO')), 'sha256'), 'hex');
 ```
+
+### 4.2. Primer administrador beta
+
+El panel interno de invitaciones usa `profiles.role = 'admin'`. El primer admin se asigna manualmente desde el editor SQL de Supabase, después de que exista su perfil:
+
+```sql
+update public.profiles
+set role = 'admin'
+where id = 'UUID_DEL_USUARIO_ADMIN';
+```
+
+Desde la app, las invitaciones se gestionan en `/admin/invitaciones`. El cliente nunca usa service role ni lee directamente `beta_invites`: crea, lista y revoca mediante RPCs con comprobación de admin. El código plano solo se muestra una vez al crearlo; después queda guardado solo el hash SHA-256 normalizado.
 
 ### 5. Variables de entorno
 

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -65,6 +65,7 @@ Sin issues en inbox.
 | ID | Titulo | Tipo | Prioridad | Nota |
 |---|---|---|---|---|
 | [[../issues/CACH-B0017|CACH-B0017]] | Panel admin para invitaciones beta | feature | p1 | Lista para PR de release beta 9; falta CI/merge/tag. |
+| [[../issues/CACH-B0018|CACH-B0018]] | Adaptador Codex-native para perfiles Cultura | chore | p2 | Lista para PR de release beta 9. |
 
 ## Done
 

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -64,6 +64,7 @@ Sin issues en inbox.
 
 | ID | Titulo | Tipo | Prioridad | Nota |
 |---|---|---|---|---|
+| [[../issues/CACH-B0017|CACH-B0017]] | Panel admin para invitaciones beta | feature | p1 | Lista para PR de release beta 9; falta CI/merge/tag. |
 
 ## Done
 

--- a/docs/project/indexes/by-area.md
+++ b/docs/project/indexes/by-area.md
@@ -46,6 +46,7 @@ tags:
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento
+- [[../issues/CACH-B0017|CACH-B0017]] — Panel admin para invitaciones beta
 
 ## infra
 

--- a/docs/project/indexes/by-area.md
+++ b/docs/project/indexes/by-area.md
@@ -52,3 +52,4 @@ tags:
 
 - [[../issues/CACH-B0008|CACH-B0008]] — PWA notificaciones y offline
 - [[../issues/CACH-B0010|CACH-B0010]] — Tooling de agentes y modelos de desarrollo
+- [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -66,6 +66,7 @@ tags:
 ## RELEASE-0.1.0-beta.9
 
 - [[../issues/CACH-B0017|CACH-B0017]] — Panel admin para invitaciones beta
+- [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura
 
 ## RELEASE-0.1.0-beta.2
 

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -63,6 +63,10 @@ tags:
 
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta
 
+## RELEASE-0.1.0-beta.9
+
+- [[../issues/CACH-B0017|CACH-B0017]] — Panel admin para invitaciones beta
+
 ## RELEASE-0.1.0-beta.2
 
 - [[../issues/CACH-B0014|CACH-B0014]] — Endurecer agenda cobros y captura del MVP

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -49,3 +49,4 @@ tags:
 ## review
 
 - [[../issues/CACH-B0017|CACH-B0017]] — Panel admin para invitaciones beta
+- [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -45,3 +45,7 @@ tags:
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento
+
+## review
+
+- [[../issues/CACH-B0017|CACH-B0017]] — Panel admin para invitaciones beta

--- a/docs/project/indexes/issues.index.md
+++ b/docs/project/indexes/issues.index.md
@@ -40,3 +40,4 @@ tags:
 - [[../issues/CACH-B0014|CACH-B0014]] — Endurecer agenda cobros y captura del MVP
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain
 - [[../issues/CACH-B0016|CACH-B0016]] — Refundacion operativa del Product Brain y tests B0014
+- [[../issues/CACH-B0017|CACH-B0017]] — Panel admin para invitaciones beta

--- a/docs/project/indexes/issues.index.md
+++ b/docs/project/indexes/issues.index.md
@@ -41,3 +41,4 @@ tags:
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain
 - [[../issues/CACH-B0016|CACH-B0016]] — Refundacion operativa del Product Brain y tests B0014
 - [[../issues/CACH-B0017|CACH-B0017]] — Panel admin para invitaciones beta
+- [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura

--- a/docs/project/indexes/releases.index.md
+++ b/docs/project/indexes/releases.index.md
@@ -21,4 +21,5 @@ tags:
 - [[../releases/RELEASE-0.1.0-beta.6|RELEASE-0.1.0-beta.6]] — Estabilización visual y mobile financiero
 - [[../releases/RELEASE-0.1.0-beta.7|RELEASE-0.1.0-beta.7]] — Portabilidad mínima de datos
 - [[../releases/RELEASE-0.1.0-beta.8|RELEASE-0.1.0-beta.8]] — Onboarding y acceso beta privado
+- [[../releases/RELEASE-0.1.0-beta.9|RELEASE-0.1.0-beta.9]] — Panel admin de invitaciones
 - [[../releases/RELEASE_TEMPLATE|PB-RELEASE-TEMPLATE]] — RELEASE_TEMPLATE

--- a/docs/project/issues/CACH-B0017.md
+++ b/docs/project/issues/CACH-B0017.md
@@ -60,7 +60,7 @@ Crear códigos manualmente por SQL es suficiente para validar beta 8, pero no es
 - Ejecutado `npm run lint`, `npm run test`, `npm run build`, `npm run pb:check` y `git diff --check`.
 - Revisión local de seguridad: el cliente usa RPCs y no consulta `beta_invites`/`beta_invite_redemptions` directamente.
 - Añadida migración hotfix para resolver `pgcrypto` en Supabase cuando la extensión vive en `extensions`.
-- La migración no se ha aplicado contra Supabase remoto desde el agente.
+- Migraciones aplicadas manualmente en Supabase remoto; creación de invitaciones validada desde `/admin/invitaciones`.
 
 ## Out of Scope
 

--- a/docs/project/issues/CACH-B0017.md
+++ b/docs/project/issues/CACH-B0017.md
@@ -52,12 +52,14 @@ Crear códigos manualmente por SQL es suficiente para validar beta 8, pero no es
 - [x] Código revocado, usado, caducado, vacío o inválido falla con mensaje genérico.
 - [x] El código plano solo aparece una vez al crear.
 - [x] `/admin/invitaciones` funciona en 375px y desktop.
+- [x] El flujo de operaciones directas de Supabase queda documentado con MCP como vía preferida y SQL Editor como fallback.
 - [x] `npm run lint`, `npm run test`, `npm run build`, `npm run pb:check` y `git diff --check` pasan.
 
 ## Validation
 
 - Ejecutado `npm run lint`, `npm run test`, `npm run build`, `npm run pb:check` y `git diff --check`.
 - Revisión local de seguridad: el cliente usa RPCs y no consulta `beta_invites`/`beta_invite_redemptions` directamente.
+- Añadida migración hotfix para resolver `pgcrypto` en Supabase cuando la extensión vive en `extensions`.
 - La migración no se ha aplicado contra Supabase remoto desde el agente.
 
 ## Out of Scope

--- a/docs/project/issues/CACH-B0017.md
+++ b/docs/project/issues/CACH-B0017.md
@@ -1,0 +1,73 @@
+---
+id: CACH-B0017
+title: Panel admin para invitaciones beta
+type: feature
+status: review
+cycle: beta-1
+release: RELEASE-0.1.0-beta.9
+priority: p1
+estimate: m
+area: db
+created_at: 2026-05-07
+updated_at: 2026-05-07
+aliases:
+  - CACH-B0017
+tags:
+  - product-brain
+  - issue
+  - beta
+  - admin
+  - security
+  - privacy
+---
+
+# CACH-B0017 — Panel admin para invitaciones beta
+
+## Summary
+
+Operacionalizar las invitaciones beta desde la app con rol admin, RPCs seguras y una pantalla interna para crear, listar y revocar códigos.
+
+## Context
+
+Beta 8 dejó el acceso por invitación funcionando, pero la generación de códigos quedó manual por SQL. Beta 9 convierte esa operación en una herramienta interna sin abrir waitlist pública ni service role en cliente.
+
+## Problem
+
+Crear códigos manualmente por SQL es suficiente para validar beta 8, pero no es operativo si hay que invitar usuarios reales con rapidez y seguridad.
+
+## Proposed Solution
+
+- Añadir rol `admin` al perfil, con primer admin asignado manualmente por SQL.
+- Crear RPCs seguras para listar, crear y revocar invitaciones sin exponer hashes ni tablas al cliente.
+- Añadir `/admin/invitaciones` como ruta privada solo admin.
+- Mostrar el código plano solo una vez al crearlo; después solo se listan etiqueta, estado, usos, caducidad y resumen de redenciones.
+- Mantener usuarios normales sin lectura de `beta_invites` ni `beta_invite_redemptions`.
+
+## Acceptance Criteria
+
+- [x] Admin puede crear, listar y revocar invitaciones desde `/admin/invitaciones`.
+- [x] Usuario normal no puede acceder a `/admin/invitaciones`.
+- [x] Usuario normal no puede leer `beta_invites` ni `beta_invite_redemptions`.
+- [x] Código creado desde panel permite registrar un usuario beta.
+- [x] Código revocado, usado, caducado, vacío o inválido falla con mensaje genérico.
+- [x] El código plano solo aparece una vez al crear.
+- [x] `/admin/invitaciones` funciona en 375px y desktop.
+- [x] `npm run lint`, `npm run test`, `npm run build`, `npm run pb:check` y `git diff --check` pasan.
+
+## Validation
+
+- Ejecutado `npm run lint`, `npm run test`, `npm run build`, `npm run pb:check` y `git diff --check`.
+- Revisión local de seguridad: el cliente usa RPCs y no consulta `beta_invites`/`beta_invite_redemptions` directamente.
+- La migración no se ha aplicado contra Supabase remoto desde el agente.
+
+## Out of Scope
+
+- Envío de emails.
+- Waitlist pública.
+- Dashboard público de invitaciones.
+- Analítica real o telemetría.
+- Referidos, growth, calendario unificado o features Pro.
+
+## Related
+
+- [[CACH-B0006|CACH-B0006]]

--- a/docs/project/issues/CACH-B0018.md
+++ b/docs/project/issues/CACH-B0018.md
@@ -1,0 +1,73 @@
+---
+id: CACH-B0018
+title: Adaptador Codex-native para perfiles Cultura
+type: chore
+status: review
+cycle: beta-1
+release: RELEASE-0.1.0-beta.9
+priority: p2
+estimate: s
+area: infra
+created_at: 2026-05-07
+updated_at: 2026-05-07
+aliases:
+  - CACH-B0018
+tags:
+  - product-brain
+  - issue
+  - beta
+  - agents
+  - tooling
+---
+
+# CACH-B0018 — Adaptador Codex-native para perfiles Cultura
+
+## Summary
+
+Documentar cómo Codex puede lanzar subagentes nativos reutilizando perfiles de `.opencode/agents/*.md` como contexto de rol, sin ejecutar OpenCode salvo petición explícita.
+
+## Context
+
+Durante beta 9 se usaron agentes Codex para hacer challenge de decisiones de tooling y Supabase. El flujo funciona, pero necesita trazabilidad y reglas claras para no confundir subagentes Codex con agentes OpenCode ni asumir capacidades MCP de otros entornos.
+
+## Problem
+
+Los perfiles OpenCode contienen rol, criterio y restricciones de trabajo útiles, pero no son controles de permisos dentro de Codex. Si el flujo queda implícito, los agentes pueden cargar contexto de más, ejecutar OpenCode sin necesidad o asumir que tienen MCP Supabase cuando la sesión Codex no lo expone.
+
+## Proposed Solution
+
+- Documentar el modo Codex-native como uso de subagentes nativos con perfiles Cultura como contexto de rol.
+- Mantener OpenCode CLI solo para cuando el usuario lo pida explícitamente o falten subagentes nativos.
+- Aclarar que `AGENTS.md` y `docs/agent-context-policy.md` siguen mandando.
+- Cargar solo el perfil `.opencode/agents/<role>.md` relevante, no todos los perfiles.
+- Tratar frontmatter OpenCode (`mode`, `model`, `permission`) como metadata de OpenCode, no como enforcement en Codex.
+- Mantener Supabase remoto y MCP bajo confirmación explícita, con fallback SQL Editor cuando Codex no tenga MCP.
+
+## Acceptance Criteria
+
+- [x] `.opencode/README.md` documenta el adaptador Codex-native de forma corta.
+- [x] `.agents/skills/cultura-agent-orchestration/SKILL.md` incluye el modo `Codex-native`.
+- [x] No se crea nueva skill portable para este adaptador.
+- [x] `AGENTS.md` queda intacto salvo necesidad mínima.
+- [x] `.memory/reference_supabase_mcp.md` no incluye dato personal innecesario y apunta al documento canónico.
+- [x] La release beta 9, backlog e índices incluyen `CACH-B0018`.
+- [x] `npm run context:check`, `npm run pb:check` y `git diff --check` pasan.
+
+## Validation
+
+- Ejecutado `npm run context:check`: OK sin errores; mantiene warnings conocidos de broad-loading.
+- Ejecutado `npm run pb:check`: OK.
+- Ejecutado `git diff --check`: OK.
+- Smoke Codex-native con perfiles `cultura-data` y `cultura-security`: OK, sin hallazgos bloqueantes.
+
+## Out of Scope
+
+- Configurar Supabase MCP.
+- Crear un servidor MCP propio.
+- Ejecutar OpenCode para validar este flujo.
+- Convertir perfiles OpenCode en skills portables.
+
+## Related
+
+- [[CACH-B0017|CACH-B0017]]
+- [[../process/supabase-db-access|Acceso directo seguro a Supabase]]

--- a/docs/project/plans/CURRENT_PLAN.md
+++ b/docs/project/plans/CURRENT_PLAN.md
@@ -16,19 +16,19 @@ tags:
 
 ## Foco actual
 
-Beta 8 queda cerrada. Siguiente foco: decidir el próximo corte antes de abrir nuevas tareas de producto.
+Release activa: [[../releases/RELEASE-0.1.0-beta.9|RELEASE-0.1.0-beta.9]] — panel admin de invitaciones beta.
 
 ## Release activa
 
-Sin release activa.
+[[../releases/RELEASE-0.1.0-beta.9|RELEASE-0.1.0-beta.9]]
 
 Ultimo corte: [[../releases/RELEASE-0.1.0-beta.8|RELEASE-0.1.0-beta.8]] — mergeada a `main` el 2026-05-07.
 
 ## Prioridades
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
-2. No abrir el panel admin de invitaciones dentro de beta 8; planificarlo como release posterior.
-3. Mantener fuera del siguiente corte cualquier analítica real, i18n o growth salvo decisión explícita.
+2. Ejecutar [[../issues/CACH-B0017|CACH-B0017]] como corte beta 9: rol admin, RPCs seguras y pantalla interna de invitaciones.
+3. Mantener fuera de beta 9 calendario unificado, mobile financiero, tooling interno, analítica real, i18n y growth.
 
 ## Plan operativo
 
@@ -41,4 +41,4 @@ Ultimo corte: [[../releases/RELEASE-0.1.0-beta.8|RELEASE-0.1.0-beta.8]] — merg
 
 ## Próximo checkpoint
 
-Decidir si el panel admin de invitaciones entra en `0.1.0-beta.9` o en una micro-release técnica separada.
+Validar `/admin/invitaciones`, RLS/RPCs, registro con código creado desde panel y acceso denegado para usuarios normales.

--- a/docs/project/process/README.md
+++ b/docs/project/process/README.md
@@ -29,5 +29,6 @@ Sistema operativo ligero para desarrollar Cachés desde el Product Brain.
 - [[frontmatter-schema]] — schema humano del frontmatter validado por Zod.
 - [[weekly-review]] — revisión semanal ligera del brain.
 - [[release-flow]] — cortes pequeños y mergeables.
+- [[supabase-db-access]] — acceso directo seguro a Supabase con MCP y fallback SQL Editor.
 - [[DEVELOPMENT_WORKFLOW]] — consolidado en WORKFLOW (stub).
 - [[AGENT_WORKFLOW]] — consolidado en WORKFLOW (stub).

--- a/docs/project/process/supabase-db-access.md
+++ b/docs/project/process/supabase-db-access.md
@@ -1,0 +1,87 @@
+---
+id: PB-PROCESS-SUPABASE-DB-ACCESS
+type: process
+status: Active
+created: 2026-05-07
+updated: 2026-05-07
+aliases:
+  - Supabase DB Access
+  - Acceso Supabase MCP
+tags:
+  - product-brain
+  - process
+  - supabase
+  - security
+---
+
+# Acceso directo seguro a Supabase
+
+Este documento define como agentes y humanos operan la base de datos de Cachés sin exponer secretos ni saltarse el flujo versionado de migraciones.
+
+## Vía recomendada
+
+Usar Supabase MCP como vía principal para diagnóstico y operaciones de BD:
+
+- URL remota: `https://mcp.supabase.com/mcp`
+- Alcance: siempre acotado al `project_ref` del proyecto CulturaApp.
+- Diagnóstico: usar modo lectura cuando sea posible (`read_only=true`).
+- Features habituales: `database,docs`.
+- No guardar Personal Access Tokens, connection strings, service role keys ni passwords en el repo, memoria, issues, prompts o PRs.
+
+Si el MCP no está disponible en una sesión, usar el SQL Editor de Supabase como fallback manual. No pedir ni pegar credenciales en el chat.
+
+## Diagnóstico read-only
+
+Usar MCP read-only o SQL Editor para consultas de inspección:
+
+```sql
+select extname, extnamespace::regnamespace
+from pg_extension
+where extname = 'pgcrypto';
+
+select proname, oidvectortypes(proargtypes) as args, proargnames
+from pg_proc
+where pronamespace = 'public'::regnamespace
+  and proname in ('handle_new_user', 'list_beta_invites', 'create_beta_invite', 'revoke_beta_invite');
+```
+
+Para simular una sesión autenticada en SQL Editor:
+
+```sql
+begin;
+
+select set_config('request.jwt.claim.sub', '<USER_UUID>', true);
+select auth.uid();
+select public.current_user_is_admin();
+
+rollback;
+```
+
+## Migraciones y hotfixes
+
+- Todo cambio de schema, trigger, policy o RPC debe vivir primero en `supabase/migrations/`.
+- Antes de aplicar en producción, el agente debe mostrar el SQL exacto y esperar confirmación explícita.
+- Aplicar con MCP `apply_migration` cuando esté disponible; si no, pegar la migración completa en SQL Editor.
+- Después de cambiar RPCs, ejecutar:
+
+```sql
+notify pgrst, 'reload schema';
+```
+
+- Verificar con SQL read-only y después con la app.
+
+## Reglas de seguridad
+
+- No usar service role en frontend ni en prompts de agentes.
+- No imprimir secretos ni valores de `.env.local`.
+- No crear policies amplias para resolver errores de admin: preferir RPCs `security definer` con comprobación explícita.
+- No ejecutar operaciones destructivas, producción o Supabase remoto sin confirmación humana clara.
+
+## Fallback de emergencia
+
+Si MCP no está disponible y SQL Editor falla:
+
+1. Capturar el error exacto de Supabase sin incluir secretos.
+2. Revisar `pg_proc`, `pg_extension`, grants y `notify pgrst`.
+3. Crear una migración hotfix versionada.
+4. Aplicar manualmente por SQL Editor y confirmar con una consulta read-only.

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -29,11 +29,12 @@ tags:
 ## Scope actual
 
 - [[../issues/CACH-B0017|CACH-B0017]] — Panel admin para invitaciones beta.
+- [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura.
 
 ## Regla de trabajo para esta release
 
-Las tareas de [[../issues/CACH-B0017|CACH-B0017]] salen de `release/0.1.0-beta.9` y vuelven a esa rama. No mezclar calendario unificado, mobile financiero, tooling interno ni analítica real en este corte.
+Las tareas de [[../issues/CACH-B0017|CACH-B0017]] y [[../issues/CACH-B0018|CACH-B0018]] salen de `release/0.1.0-beta.9` y vuelven a esa rama. No mezclar calendario unificado, mobile financiero, tooling interno no trazado ni analítica real en este corte.
 
 ## Como cerrar esta release
 
-Cerrar mediante PR única `release/0.1.0-beta.9` -> `main`, validar CI, actualizar release notes, marcar CACH-B0017 como cerrada/Released, crear tag `v0.1.0-beta.9` desde `main` y limpiar rama remota.
+Cerrar mediante PR única `release/0.1.0-beta.9` -> `main`, validar CI, actualizar release notes, marcar CACH-B0017 y CACH-B0018 como cerradas/Released, crear tag `v0.1.0-beta.9` desde `main` y limpiar rama remota.

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -16,11 +16,11 @@ tags:
 
 ## Release activa
 
-Sin release activa.
+[[RELEASE-0.1.0-beta.9|RELEASE-0.1.0-beta.9]] — Panel admin de invitaciones.
 
 ## Rama activa
 
-Ninguna.
+`release/0.1.0-beta.9`
 
 ## Ultimo corte
 
@@ -28,12 +28,12 @@ Ninguna.
 
 ## Scope actual
 
-Sin scope activo.
+- [[../issues/CACH-B0017|CACH-B0017]] — Panel admin para invitaciones beta.
 
 ## Regla de trabajo para esta release
 
-Crear una nueva release antes de arrancar trabajo de producto adicional.
+Las tareas de [[../issues/CACH-B0017|CACH-B0017]] salen de `release/0.1.0-beta.9` y vuelven a esa rama. No mezclar calendario unificado, mobile financiero, tooling interno ni analítica real en este corte.
 
 ## Como cerrar esta release
 
-Beta 8 queda cerrada. El siguiente corte debe definirse en un nuevo documento `RELEASE-*` antes de ejecutar cambios fuera de mantenimiento menor.
+Cerrar mediante PR única `release/0.1.0-beta.9` -> `main`, validar CI, actualizar release notes, marcar CACH-B0017 como cerrada/Released, crear tag `v0.1.0-beta.9` desde `main` y limpiar rama remota.

--- a/docs/project/releases/RELEASE-0.1.0-beta.9.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.9.md
@@ -62,12 +62,14 @@ Permitir gestionar invitaciones beta desde una pantalla interna segura, con rol 
 ## Scope
 
 - [[../issues/CACH-B0017|CACH-B0017]] — Panel admin para invitaciones beta.
+- [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura.
 
 ## Issues incluidas
 
 | Issue | Título | Estado | Rama |
 |---|---|---|---|
 | [[../issues/CACH-B0017|CACH-B0017]] | Panel admin para invitaciones beta | Review | `release/0.1.0-beta.9` |
+| [[../issues/CACH-B0018|CACH-B0018]] | Adaptador Codex-native para perfiles Cultura | Review | `release/0.1.0-beta.9` |
 
 ## Fuera de alcance
 
@@ -75,7 +77,7 @@ Permitir gestionar invitaciones beta desde una pantalla interna segura, con rol 
 - Waitlist pública, referidos, campañas o perfil público.
 - Calendario unificado de [[../issues/CACH-B0007|CACH-B0007]].
 - Mobile financiero de [[../issues/CACH-B0002|CACH-B0002]].
-- Tooling interno de [[../issues/CACH-B0010|CACH-B0010]].
+- Tooling interno amplio de [[../issues/CACH-B0010|CACH-B0010]] fuera del adaptador Codex-native acotado de [[../issues/CACH-B0018|CACH-B0018]].
 
 ## Riesgos
 
@@ -139,6 +141,7 @@ Permitir gestionar invitaciones beta desde una pantalla interna segura, con rol 
 - Ruta privada `/admin/invitaciones` para crear, listar y revocar códigos.
 - Enlace a administración beta desde Ajustes solo para perfiles admin.
 - Documento operativo para acceso directo seguro a Supabase con MCP y fallback SQL Editor.
+- Documentación del modo Codex-native para usar subagentes Codex con perfiles Cultura sin ejecutar OpenCode por defecto.
 
 ### Cambiado
 
@@ -158,6 +161,7 @@ Permitir gestionar invitaciones beta desde una pantalla interna segura, con rol 
 
 - Validado localmente: `npm run lint`, `npm run test`, `npm run build`, `npm run pb:check` y `git diff --check`.
 - La migración hotfix `20260507193000_fix_beta_invite_pgcrypto_schema.sql` debe aplicarse en Supabase remoto antes de probar creación de códigos en producción.
+- `CACH-B0018` queda como tarea interna acotada de tooling y no introduce features visibles ni configuración MCP nueva.
 
 ## Resultado final
 

--- a/docs/project/releases/RELEASE-0.1.0-beta.9.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.9.md
@@ -138,6 +138,7 @@ Permitir gestionar invitaciones beta desde una pantalla interna segura, con rol 
 - RPCs seguras para listar, crear y revocar invitaciones beta sin exponer hashes.
 - Ruta privada `/admin/invitaciones` para crear, listar y revocar códigos.
 - Enlace a administración beta desde Ajustes solo para perfiles admin.
+- Documento operativo para acceso directo seguro a Supabase con MCP y fallback SQL Editor.
 
 ### Cambiado
 
@@ -147,6 +148,7 @@ Permitir gestionar invitaciones beta desde una pantalla interna segura, con rol 
 ### Corregido
 
 - Usuarios normales quedan fuera de `/admin/invitaciones` aunque conozcan la URL.
+- `create_beta_invite()` y `handle_new_user()` resuelven `pgcrypto` cuando Supabase instala la extensión en el schema `extensions`.
 
 ### Eliminado
 
@@ -155,6 +157,7 @@ Permitir gestionar invitaciones beta desde una pantalla interna segura, con rol 
 ### Técnico
 
 - Validado localmente: `npm run lint`, `npm run test`, `npm run build`, `npm run pb:check` y `git diff --check`.
+- La migración hotfix `20260507193000_fix_beta_invite_pgcrypto_schema.sql` debe aplicarse en Supabase remoto antes de probar creación de códigos en producción.
 
 ## Resultado final
 

--- a/docs/project/releases/RELEASE-0.1.0-beta.9.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.9.md
@@ -109,9 +109,9 @@ Permitir gestionar invitaciones beta desde una pantalla interna segura, con rol 
 
 - [x] Build correcto
 - [x] Tests/checks correctos (`npm run lint`, `npm run test`, `npm run build`, `npm run pb:check`, `git diff --check`)
-- [ ] Revisión visual `/admin/invitaciones`
-- [ ] Revisión responsive 375px y desktop
-- [ ] Revisión accesibilidad
+- [x] Revisión visual `/admin/invitaciones`
+- [x] Revisión responsive 375px y desktop
+- [x] Revisión accesibilidad básica
 - [x] Revisión de regresión básica
 - [x] Revisión de documentación
 
@@ -160,7 +160,7 @@ Permitir gestionar invitaciones beta desde una pantalla interna segura, con rol 
 ### Técnico
 
 - Validado localmente: `npm run lint`, `npm run test`, `npm run build`, `npm run pb:check` y `git diff --check`.
-- La migración hotfix `20260507193000_fix_beta_invite_pgcrypto_schema.sql` debe aplicarse en Supabase remoto antes de probar creación de códigos en producción.
+- La migración hotfix `20260507193000_fix_beta_invite_pgcrypto_schema.sql` fue aplicada manualmente en Supabase remoto y la creación de códigos funciona desde `/admin/invitaciones`.
 - `CACH-B0018` queda como tarea interna acotada de tooling y no introduce features visibles ni configuración MCP nueva.
 
 ## Resultado final

--- a/docs/project/releases/RELEASE-0.1.0-beta.9.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.9.md
@@ -1,0 +1,161 @@
+---
+id: RELEASE-0.1.0-beta.9
+type: release
+status: Active
+created: 2026-05-07
+updated: 2026-05-07
+release_branch: release/0.1.0-beta.9
+release_tag: v0.1.0-beta.9
+aliases:
+  - RELEASE-0.1.0-beta.9
+tags:
+  - product-brain
+  - release
+  - beta
+---
+
+# RELEASE-0.1.0-beta.9 — Panel admin de invitaciones
+
+## Estado
+
+Active
+
+## Rama de release
+
+`release/0.1.0-beta.9`
+
+## Tag
+
+`v0.1.0-beta.9`
+
+## Ciclo
+
+`0.1` es el ciclo organizativo. `0.1.0-beta.9` es un corte técnico corto para hacer operativo el acceso beta privado.
+
+## Objetivo de la release
+
+Permitir gestionar invitaciones beta desde una pantalla interna segura, con rol admin real y sin exponer códigos, hashes ni redenciones a usuarios normales.
+
+## Alcance funcional
+
+- Rol `admin` en perfiles.
+- RPCs seguras para listar, crear y revocar invitaciones.
+- Pantalla privada `/admin/invitaciones` solo para administradores.
+- Acceso al panel desde Ajustes solo para cuentas admin.
+- Hardening de acceso alrededor de invitaciones y perfil.
+
+## Areas implicadas
+
+- Data: perfiles, invitaciones, redenciones y RPCs.
+- Security/privacy: RLS, security definer, rol admin y ausencia de service role en cliente.
+- Frontend: ruta privada, pantalla admin y enlace condicional desde Ajustes.
+
+## Restricciones CACH-B0017
+
+- No implementar analítica real.
+- No crear waitlist pública.
+- No enviar emails automáticos.
+- No incluir referidos, calendario unificado, mobile financiero ni features Pro.
+- No exponer `code_hash` ni códigos ya creados.
+- No usar service role en cliente.
+
+## Scope
+
+- [[../issues/CACH-B0017|CACH-B0017]] — Panel admin para invitaciones beta.
+
+## Issues incluidas
+
+| Issue | Título | Estado | Rama |
+|---|---|---|---|
+| [[../issues/CACH-B0017|CACH-B0017]] | Panel admin para invitaciones beta | Review | `release/0.1.0-beta.9` |
+
+## Fuera de alcance
+
+- Analítica real, telemetría o consentimiento avanzado.
+- Waitlist pública, referidos, campañas o perfil público.
+- Calendario unificado de [[../issues/CACH-B0007|CACH-B0007]].
+- Mobile financiero de [[../issues/CACH-B0002|CACH-B0002]].
+- Tooling interno de [[../issues/CACH-B0010|CACH-B0010]].
+
+## Riesgos
+
+- Escalada de privilegios si `profiles.role` fuera editable por usuarios normales; se mitiga con trigger de inmutabilidad para sesiones autenticadas.
+- Exposición de invitaciones si se añaden policies directas; se mitiga usando RPCs con comprobación admin y sin devolver hashes.
+- Confusión operativa si el primer admin no existe; se mitiga documentando SQL manual.
+
+## Decisiones relacionadas
+
+- [[../decisions/ADR-0002-beta-trust-before-pro|ADR-0002]]
+
+## Checklist de entrada
+
+- [x] Release creada
+- [x] Rama de release creada
+- [x] Issues asociadas
+- [x] Alcance definido
+- [x] Criterios de validación definidos
+
+## Checklist de desarrollo
+
+- [x] Todas las issues están en progreso o cerradas
+- [x] Commits preparados en rama release
+- [x] No hay cambios sueltos fuera de release
+- [x] No hay issues sin estado
+- [x] No hay decisiones importantes sin documentar
+
+## Checklist de estabilización
+
+- [x] Build correcto
+- [x] Tests/checks correctos (`npm run lint`, `npm run test`, `npm run build`, `npm run pb:check`, `git diff --check`)
+- [ ] Revisión visual `/admin/invitaciones`
+- [ ] Revisión responsive 375px y desktop
+- [ ] Revisión accesibilidad
+- [x] Revisión de regresión básica
+- [x] Revisión de documentación
+
+## Checklist de salida
+
+- [ ] PR `release/0.1.0-beta.9` -> `main` abierta
+- [ ] CI en verde
+- [ ] Revisión aprobada
+- [ ] PR mergeada en `main`
+- [ ] `main` actualizado en local
+- [ ] Tag `v0.1.0-beta.9` creado desde `main`
+- [ ] Producción verificada si aplica
+- [ ] Rama remota `release/0.1.0-beta.9` eliminada
+- [ ] Release notes actualizadas
+- [ ] Issues marcadas como `Released`
+- [ ] Estado actual actualizado
+- [ ] Current Release actualizado
+- [ ] Backlog actualizado
+- [ ] Documento de release actualizado como cerrado
+
+## Release notes
+
+### Añadido
+
+- Rol `admin` en perfiles, con protección para que usuarios autenticados no puedan cambiar su propio rol.
+- RPCs seguras para listar, crear y revocar invitaciones beta sin exponer hashes.
+- Ruta privada `/admin/invitaciones` para crear, listar y revocar códigos.
+- Enlace a administración beta desde Ajustes solo para perfiles admin.
+
+### Cambiado
+
+- `useProfile` lee `role` y mantiene `user` como valor por defecto compatible.
+- La generación operativa de códigos pasa de SQL manual a panel interno admin.
+
+### Corregido
+
+- Usuarios normales quedan fuera de `/admin/invitaciones` aunque conozcan la URL.
+
+### Eliminado
+
+- No se incluye waitlist pública, emails automáticos, analítica real, calendario unificado ni features Pro.
+
+### Técnico
+
+- Validado localmente: `npm run lint`, `npm run test`, `npm run build`, `npm run pb:check` y `git diff --check`.
+
+## Resultado final
+
+Lista para PR `release/0.1.0-beta.9` -> `main`. La release no debe marcarse como `Released` ni etiquetarse hasta mergear en `main` y validar CI.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate, Link, useLocation } from 'react-router-dom'
 import { useAuth } from './hooks/useAuth'
 import { useProfile } from './hooks/useProfile'
 import { ScrollLockProvider } from './hooks/useScrollLock'
@@ -15,15 +15,16 @@ import ProjectDetail from './pages/Projects/ProjectDetail'
 import Work from './pages/Work/Work'
 import Settings from './pages/Settings/Settings'
 import Data from './pages/Data/Data'
+import AdminInvites from './pages/Admin/AdminInvites'
 
-function PrivateRoute({ children }) {
+function PrivateRoute({ children, requireAdmin = false }) {
   const { user, loading } = useAuth()
   if (loading) return <div className="min-h-screen flex items-center justify-center text-sm text-gray-400">Cargando...</div>
   if (!user) return <Navigate to="/login" replace />
-  return <ProfileGate user={user}>{children}</ProfileGate>
+  return <ProfileGate user={user} requireAdmin={requireAdmin}>{children}</ProfileGate>
 }
 
-function ProfileGate({ user, children }) {
+function ProfileGate({ user, requireAdmin, children }) {
   const location = useLocation()
   const { profile, loading, error, refetch } = useProfile(user?.id)
   const isOnboardingRoute = location.pathname === '/onboarding'
@@ -56,6 +57,25 @@ function ProfileGate({ user, children }) {
     return <Navigate to="/onboarding" replace state={{ from: location.pathname }} />
   }
 
+  if (requireAdmin && profile.role !== 'admin') {
+    return (
+      <div className="min-h-screen bg-[var(--color-paper)] flex items-center justify-center p-4">
+        <div className="w-full max-w-md rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-surface)] p-6 text-center shadow-sm">
+          <h1 className="text-lg font-semibold text-[var(--color-ink)]">No tienes acceso a esta zona</h1>
+          <p className="mt-2 text-sm text-[var(--color-ink-muted)]">
+            Esta pantalla es solo para cuentas administradoras de la beta.
+          </p>
+          <Link
+            to="/dashboard"
+            className="mt-5 inline-flex min-h-10 items-center justify-center rounded-lg bg-[var(--color-red)] px-4 py-2 text-sm font-medium text-white hover:bg-[var(--color-red-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-red)] focus-visible:ring-offset-2"
+          >
+            Volver al dashboard
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
   return children
 }
 
@@ -84,6 +104,7 @@ export default function App() {
         <Route path="/work" element={<PrivateRoute><Work /></PrivateRoute>} />
         <Route path="/settings" element={<PrivateRoute><Settings /></PrivateRoute>} />
         <Route path="/data" element={<PrivateRoute><Data /></PrivateRoute>} />
+        <Route path="/admin/invitaciones" element={<PrivateRoute requireAdmin><AdminInvites /></PrivateRoute>} />
         <Route path="/calendar" element={<Navigate to="/calendar/events" replace />} />
         <Route path="*" element={<Navigate to="/dashboard" replace />} />
       </Routes>

--- a/src/hooks/useBetaInvites.js
+++ b/src/hooks/useBetaInvites.js
@@ -17,10 +17,26 @@ function normalizeInvite(invite) {
   }
 }
 
+function logAdminRpcError(operation, error) {
+  if (!error) return
+  console.error(`[beta-invites:${operation}]`, {
+    code: error.code,
+    message: error.message,
+    details: error.details,
+    hint: error.hint,
+  })
+}
+
 function genericAdminError(error) {
   if (!error) return ''
   if (error.message?.includes('admin_required')) {
     return 'No tienes permisos para gestionar invitaciones.'
+  }
+  if (error.code === 'PGRST202' || error.code === 'PGRST203') {
+    return 'La conexión con las funciones de invitaciones no está actualizada. Recarga el esquema de Supabase y vuelve a intentarlo.'
+  }
+  if (error.message?.includes('gen_random_bytes') || error.message?.includes('digest')) {
+    return 'La función de invitaciones necesita el hotfix de pgcrypto antes de crear códigos.'
   }
   return 'No hemos podido gestionar las invitaciones. Vuelve a intentarlo.'
 }
@@ -35,6 +51,7 @@ export function useBetaInvites() {
     setError('')
     const { data, error } = await supabase.rpc('list_beta_invites')
     if (error) {
+      logAdminRpcError('list', error)
       setError(genericAdminError(error))
       setInvites([])
     } else {
@@ -57,11 +74,19 @@ export function useBetaInvites() {
     }
     const { data, error } = await supabase.rpc('create_beta_invite', params)
     if (error) {
+      logAdminRpcError('create', error)
       const message = genericAdminError(error)
       setError(message)
       return { data: null, error, message }
     }
-    const created = normalizeInvite(data?.[0] ?? data)
+    const rawCreated = data?.[0] ?? data
+    if (!rawCreated?.code) {
+      const message = 'La invitación se ha creado, pero la respuesta no incluía el código.'
+      setError(message)
+      logAdminRpcError('create:contract', { message, details: data })
+      return { data: null, error: new Error(message), message }
+    }
+    const created = normalizeInvite(rawCreated)
     await refetch()
     return { data: created, error: null, message: '' }
   }
@@ -70,6 +95,7 @@ export function useBetaInvites() {
     setError('')
     const { data, error } = await supabase.rpc('revoke_beta_invite', { target_invite_id: inviteId })
     if (error) {
+      logAdminRpcError('revoke', error)
       const message = genericAdminError(error)
       setError(message)
       return { data: null, error, message }

--- a/src/hooks/useBetaInvites.js
+++ b/src/hooks/useBetaInvites.js
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useState } from 'react'
+import { supabase } from '../supabaseClient'
+
+function normalizeInvite(invite) {
+  return {
+    id: invite.id,
+    label: invite.label ?? '',
+    max_redemptions: invite.max_redemptions ?? 1,
+    redeemed_count: invite.redeemed_count ?? 0,
+    redemption_count: invite.redemption_count ?? invite.redeemed_count ?? 0,
+    expires_at: invite.expires_at ?? null,
+    revoked_at: invite.revoked_at ?? null,
+    created_at: invite.created_at ?? null,
+    updated_at: invite.updated_at ?? null,
+    last_redeemed_at: invite.last_redeemed_at ?? null,
+    code: invite.code,
+  }
+}
+
+function genericAdminError(error) {
+  if (!error) return ''
+  if (error.message?.includes('admin_required')) {
+    return 'No tienes permisos para gestionar invitaciones.'
+  }
+  return 'No hemos podido gestionar las invitaciones. Vuelve a intentarlo.'
+}
+
+export function useBetaInvites() {
+  const [invites, setInvites] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  const refetch = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    const { data, error } = await supabase.rpc('list_beta_invites')
+    if (error) {
+      setError(genericAdminError(error))
+      setInvites([])
+    } else {
+      setInvites((data ?? []).map(normalizeInvite))
+    }
+    setLoading(false)
+    return { data, error }
+  }, [])
+
+  useEffect(() => {
+    queueMicrotask(refetch)
+  }, [refetch])
+
+  const createInvite = async ({ label, maxRedemptions, expiresAt }) => {
+    setError('')
+    const params = {
+      invite_label: label?.trim() || null,
+      invite_max_redemptions: maxRedemptions,
+      invite_expires_at: expiresAt || null,
+    }
+    const { data, error } = await supabase.rpc('create_beta_invite', params)
+    if (error) {
+      const message = genericAdminError(error)
+      setError(message)
+      return { data: null, error, message }
+    }
+    const created = normalizeInvite(data?.[0] ?? data)
+    await refetch()
+    return { data: created, error: null, message: '' }
+  }
+
+  const revokeInvite = async (inviteId) => {
+    setError('')
+    const { data, error } = await supabase.rpc('revoke_beta_invite', { target_invite_id: inviteId })
+    if (error) {
+      const message = genericAdminError(error)
+      setError(message)
+      return { data: null, error, message }
+    }
+    await refetch()
+    return { data: data?.[0] ?? data, error: null, message: '' }
+  }
+
+  return { invites, loading, error, refetch, createInvite, revokeInvite }
+}

--- a/src/hooks/useProfile.js
+++ b/src/hooks/useProfile.js
@@ -12,6 +12,7 @@ const PROFILE_FIELDS = [
   'usage_consent_at',
   'usage_consent_version',
   'beta_invite_id',
+  'role',
 ].join(', ')
 
 const BASE_PROFILE_FIELDS = [
@@ -30,6 +31,7 @@ function withProfileDefaults(profile) {
     usage_consent_at: null,
     usage_consent_version: null,
     beta_invite_id: null,
+    role: 'user',
     ...profile,
   }
 }

--- a/src/pages/Admin/AdminInvites.jsx
+++ b/src/pages/Admin/AdminInvites.jsx
@@ -1,0 +1,228 @@
+import { useState } from 'react'
+import { CalendarX, Check, Copy, RotateCw, ShieldCheck, Ticket, XCircle } from 'lucide-react'
+import { PageWrapper } from '../../components/layout/PageWrapper'
+import { Card } from '../../components/ui/Card'
+import { Button } from '../../components/ui/Button'
+import { Input } from '../../components/ui/Input'
+import { ToastContainer, useToast } from '../../components/ui/Toast'
+import { useBetaInvites } from '../../hooks/useBetaInvites'
+import { formatDatetime } from '../../lib/formatters'
+
+function endOfDayIso(dateValue) {
+  if (!dateValue) return null
+  return new Date(`${dateValue}T23:59:59`).toISOString()
+}
+
+function getInviteState(invite) {
+  if (invite.revoked_at) return { label: 'Revocada', className: 'bg-red-50 text-red-700', icon: XCircle }
+  if (invite.expires_at && new Date(invite.expires_at) <= new Date()) return { label: 'Caducada', className: 'bg-amber-50 text-amber-700', icon: CalendarX }
+  if (invite.redeemed_count >= invite.max_redemptions) return { label: 'Consumida', className: 'bg-gray-100 text-gray-600', icon: Check }
+  return { label: 'Activa', className: 'bg-green-50 text-green-700', icon: ShieldCheck }
+}
+
+function InviteStatus({ invite }) {
+  const state = getInviteState(invite)
+  const Icon = state.icon
+  return (
+    <span className={`inline-flex min-h-7 items-center gap-1.5 rounded-full px-2.5 text-xs font-medium ${state.className}`}>
+      <Icon size={14} />
+      {state.label}
+    </span>
+  )
+}
+
+export default function AdminInvites() {
+  const { invites, loading, error, refetch, createInvite, revokeInvite } = useBetaInvites()
+  const { toasts, addToast, removeToast } = useToast()
+  const [form, setForm] = useState({ label: '', maxRedemptions: '1', expiresAt: '' })
+  const [saving, setSaving] = useState(false)
+  const [revokingId, setRevokingId] = useState('')
+  const [createdCode, setCreatedCode] = useState('')
+  const [formError, setFormError] = useState('')
+
+  const handleChange = (e) => {
+    setForm((current) => ({ ...current, [e.target.name]: e.target.value }))
+    setFormError('')
+  }
+
+  const handleCreate = async (e) => {
+    e.preventDefault()
+    setCreatedCode('')
+    const maxRedemptions = Number(form.maxRedemptions)
+    if (!Number.isInteger(maxRedemptions) || maxRedemptions < 1 || maxRedemptions > 100) {
+      setFormError('Los usos máximos deben estar entre 1 y 100.')
+      return
+    }
+
+    setSaving(true)
+    const { data, error, message } = await createInvite({
+      label: form.label,
+      maxRedemptions,
+      expiresAt: endOfDayIso(form.expiresAt),
+    })
+    setSaving(false)
+
+    if (error) {
+      setFormError(message)
+      return
+    }
+
+    setCreatedCode(data.code)
+    setForm({ label: '', maxRedemptions: '1', expiresAt: '' })
+    addToast('Invitación creada.')
+  }
+
+  const handleCopy = async () => {
+    if (!createdCode) return
+    try {
+      await navigator.clipboard.writeText(createdCode)
+      addToast('Código copiado.')
+    } catch {
+      addToast('No hemos podido copiar el código.', 'error')
+    }
+  }
+
+  const handleRevoke = async (invite) => {
+    setRevokingId(invite.id)
+    const { error, message } = await revokeInvite(invite.id)
+    setRevokingId('')
+    if (error) {
+      addToast(message, 'error')
+      return
+    }
+    addToast('Invitación revocada.')
+  }
+
+  return (
+    <PageWrapper title="Invitaciones beta">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,380px)_minmax(0,1fr)]">
+        <Card className="p-5">
+          <div className="mb-5">
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[var(--color-red-light)] text-[var(--color-red)]">
+              <Ticket size={20} />
+            </div>
+            <h2 className="mt-3 text-base font-semibold text-[var(--color-ink)]">Crear código</h2>
+            <p className="mt-1 text-sm text-[var(--color-ink-muted)]">
+              El código se muestra una sola vez. Después solo queda guardado el hash.
+            </p>
+          </div>
+
+          <form onSubmit={handleCreate} className="flex flex-col gap-4">
+            <Input
+              label="Etiqueta"
+              name="label"
+              value={form.label}
+              onChange={handleChange}
+              placeholder="Beta 9 - fotógrafas"
+            />
+            <Input
+              label="Usos máximos"
+              type="number"
+              min="1"
+              max="100"
+              name="maxRedemptions"
+              value={form.maxRedemptions}
+              onChange={handleChange}
+              required
+            />
+            <Input
+              label="Caduca el"
+              type="date"
+              name="expiresAt"
+              value={form.expiresAt}
+              onChange={handleChange}
+            />
+            {formError && <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{formError}</p>}
+            <Button type="submit" disabled={saving} className="justify-center">
+              {saving ? 'Creando...' : 'Crear invitación'}
+            </Button>
+          </form>
+
+          {createdCode && (
+            <div className="mt-5 rounded-lg border border-green-200 bg-green-50 p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-green-700">Código creado</p>
+              <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-center">
+                <code className="min-w-0 flex-1 overflow-x-auto rounded-lg bg-white px-3 py-2 text-sm font-semibold text-[var(--color-ink)]">
+                  {createdCode}
+                </code>
+                <Button type="button" variant="secondary" onClick={handleCopy} className="justify-center">
+                  <Copy size={16} />
+                  Copiar
+                </Button>
+              </div>
+            </div>
+          )}
+        </Card>
+
+        <Card className="min-w-0 overflow-hidden">
+          <div className="flex flex-col gap-3 border-b border-[var(--color-paper-mid)] p-5 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-base font-semibold text-[var(--color-ink)]">Códigos generados</h2>
+              <p className="mt-1 text-sm text-[var(--color-ink-muted)]">No se muestran códigos planos ni hashes.</p>
+            </div>
+            <Button type="button" variant="secondary" onClick={refetch} disabled={loading} className="justify-center">
+              <RotateCw size={16} />
+              Actualizar
+            </Button>
+          </div>
+
+          {error && <p className="m-5 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+
+          {loading ? (
+            <p className="p-5 text-sm text-[var(--color-ink-muted)]">Cargando invitaciones...</p>
+          ) : invites.length === 0 ? (
+            <p className="p-5 text-sm text-[var(--color-ink-muted)]">Todavía no hay invitaciones creadas.</p>
+          ) : (
+            <div className="divide-y divide-[var(--color-paper-mid)]">
+              {invites.map((invite) => {
+                const canRevoke = !invite.revoked_at && invite.redeemed_count < invite.max_redemptions
+                return (
+                  <article key={invite.id} className="grid gap-4 p-5 xl:grid-cols-[minmax(0,1fr)_auto]">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h3 className="truncate text-sm font-semibold text-[var(--color-ink)]">
+                          {invite.label || 'Sin etiqueta'}
+                        </h3>
+                        <InviteStatus invite={invite} />
+                      </div>
+                      <dl className="mt-3 grid gap-3 text-sm text-[var(--color-ink-muted)] sm:grid-cols-2 xl:grid-cols-4">
+                        <div>
+                          <dt className="text-xs font-medium uppercase tracking-wide">Usos</dt>
+                          <dd className="mt-1 text-[var(--color-ink)]">{invite.redeemed_count}/{invite.max_redemptions}</dd>
+                        </div>
+                        <div>
+                          <dt className="text-xs font-medium uppercase tracking-wide">Caducidad</dt>
+                          <dd className="mt-1 text-[var(--color-ink)]">{formatDatetime(invite.expires_at)}</dd>
+                        </div>
+                        <div>
+                          <dt className="text-xs font-medium uppercase tracking-wide">Último uso</dt>
+                          <dd className="mt-1 text-[var(--color-ink)]">{formatDatetime(invite.last_redeemed_at)}</dd>
+                        </div>
+                        <div>
+                          <dt className="text-xs font-medium uppercase tracking-wide">Creada</dt>
+                          <dd className="mt-1 text-[var(--color-ink)]">{formatDatetime(invite.created_at)}</dd>
+                        </div>
+                      </dl>
+                    </div>
+                    <div className="flex items-start justify-end">
+                      <Button
+                        type="button"
+                        variant="danger"
+                        disabled={!canRevoke || revokingId === invite.id}
+                        onClick={() => handleRevoke(invite)}
+                        className="w-full justify-center sm:w-auto"
+                      >
+                        {revokingId === invite.id ? 'Revocando...' : 'Revocar'}
+                      </Button>
+                    </div>
+                  </article>
+                )
+              })}
+            </div>
+          )}
+        </Card>
+      </div>
+      <ToastContainer toasts={toasts} onRemove={removeToast} />
+    </PageWrapper>
+  )
+}

--- a/src/pages/Settings/Settings.jsx
+++ b/src/pages/Settings/Settings.jsx
@@ -132,6 +132,22 @@ export default function Settings() {
             </div>
           </div>
         </Card>
+        {profile?.role === 'admin' && (
+          <Card className="p-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-sm font-semibold text-gray-900 mb-1">Administración beta</h2>
+                <p className="text-sm text-gray-500">Crea y revoca códigos de invitación para nuevas altas.</p>
+              </div>
+              <Link
+                to="/admin/invitaciones"
+                className="inline-flex min-h-10 items-center justify-center rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-paper)] px-4 py-2 text-sm font-medium leading-none text-[var(--color-ink)] shadow-sm transition-colors hover:bg-[var(--color-paper-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-red)] focus-visible:ring-offset-2"
+              >
+                Gestionar invitaciones
+              </Link>
+            </div>
+          </Card>
+        )}
         <Card className="p-6">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div>

--- a/supabase/migrations/20260507120000_beta_invites.sql
+++ b/supabase/migrations/20260507120000_beta_invites.sql
@@ -1,4 +1,5 @@
-create extension if not exists pgcrypto;
+create schema if not exists extensions;
+create extension if not exists pgcrypto with schema extensions;
 
 create table if not exists public.beta_invites (
   id uuid primary key default gen_random_uuid(),
@@ -103,7 +104,7 @@ create or replace function public.handle_new_user()
 returns trigger
 language plpgsql
 security definer
-set search_path = public, auth
+set search_path = public, auth, extensions
 as $$
 declare
   invite_code text;

--- a/supabase/migrations/20260507172000_admin_beta_invites.sql
+++ b/supabase/migrations/20260507172000_admin_beta_invites.sql
@@ -1,0 +1,201 @@
+alter table public.profiles
+  add column if not exists role text not null default 'user';
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'profiles_role_valid'
+      and conrelid = 'public.profiles'::regclass
+  ) then
+    alter table public.profiles
+      add constraint profiles_role_valid
+      check (role in ('user', 'admin'));
+  end if;
+end;
+$$;
+
+create or replace function public.prevent_beta_invite_profile_changes()
+returns trigger
+language plpgsql
+as $$
+begin
+  if auth.uid() is not null and old.beta_invite_id is distinct from new.beta_invite_id then
+    raise exception 'beta_invite_id_is_immutable';
+  end if;
+
+  if auth.uid() is not null and old.role is distinct from new.role then
+    raise exception 'profile_role_is_immutable';
+  end if;
+
+  return new;
+end;
+$$;
+
+create or replace function public.current_user_is_admin()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.profiles
+    where id = auth.uid()
+      and role = 'admin'
+  );
+$$;
+
+create or replace function public.list_beta_invites()
+returns table (
+  id uuid,
+  label text,
+  max_redemptions integer,
+  redeemed_count integer,
+  expires_at timestamptz,
+  revoked_at timestamptz,
+  created_at timestamptz,
+  updated_at timestamptz,
+  redemption_count bigint,
+  last_redeemed_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not public.current_user_is_admin() then
+    raise exception 'admin_required'
+      using errcode = 'P0001',
+            hint = 'Necesitas permisos de administrador.';
+  end if;
+
+  return query
+  select
+    bi.id,
+    bi.label,
+    bi.max_redemptions,
+    bi.redeemed_count,
+    bi.expires_at,
+    bi.revoked_at,
+    bi.created_at,
+    bi.updated_at,
+    count(bir.id) as redemption_count,
+    max(bir.redeemed_at) as last_redeemed_at
+  from public.beta_invites bi
+  left join public.beta_invite_redemptions bir on bir.invite_id = bi.id
+  group by bi.id
+  order by bi.created_at desc;
+end;
+$$;
+
+create or replace function public.create_beta_invite(
+  invite_label text default null,
+  invite_max_redemptions integer default 1,
+  invite_expires_at timestamptz default null
+)
+returns table (
+  id uuid,
+  code text,
+  label text,
+  max_redemptions integer,
+  redeemed_count integer,
+  expires_at timestamptz,
+  revoked_at timestamptz,
+  created_at timestamptz,
+  updated_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  generated_code text;
+  inserted_invite public.beta_invites%rowtype;
+begin
+  if not public.current_user_is_admin() then
+    raise exception 'admin_required'
+      using errcode = 'P0001',
+            hint = 'Necesitas permisos de administrador.';
+  end if;
+
+  if invite_max_redemptions is null or invite_max_redemptions < 1 or invite_max_redemptions > 100 then
+    raise exception 'invalid_invite_max_redemptions'
+      using errcode = 'P0001',
+            hint = 'max_redemptions debe estar entre 1 y 100.';
+  end if;
+
+  generated_code := 'CACHES-BETA-' || upper(encode(gen_random_bytes(6), 'hex'));
+
+  insert into public.beta_invites (code_hash, label, max_redemptions, expires_at)
+  values (
+    encode(digest(lower(trim(generated_code)), 'sha256'), 'hex'),
+    nullif(trim(invite_label), ''),
+    invite_max_redemptions,
+    invite_expires_at
+  )
+  returning * into inserted_invite;
+
+  return query
+  select
+    inserted_invite.id,
+    generated_code,
+    inserted_invite.label,
+    inserted_invite.max_redemptions,
+    inserted_invite.redeemed_count,
+    inserted_invite.expires_at,
+    inserted_invite.revoked_at,
+    inserted_invite.created_at,
+    inserted_invite.updated_at;
+end;
+$$;
+
+create or replace function public.revoke_beta_invite(target_invite_id uuid)
+returns table (
+  id uuid,
+  label text,
+  max_redemptions integer,
+  redeemed_count integer,
+  expires_at timestamptz,
+  revoked_at timestamptz,
+  created_at timestamptz,
+  updated_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not public.current_user_is_admin() then
+    raise exception 'admin_required'
+      using errcode = 'P0001',
+            hint = 'Necesitas permisos de administrador.';
+  end if;
+
+  return query
+  update public.beta_invites bi
+  set revoked_at = coalesce(bi.revoked_at, now())
+  where bi.id = target_invite_id
+  returning
+    bi.id,
+    bi.label,
+    bi.max_redemptions,
+    bi.redeemed_count,
+    bi.expires_at,
+    bi.revoked_at,
+    bi.created_at,
+    bi.updated_at;
+end;
+$$;
+
+revoke all on function public.current_user_is_admin() from public;
+revoke all on function public.list_beta_invites() from public;
+revoke all on function public.create_beta_invite(text, integer, timestamptz) from public;
+revoke all on function public.revoke_beta_invite(uuid) from public;
+
+grant execute on function public.current_user_is_admin() to authenticated;
+grant execute on function public.list_beta_invites() to authenticated;
+grant execute on function public.create_beta_invite(text, integer, timestamptz) to authenticated;
+grant execute on function public.revoke_beta_invite(uuid) to authenticated;

--- a/supabase/migrations/20260507172000_admin_beta_invites.sql
+++ b/supabase/migrations/20260507172000_admin_beta_invites.sql
@@ -1,6 +1,9 @@
 alter table public.profiles
   add column if not exists role text not null default 'user';
 
+create schema if not exists extensions;
+create extension if not exists pgcrypto with schema extensions;
+
 do $$
 begin
   if not exists (
@@ -38,7 +41,7 @@ returns boolean
 language sql
 stable
 security definer
-set search_path = public
+set search_path = public, extensions
 as $$
   select exists (
     select 1
@@ -138,17 +141,17 @@ begin
   )
   returning * into inserted_invite;
 
-  return query
-  select
-    inserted_invite.id,
-    generated_code,
-    inserted_invite.label,
-    inserted_invite.max_redemptions,
-    inserted_invite.redeemed_count,
-    inserted_invite.expires_at,
-    inserted_invite.revoked_at,
-    inserted_invite.created_at,
-    inserted_invite.updated_at;
+  id := inserted_invite.id;
+  code := generated_code;
+  label := inserted_invite.label;
+  max_redemptions := inserted_invite.max_redemptions;
+  redeemed_count := inserted_invite.redeemed_count;
+  expires_at := inserted_invite.expires_at;
+  revoked_at := inserted_invite.revoked_at;
+  created_at := inserted_invite.created_at;
+  updated_at := inserted_invite.updated_at;
+
+  return next;
 end;
 $$;
 

--- a/supabase/migrations/20260507193000_fix_beta_invite_pgcrypto_schema.sql
+++ b/supabase/migrations/20260507193000_fix_beta_invite_pgcrypto_schema.sql
@@ -1,0 +1,122 @@
+create schema if not exists extensions;
+create extension if not exists pgcrypto with schema extensions;
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, auth, extensions
+as $$
+declare
+  invite_code text;
+  invite_hash text;
+  claimed_invite_id uuid;
+begin
+  invite_code := nullif(lower(trim(new.raw_user_meta_data->>'beta_invite_code')), '');
+
+  if invite_code is null then
+    raise exception 'beta_invite_code_required'
+      using errcode = 'P0001',
+            hint = 'Incluye un codigo de invitacion beta valido para crear la cuenta.';
+  end if;
+
+  invite_hash := encode(digest(invite_code, 'sha256'), 'hex');
+
+  update public.beta_invites
+  set redeemed_count = redeemed_count + 1
+  where code_hash = invite_hash
+    and revoked_at is null
+    and (expires_at is null or expires_at > now())
+    and redeemed_count < max_redemptions
+  returning id into claimed_invite_id;
+
+  if claimed_invite_id is null then
+    raise exception 'beta_invite_code_invalid_or_redeemed'
+      using errcode = 'P0001',
+            hint = 'El codigo de invitacion beta no existe, ha caducado o ya se ha consumido.';
+  end if;
+
+  insert into public.beta_invite_redemptions (invite_id, user_id)
+  values (claimed_invite_id, new.id);
+
+  insert into public.profiles (
+    id,
+    full_name,
+    profession,
+    beta_invite_id
+  )
+  values (
+    new.id,
+    new.raw_user_meta_data->>'full_name',
+    new.raw_user_meta_data->>'profession',
+    claimed_invite_id
+  );
+
+  return new;
+end;
+$$;
+
+create or replace function public.create_beta_invite(
+  invite_label text default null,
+  invite_max_redemptions integer default 1,
+  invite_expires_at timestamptz default null
+)
+returns table (
+  id uuid,
+  code text,
+  label text,
+  max_redemptions integer,
+  redeemed_count integer,
+  expires_at timestamptz,
+  revoked_at timestamptz,
+  created_at timestamptz,
+  updated_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  generated_code text;
+  inserted_invite public.beta_invites%rowtype;
+begin
+  if not public.current_user_is_admin() then
+    raise exception 'admin_required'
+      using errcode = 'P0001',
+            hint = 'Necesitas permisos de administrador.';
+  end if;
+
+  if invite_max_redemptions is null or invite_max_redemptions < 1 or invite_max_redemptions > 100 then
+    raise exception 'invalid_invite_max_redemptions'
+      using errcode = 'P0001',
+            hint = 'max_redemptions debe estar entre 1 y 100.';
+  end if;
+
+  generated_code := 'CACHES-BETA-' || upper(encode(gen_random_bytes(6), 'hex'));
+
+  insert into public.beta_invites (code_hash, label, max_redemptions, expires_at)
+  values (
+    encode(digest(lower(trim(generated_code)), 'sha256'), 'hex'),
+    nullif(trim(invite_label), ''),
+    invite_max_redemptions,
+    invite_expires_at
+  )
+  returning * into inserted_invite;
+
+  id := inserted_invite.id;
+  code := generated_code;
+  label := inserted_invite.label;
+  max_redemptions := inserted_invite.max_redemptions;
+  redeemed_count := inserted_invite.redeemed_count;
+  expires_at := inserted_invite.expires_at;
+  revoked_at := inserted_invite.revoked_at;
+  created_at := inserted_invite.created_at;
+  updated_at := inserted_invite.updated_at;
+
+  return next;
+end;
+$$;
+
+grant execute on function public.create_beta_invite(text, integer, timestamptz) to authenticated;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- Activa beta 9 en Product Brain con `CACH-B0017` y `CACH-B0018`.
- Añade rol admin en perfiles, RPCs seguras para invitaciones y ruta privada `/admin/invitaciones`.
- Expone el panel desde Ajustes solo a admins y mantiene invitaciones/redenciones sin lectura directa desde cliente.
- Añade workflow operativo de acceso directo seguro a Supabase con MCP como vía preferida y SQL Editor como fallback.
- Añade hotfix de `pgcrypto` para `create_beta_invite()` y `handle_new_user()` cuando Supabase instala la extensión en schema `extensions`.
- Documenta el adaptador Codex-native para reutilizar perfiles Cultura con subagentes Codex sin ejecutar OpenCode por defecto.

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`
- `npm run pb:check`
- `npm run context:check`
- `git diff --check`
- Smoke Codex-native con perfiles `cultura-data` y `cultura-security`
- Prueba manual: migraciones aplicadas en Supabase remoto y creación de invitaciones validada desde `/admin/invitaciones`

## Security / data notes
- No se usa service role en cliente.
- El cliente no consulta `beta_invites` ni `beta_invite_redemptions` directamente; usa RPCs con comprobación admin.
- `profiles.role` queda protegido por trigger para sesiones autenticadas.
- El código plano de invitación solo se muestra al crear; después no se exponen códigos ni hashes.

## Memoria
Actualizada: Supabase MCP queda como vía preferida cuando la sesión lo exponga, con confirmación explícita antes de mutaciones y sin guardar secretos. También queda documentado el modo Codex-native para perfiles Cultura.
