### PR TITLE
chore(CACH-B0010): add model routing pilot

### DIFF
--- a/.memory/topics/agent-workflows.md
+++ b/.memory/topics/agent-workflows.md
@@ -32,6 +32,7 @@ Agent execution:
 - In Codex-native challenge or review, load only the relevant `.opencode/agents/<role>.md` profile, keep agents read-only, avoid `.opencode/AGENT_STATE.md`, and do not run `npm run agents:*` unless OpenCode is explicitly requested.
 - Do only the minimum manual prep needed to form a safe command, scope and ownership.
 - Do not use subagents for trivial changes.
+- Model routing pilot: keep GPT-5.5 as lead/orchestrator/verifier for ambiguous, sensitive, multi-area, data/RLS, finance, security, release and final review work. Use GPT-5.3-Codex-Spark only as a fast worker for small, local, low-risk tasks with explicit ownership and objective verification; escalate to GPT-5.5 after failed verification, sensitive scope, more than 1 retry or overly broad diffs.
 - Parallel agents need isolated write ownership or explicit coordination through `.opencode/AGENT_STATE.md`.
 - `.opencode/AGENT_STATE.md` is a live scratchboard; keep active signals and events empty after completed tasks.
 - Permanent history lives in GitHub issues, PRs and commits, not in `.opencode/AGENT_STATE.md` or `.memory/`.

--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -326,3 +326,35 @@ opencode models opencode
 ```
 
 Y cambia el campo `model` en los agentes.
+
+## Routing de modelos
+
+El routing inteligente de modelos se trata como piloto controlado, no como default irreversible. El objetivo es reducir coste y latencia en tareas simples sin perder calidad de cierre.
+
+Regla base:
+
+- `GPT-5.5`: lead/orquestador, planificacion, ambiguedad, arquitectura, Product Brain, cambios multi-area, datos/RLS, seguridad, finanzas, calendarios complejos, review, verificacion final, PR/release y cualquier accion sensible.
+- `GPT-5.3-Codex-Spark`: worker rapido para tareas locales, pequenas, con ownership explicito, patrones claros, bajo riesgo y verificacion objetiva. Encaja para copy, refactors mecanicos, fixes simples, exploracion read-only y cambios acotados de codigo.
+- Escalada a `GPT-5.5`: si Spark falla verificacion, toca zona sensible, necesita mas de 1 retry, devuelve un diff demasiado amplio o necesita decidir producto/arquitectura.
+
+Mientras Spark siga en preview o sin precio/SLAs estables, no debe ser dependencia operativa base. Usalo como acelerador experimental medido.
+
+Los lanzadores aceptan metadatos para el piloto:
+
+```bash
+npm run agents:run -- \
+  --task-type frontend \
+  --routing-reason "cambio local de bajo riesgo con ownership claro" \
+  --model-lead gpt-5.5 \
+  --model-worker gpt-5.3-codex-spark \
+  --model-reviewer gpt-5.5 \
+  "Ajusta el copy de estados vacios en /work"
+```
+
+Cada run escribe `metadata.json` en `.opencode/runs/<timestamp>/` con tipo de tarea, motivo de routing, modelos esperados, ownership, verificacion esperada, estado y duracion. Coste, retries y escalaciones quedan como campos operativos para completar durante el piloto; no se guardan en `.memory/`.
+
+Promociona Spark solo si el piloto de 20-30 tareas demuestra:
+
+- 25-40% menos coste o latencia en tareas simples.
+- Sin aumento de CI rojo, bugs post-merge ni findings severos de review.
+- Fallback claro si Spark no esta disponible o cambia sus condiciones de preview.

--- a/.opencode/agents/cultura-lead.md
+++ b/.opencode/agents/cultura-lead.md
@@ -16,13 +16,16 @@ Eres el dispatcher principal de CulturaApp. No eres el implementador principal: 
 ## Protocolo
 
 1. Clasifica la tarea y delega con `@cultura-*`; no retengas trabajo de subagentes.
-2. Si hay varios dominios, define ownership disjunto antes de pedir escritura.
-3. Si un agente publica `schema_changed`, `api_changed`, `ui_changed`, `needs_review` o `bloqueo`, activa a quienes dependan de esa senal.
-4. Para cambios de codigo, cierra con `@cultura-testing`; para cambios medianos, sensibles o multi-area, añade `@cultura-review`.
-5. Antes de PR, revisa tarea/issue, diff y commits contra base; activa `@cultura-docs` si hay memoria durable o declara `Memoria: no aplica`.
-6. Mantén trazabilidad: rama de tarea desde `main` actualizado salvo instruccion distinta; PR a `main`; issue enlazada en PR (`Closes #N`/`Fixes #N`) o commit/comentario; no cierres issue con PR abierta hasta merge.
-7. Si el cambio debe verse en produccion, preview no basta: merge a `main`, verifica produccion o declara bloqueo. Tras merge, confirma limpieza de rama remota y borra local solo desde `main` actualizado.
-8. Cierra con subagentes usados, cambios, verificacion, memoria, PR/merge/produccion, limpieza de rama y riesgos.
+2. Decide riesgo y complejidad antes de delegar: dominio, ambiguedad, zona sensible, ownership, verificacion y coste esperado.
+3. Si hay varios dominios, define ownership disjunto antes de pedir escritura.
+4. En piloto de routing, conserva GPT-5.5 para criterio, planificacion, datos/RLS, seguridad, finanzas, review, verificacion final y PR/release. Usa GPT-5.3-Codex-Spark solo como worker rapido en tareas locales, acotadas, con ownership claro y verificacion objetiva.
+5. Escala a GPT-5.5 si un worker Spark falla verificacion, toca zona sensible, necesita mas de 1 retry o devuelve un diff demasiado amplio.
+6. Si un agente publica `schema_changed`, `api_changed`, `ui_changed`, `needs_review` o `bloqueo`, activa a quienes dependan de esa senal.
+7. Para cambios de codigo, cierra con `@cultura-testing`; para cambios medianos, sensibles o multi-area, añade `@cultura-review`.
+8. Antes de PR, revisa tarea/issue, diff y commits contra base; activa `@cultura-docs` si hay memoria durable o declara `Memoria: no aplica`.
+9. Mantén trazabilidad: rama de tarea desde `main` actualizado salvo instruccion distinta; PR a `main`; issue enlazada en PR (`Closes #N`/`Fixes #N`) o commit/comentario; no cierres issue con PR abierta hasta merge.
+10. Si el cambio debe verse en produccion, preview no basta: merge a `main`, verifica produccion o declara bloqueo. Tras merge, confirma limpieza de rama remota y borra local solo desde `main` actualizado.
+11. Cierra con subagentes usados, modelos/roles si aplica, cambios, verificacion, memoria, PR/merge/produccion, limpieza de rama y riesgos.
 
 ## Enrutado
 

--- a/.opencode/scripts/run-agent.mjs
+++ b/.opencode/scripts/run-agent.mjs
@@ -11,6 +11,11 @@ const repoRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)))
 const CHECKPOINT_INTERVAL = 30000
 // Timeout máximo por agente: 45 min por defecto, configurable via AGENT_TIMEOUT_MS
 const AGENT_TIMEOUT_MS = parseInt(process.env.AGENT_TIMEOUT_MS ?? "2700000", 10)
+const MODEL_DEFAULTS = {
+  lead: process.env.AGENT_MODEL_LEAD ?? "frontmatter/default",
+  worker: process.env.AGENT_MODEL_WORKER ?? "frontmatter/default",
+  reviewer: process.env.AGENT_MODEL_REVIEWER ?? "frontmatter/default",
+}
 
 function usage() {
   console.log(`Uso:
@@ -22,6 +27,11 @@ Opciones:
   --scope "src/hooks,src/pages" Alcance permitido o esperado
   --ownership "frontend:src/pages; data:src/hooks"
   --verify "npm run lint && npm run build"
+  --task-type frontend|data|docs     Tipo de tarea para telemetria. Por defecto: unspecified
+  --routing-reason "bajo riesgo"     Motivo de routing de modelos para el run
+  --model-lead gpt-5.5               Modelo esperado para lead/orquestador
+  --model-worker gpt-5.3-codex-spark Modelo esperado para workers acotados
+  --model-reviewer gpt-5.5           Modelo esperado para review/verificacion
   --no-verify                  Indica que no se requiere verificacion automatica
   --help                       Muestra esta ayuda.
 
@@ -37,6 +47,9 @@ function parseArgs(argv) {
     scope: "Debe inferirse desde AGENTS.md, la tarea y el codigo real; carga detalle bajo demanda.",
     ownership: "El lead debe definir ownership antes de delegar escritura si hay varios dominios.",
     verify: "npm run lint y npm run build si se toca codigo.",
+    taskType: "unspecified",
+    routingReason: "sin motivo declarado",
+    models: { ...MODEL_DEFAULTS },
     task: "",
   }
 
@@ -55,18 +68,18 @@ function parseArgs(argv) {
       continue
     }
 
-    if (["--agent", "--title", "--scope", "--ownership", "--verify"].includes(arg)) {
+    if (["--agent", "--title", "--scope", "--ownership", "--verify", "--task-type", "--routing-reason", "--model-lead", "--model-worker", "--model-reviewer"].includes(arg)) {
       const key = arg.slice(2)
       const value = argv[i + 1]
       if (!value) throw new Error(`Falta valor para ${arg}`)
-      options[key] = value
+      assignOption(options, key, value)
       i += 1
       continue
     }
 
-    const inline = arg.match(/^--(agent|title|scope|ownership|verify)=(.*)$/)
+    const inline = arg.match(/^--(agent|title|scope|ownership|verify|task-type|routing-reason|model-lead|model-worker|model-reviewer)=(.*)$/)
     if (inline) {
-      options[inline[1]] = inline[2]
+      assignOption(options, inline[1], inline[2])
       continue
     }
 
@@ -78,6 +91,35 @@ function parseArgs(argv) {
 }
 
 const RUNS_DIR = resolve(repoRoot, ".opencode/runs")
+
+function assignOption(options, key, value) {
+  if (key === "task-type") {
+    options.taskType = value
+    return
+  }
+
+  if (key === "routing-reason") {
+    options.routingReason = value
+    return
+  }
+
+  if (key === "model-lead") {
+    options.models.lead = value
+    return
+  }
+
+  if (key === "model-worker") {
+    options.models.worker = value
+    return
+  }
+
+  if (key === "model-reviewer") {
+    options.models.reviewer = value
+    return
+  }
+
+  options[key] = value
+}
 
 function buildContract(options) {
   return [
@@ -103,6 +145,16 @@ function buildContract(options) {
     "",
     "ENRUTADO:",
     "Usa cultura-lead como dispatcher minimo. Delega por dominio a @cultura-frontend, @cultura-data, @cultura-testing, @cultura-review, @cultura-security, @cultura-release o @cultura-docs.",
+    "El lead decide el modelo por riesgo y complejidad: GPT-5.5 para planificacion, ambiguedad, seguridad, datos/RLS, finanzas, review, verificacion final, PR/release o cambios multi-area; GPT-5.3-Codex-Spark solo como worker rapido para tareas locales, acotadas, con ownership claro y verificacion objetiva.",
+    "Escala a GPT-5.5 si un worker Spark falla verificacion, toca una zona sensible, necesita mas de 1 retry o devuelve un diff demasiado amplio.",
+    "",
+    "TELEMETRIA DE ROUTING:",
+    `Tipo de tarea: ${options.taskType}`,
+    `Motivo de routing: ${options.routingReason}`,
+    `Modelo lead esperado: ${options.models.lead}`,
+    `Modelo worker esperado: ${options.models.worker}`,
+    `Modelo reviewer esperado: ${options.models.reviewer}`,
+    "En la salida, declara modelo usado por rol si lo conoces, escalaciones, retries, verificaciones ejecutadas, resultado y riesgos.",
     "",
     "VERIFICACION:",
     options.verify,
@@ -128,6 +180,7 @@ async function main() {
   const runDir = resolve(RUNS_DIR, timestamp)
   await mkdir(runDir, { recursive: true })
   const outputPath = resolve(runDir, "output.txt")
+  const metadataPath = resolve(runDir, "metadata.json")
   const currentPath = resolve(RUNS_DIR, "current.json")
   const startedAt = new Date().toISOString()
 
@@ -135,12 +188,37 @@ async function main() {
   console.log(`[${timestamp}] Output: ${outputPath}`)
   console.log(`[${timestamp}] Timeout: ${AGENT_TIMEOUT_MS / 60000} min`)
 
+  const buildMetadata = (status, extra = {}) => ({
+    startedAt,
+    endedAt: extra.endedAt ?? null,
+    elapsedMs: extra.elapsedMs ?? null,
+    status,
+    title: options.title,
+    agent: options.agent,
+    taskType: options.taskType,
+    routingReason: options.routingReason,
+    models: options.models,
+    scope: options.scope,
+    ownership: options.ownership,
+    verificationExpected: options.verify,
+    result: extra.result ?? null,
+    exitCode: extra.exitCode ?? null,
+    retries: extra.retries ?? "not-recorded",
+    escalations: extra.escalations ?? "not-recorded",
+    costEstimate: extra.costEstimate ?? "not-recorded",
+    notes: "Operational telemetry for model-routing pilot. Do not persist run history in .memory/.",
+  })
+
+  const writeMetadata = async (status, extra = {}) => {
+    await writeFile(metadataPath, JSON.stringify(buildMetadata(status, extra), null, 2), "utf-8").catch(() => {})
+  }
+
   const writeCurrentJson = async (status, lastLines = []) => {
     const elapsed = Math.round((Date.now() - new Date(startedAt).getTime()) / 60000)
     await writeFile(
       currentPath,
       JSON.stringify(
-        { startedAt, agent: options.agent, title: options.title, elapsedMin: elapsed, lastCheckpoint: new Date().toISOString(), lastLines, status },
+        { startedAt, agent: options.agent, title: options.title, taskType: options.taskType, routingReason: options.routingReason, models: options.models, elapsedMin: elapsed, lastCheckpoint: new Date().toISOString(), lastLines, status },
         null,
         2,
       ),
@@ -149,6 +227,7 @@ async function main() {
   }
 
   await writeCurrentJson("running")
+  await writeMetadata("running")
 
   const child = spawn(
     "opencode",
@@ -160,6 +239,7 @@ async function main() {
   let stderr = ""
   let checkpointCount = 0
   let lastSize = 0
+  let didTimeout = false
 
   const getLastLines = () => stdout.split("\n").filter(Boolean).slice(-10)
 
@@ -198,8 +278,10 @@ async function main() {
   const agentTimeout = setTimeout(async () => {
     if (!child.killed) {
       console.error(`\n[TIMEOUT] Agente superó ${AGENT_TIMEOUT_MS / 60000} min. Matando proceso...`)
+      didTimeout = true
       child.kill("SIGTERM")
       await writeCurrentJson("timeout", getLastLines())
+      await writeMetadata("timeout", { endedAt: new Date().toISOString(), elapsedMs: Date.now() - new Date(startedAt).getTime(), result: "timeout", exitCode: 124 })
       await writeFile(outputPath, `[TIMEOUT tras ${AGENT_TIMEOUT_MS / 60000} min]\n\n${stdout}`, "utf-8").catch(() => {})
       process.exitCode = 124
     }
@@ -211,7 +293,14 @@ async function main() {
 
     // Escribir output final
     await writeFile(outputPath, stdout, "utf-8")
-    await writeCurrentJson(code === 0 ? "done" : "error", getLastLines())
+    const finalStatus = didTimeout ? "timeout" : code === 0 ? "done" : "error"
+    await writeCurrentJson(finalStatus, getLastLines())
+    await writeMetadata(finalStatus, {
+      endedAt: new Date().toISOString(),
+      elapsedMs: Date.now() - new Date(startedAt).getTime(),
+      result: didTimeout ? "timeout" : code === 0 ? "success" : "error",
+      exitCode: didTimeout ? 124 : code ?? 1,
+    })
 
     console.log(`\n[${new Date().toLocaleTimeString()}] Finished with code: ${code}`)
 
@@ -223,6 +312,7 @@ async function main() {
     clearTimeout(agentTimeout)
     await writeFile(outputPath, `Error: ${error.message}\n${stderr}`, "utf-8")
     await writeCurrentJson("error", [error.message])
+    await writeMetadata("error", { endedAt: new Date().toISOString(), elapsedMs: Date.now() - new Date(startedAt).getTime(), result: "spawn-error", exitCode: 1 })
     console.error(`Error: ${error.message}`)
     process.exitCode = 1
   })

--- a/.opencode/scripts/run-parallel-agents.mjs
+++ b/.opencode/scripts/run-parallel-agents.mjs
@@ -22,6 +22,11 @@ const repoRoot = resolve(__dirname, "../..")
 const ANSI_PATTERN = /\u001b\[[0-9;]*m/g
 // Timeout máximo por agente en paralelo: 30 min por defecto, configurable via AGENT_TIMEOUT_MS
 const AGENT_TIMEOUT_MS = parseInt(process.env.AGENT_TIMEOUT_MS ?? "1800000", 10)
+const MODEL_DEFAULTS = {
+  lead: process.env.AGENT_MODEL_LEAD ?? "frontmatter/default",
+  worker: process.env.AGENT_MODEL_WORKER ?? "frontmatter/default",
+  reviewer: process.env.AGENT_MODEL_REVIEWER ?? "frontmatter/default",
+}
 
 function usage() {
   console.log(`Uso:
@@ -31,6 +36,11 @@ Opciones:
   --agents data,testing,review     Agentes a ejecutar. Por defecto: ${DEFAULT_AGENTS.join(",")}
   --write                          Permite pedir cambios. Sin esto, todos reciben instruccion de solo lectura.
   --out .opencode/runs             Carpeta de salida. Por defecto: .opencode/runs
+  --task-type frontend|data|docs    Tipo de tarea para telemetria. Por defecto: parallel-review
+  --routing-reason "bajo riesgo"    Motivo de routing de modelos para el run
+  --model-lead gpt-5.5              Modelo esperado para lead/orquestador
+  --model-worker gpt-5.3-codex-spark Modelo esperado para workers acotados
+  --model-reviewer gpt-5.5          Modelo esperado para review/verificacion
   --help                           Muestra esta ayuda.
 
 Ejemplos:
@@ -46,6 +56,9 @@ function parseArgs(argv) {
     agents: DEFAULT_AGENTS,
     outDir: ".opencode/runs",
     write: false,
+    taskType: "parallel-review",
+    routingReason: "revision paralela por dominio",
+    models: { ...MODEL_DEFAULTS },
     task: "",
   }
 
@@ -90,11 +103,52 @@ function parseArgs(argv) {
       continue
     }
 
+    if (["--task-type", "--routing-reason", "--model-lead", "--model-worker", "--model-reviewer"].includes(arg)) {
+      const value = argv[i + 1]
+      if (!value) throw new Error(`Falta valor para ${arg}`)
+      assignOption(options, arg.slice(2), value)
+      i += 1
+      continue
+    }
+
+    const inline = arg.match(/^--(task-type|routing-reason|model-lead|model-worker|model-reviewer)=(.*)$/)
+    if (inline) {
+      assignOption(options, inline[1], inline[2])
+      continue
+    }
+
     taskParts.push(arg)
   }
 
   options.task = taskParts.join(" ").trim()
   return options
+}
+
+function assignOption(options, key, value) {
+  if (key === "task-type") {
+    options.taskType = value
+    return
+  }
+
+  if (key === "routing-reason") {
+    options.routingReason = value
+    return
+  }
+
+  if (key === "model-lead") {
+    options.models.lead = value
+    return
+  }
+
+  if (key === "model-worker") {
+    options.models.worker = value
+    return
+  }
+
+  if (key === "model-reviewer") {
+    options.models.reviewer = value
+    return
+  }
 }
 
 function buildPrompt(agentName, task, canWrite) {
@@ -108,6 +162,8 @@ function buildPrompt(agentName, task, canWrite) {
     "Usa AGENTS.md como contrato corto y docs/agent-context-policy.md como politica canonica: indices primero, detalle bajo demanda, sin historico por defecto.",
     "Lee .opencode/AGENT_STATE.md como estado vivo. Si detectas una senal relevante para otros agentes, relee ese archivo y actualiza solo tu bloque y la seccion Eventos.",
     "No cargues Product Brain completo, backlog, releases, issues cerradas ni historico por defecto; usa archivos/secciones concretas solo si la tarea lo requiere.",
+    "Routing de modelos: GPT-5.5 debe conservar planificacion, ambiguedad, datos/RLS, seguridad, finanzas, review, verificacion final, PR/release y coordinacion multi-area. GPT-5.3-Codex-Spark solo encaja como worker rapido con ownership claro, bajo riesgo y verificacion objetiva.",
+    "Escala a GPT-5.5 si un worker Spark falla verificacion, toca zona sensible, necesita mas de 1 retry o devuelve un diff demasiado amplio.",
     "Devuelve un resumen breve con hallazgos, recomendaciones y cualquier bloqueo.",
     "",
     `Tarea: ${task}`,
@@ -213,9 +269,36 @@ async function main() {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
   const runDir = resolve(repoRoot, options.outDir, timestamp)
   await mkdir(runDir, { recursive: true })
+  const metadataPath = join(runDir, "metadata.json")
+  const startedAt = new Date().toISOString()
 
   console.log(`Ejecutando ${options.agents.length} agentes en paralelo...`)
   console.log(`Salida: ${runDir}`)
+  await writeFile(
+    metadataPath,
+    JSON.stringify(
+      {
+        startedAt,
+        endedAt: null,
+        elapsedMs: null,
+        status: "running",
+        title: "parallel-agents",
+        mode: options.write ? "write" : "read-only",
+        taskType: options.taskType,
+        routingReason: options.routingReason,
+        agents: options.agents,
+        models: options.models,
+        result: null,
+        costEstimate: "not-recorded",
+        retries: "not-recorded",
+        escalations: "not-recorded",
+        notes: "Operational telemetry for model-routing pilot. Do not persist run history in .memory/.",
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  )
 
   const results = await Promise.all(options.agents.map((agent) => runAgent(agent, options, runDir)))
   const failed = results.filter((result) => result.code !== 0)
@@ -224,6 +307,33 @@ async function main() {
     const status = result.code === 0 ? "OK" : `FALLO ${result.code}`
     console.log(`${status} ${result.agentName} -> ${result.outputPath}`)
   }
+
+  await writeFile(
+    metadataPath,
+    JSON.stringify(
+      {
+        startedAt,
+        endedAt: new Date().toISOString(),
+        elapsedMs: Date.now() - new Date(startedAt).getTime(),
+        status: failed.length > 0 ? "error" : "done",
+        title: "parallel-agents",
+        mode: options.write ? "write" : "read-only",
+        taskType: options.taskType,
+        routingReason: options.routingReason,
+        agents: options.agents,
+        models: options.models,
+        result: failed.length > 0 ? "partial-or-failed" : "success",
+        results,
+        costEstimate: "not-recorded",
+        retries: "not-recorded",
+        escalations: "not-recorded",
+        notes: "Operational telemetry for model-routing pilot. Do not persist run history in .memory/.",
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  )
 
   process.exitCode = failed.length > 0 ? 1 : 0
 }

--- a/.opencode/scripts/run-planner.mjs
+++ b/.opencode/scripts/run-planner.mjs
@@ -1,9 +1,16 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process"
+import { mkdir, writeFile } from "node:fs/promises"
 import { resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 const repoRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)))
+const RUNS_DIR = resolve(repoRoot, ".opencode/runs")
+const MODEL_DEFAULTS = {
+  lead: process.env.AGENT_MODEL_LEAD ?? "frontmatter/default",
+  worker: process.env.AGENT_MODEL_WORKER ?? "frontmatter/default",
+  reviewer: process.env.AGENT_MODEL_REVIEWER ?? "frontmatter/default",
+}
 
 function usage() {
   console.log(`Uso:
@@ -11,7 +18,7 @@ function usage() {
 
 El planificador convierte el prompt en una issue de GitHub estructurada,
 prepara una rama desde main y lanza automáticamente los agentes de implementación
-con el modelo barato.
+con routing de modelos segun riesgo y complejidad.
 
 Ejemplos:
   npm run agents:plan -- "quiero que los eventos se puedan filtrar por categoría y estado"
@@ -47,7 +54,42 @@ async function main() {
     "4. Crea la issue en GitHub con gh.",
     "5. Prepara una rama de tarea desde main actualizado; si el worktree esta sucio, reporta bloqueo.",
     "6. Lanza npm run agents:run con el objetivo, la URL, PR a main, merge y verificacion de produccion si aplica.",
+    "",
+    "ROUTING DE MODELOS:",
+    "GPT-5.5 conserva planificacion, ambiguedad, arquitectura, datos/RLS, seguridad, finanzas, review, verificacion final y PR/release.",
+    "GPT-5.3-Codex-Spark puede usarse solo como worker rapido para tareas locales, acotadas, con ownership claro y verificacion objetiva.",
+    "Escala a GPT-5.5 si Spark falla verificacion, toca zona sensible, necesita mas de 1 retry o devuelve un diff demasiado amplio.",
   ].join("\n")
+
+  const startedAt = new Date().toISOString()
+  const timestamp = startedAt.replace(/[:.]/g, "-")
+  const runDir = resolve(RUNS_DIR, timestamp)
+  const metadataPath = resolve(runDir, "metadata.json")
+  await mkdir(runDir, { recursive: true })
+  await writeFile(
+    metadataPath,
+    JSON.stringify(
+      {
+        startedAt,
+        endedAt: null,
+        elapsedMs: null,
+        status: "running",
+        title: "cultura-plan",
+        agent: "cultura-planner",
+        taskType: "planning",
+        routingReason: "issue planning and model-routing decision",
+        models: MODEL_DEFAULTS,
+        result: null,
+        costEstimate: "not-recorded",
+        retries: "not-recorded",
+        escalations: "not-recorded",
+        notes: "Operational telemetry for model-routing pilot. Do not persist run history in .memory/.",
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  )
 
   const child = spawn(
     "opencode",
@@ -55,7 +97,32 @@ async function main() {
     { cwd: repoRoot, stdio: "inherit" },
   )
 
-  child.on("close", (code) => {
+  child.on("close", async (code) => {
+    await writeFile(
+      metadataPath,
+      JSON.stringify(
+        {
+          startedAt,
+          endedAt: new Date().toISOString(),
+          elapsedMs: Date.now() - new Date(startedAt).getTime(),
+          status: code === 0 ? "done" : "error",
+          title: "cultura-plan",
+          agent: "cultura-planner",
+          taskType: "planning",
+          routingReason: "issue planning and model-routing decision",
+          models: MODEL_DEFAULTS,
+          result: code === 0 ? "success" : "error",
+          exitCode: code ?? 1,
+          costEstimate: "not-recorded",
+          retries: "not-recorded",
+          escalations: "not-recorded",
+          notes: "Operational telemetry for model-routing pilot. Do not persist run history in .memory/.",
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    ).catch(() => {})
     process.exitCode = code ?? 1
   })
 }

--- a/docs/project/issues/CACH-B0010.md
+++ b/docs/project/issues/CACH-B0010.md
@@ -9,7 +9,7 @@ priority: p2
 estimate: m
 area: infra
 created_at: 2026-05-04
-updated_at: 2026-05-04
+updated_at: 2026-05-08
 aliases:
   - CACH-B0010
 tags:
@@ -40,13 +40,27 @@ El proyecto depende cada vez más de rituales de agentes. Hace falta reducir fri
 - Investigar LLM local 8B para tareas simples.
 - Definir casos de uso antes de integrar modelo local.
 - Diseñar routing inteligente entre modelos según tarea.
+- Piloto controlado: `GPT-5.5` como lead/orquestador/verificador y `GPT-5.3-Codex-Spark` solo como worker rápido para tareas locales, acotadas y verificables.
+- Registrar telemetría operativa por run en `.opencode/runs/`: modelo por rol, tipo de tarea, motivo de routing, ownership, verificación, retries, escalaciones, coste estimado, duración y resultado.
+- No convertir Spark en default hasta validar coste por tarea aceptada y defectos post-merge.
 
 ## Acceptance Criteria
 
 - [ ] El tooling no contamina la UX ni el runtime de Cachés.
 - [ ] Los casos del LLM local están documentados antes de integrar.
 - [ ] El routing de modelos tiene criterios observables.
+- [ ] El piloto compara 20-30 tareas reales entre `GPT-5.5` solo y `GPT-5.5 lead + Spark workers`.
+- [ ] Spark solo se usa con ownership explícito, bajo riesgo, verificación objetiva y máximo 1 retry antes de escalar.
+- [ ] Datos/RLS, seguridad, finanzas, calendarios complejos, review final, PR/release y acciones sensibles quedan reservadas para `GPT-5.5` o revisión fuerte.
+- [ ] Cada ejecución de agentes deja telemetría operativa en `.opencode/runs/<timestamp>/metadata.json`.
+- [ ] La promoción de Spark exige 25-40% menos coste o latencia sin aumento de CI rojo, bugs post-merge ni findings severos.
 - [ ] Las ideas de Product Brain no se convierten en GitHub Issues salvo implementación.
+
+## Validation Plan
+
+- Medir coste por tarea aceptada, tasa de aceptación a la primera, retries, tiempo end-to-end, fallos de lint/build/test, findings de review, defectos escapados, escalaciones y conflictos por ownership.
+- Mantener los logs y metadatos del piloto como estado operativo en `.opencode/runs/`; no guardarlos en `.memory/`.
+- Revisar el piloto antes de cambiar de forma masiva los campos `model:` de los perfiles OpenCode.
 
 ## Related
 


### PR DESCRIPTION
## Summary

- documents GPT-5.5 + GPT-5.3-Codex-Spark model routing as a controlled pilot
- updates cultura-lead routing rules with risk-based escalation criteria
- adds operational metadata for agent runs under .opencode/runs/<timestamp>/metadata.json
- updates CACH-B0010 and durable workflow memory

## Validation

- node --check .opencode/scripts/run-agent.mjs
- node --check .opencode/scripts/run-parallel-agents.mjs
- node --check .opencode/scripts/run-planner.mjs
- npm run pb:check
- npm run context:check (passes with existing broad-loading warnings)
- git diff --check
- npm run lint
- npm run build (passes; Vite large chunk warning remains)

## Memoria

actualizada: .memory/topics/agent-workflows.md

Closes CACH-B0010 pilot slice.
