### PR TITLE
Release 0.1.0-beta.14: email transaccional definitivo

### DIFF
--- a/.memory/projects/email-ops.md
+++ b/.memory/projects/email-ops.md
@@ -6,3 +6,10 @@
 - Durable memory: if Auth logs show `user_confirmation_requested` but the user does not receive the confirmation email, check Supabase Auth SMTP `Sender email`, Brevo sender/domain validation, Brevo transactional logs and SPF/DKIM/DMARC before assuming an app bug.
 - Current caveat: a personal confirmed/validated sender is used temporarily because Brevo rejects or does not deliver from unconfirmed/non-real senders. Do not switch to a definitive Cachés sender until the email/alias exists and Brevo confirms the domain/remitente.
 - Privacy note: do not store the personal sender address, SMTP credentials or Brevo keys in memory, docs, issues or prompts.
+
+## 2026-05-09 - Definitive Caches Sender
+
+- `caches.es` is the definitive email domain for Cachés.
+- `contacto@caches.es` is the real human mailbox and reply-to address.
+- `no-reply@caches.es` is the transactional sender alias for beta invites and Auth SMTP once configured.
+- Brevo domain authentication for `caches.es` was validated before switching the Edge Function sender. Supabase Auth SMTP still must be checked separately in the Dashboard because SMTP keys are not stored in repo or chat.

--- a/README.md
+++ b/README.md
@@ -409,7 +409,10 @@ Crea `.env.local` en la raíz del proyecto (no lo subas a git):
 ```
 VITE_SUPABASE_URL=https://xxxx.supabase.co
 VITE_SUPABASE_ANON_KEY=tu_anon_key
+VITE_APP_URL=https://culturapp-rho.vercel.app
 ```
+
+`VITE_APP_URL` es la URL canonica que se usa para enlaces de confirmacion de Supabase Auth. En local puede seguir apuntando a produccion para evitar que los usuarios beta acaben en `localhost` al confirmar email.
 
 ---
 

--- a/docs/project/DIGEST.md
+++ b/docs/project/DIGEST.md
@@ -51,9 +51,7 @@ _Sin entradas._
 
 ### In progress
 
-| ID | Título | Tipo | Nivel | P |
-|---|---|---|---|---|
-| CACH-B0020 | Validar dominio de email transaccional y cambiar remitentes definitivos | chore | task | p0 |
+_Sin entradas._
 
 ### Review / Verify
 
@@ -63,6 +61,7 @@ _Sin entradas._
 
 | ID | Título | Tipo | Nivel | P |
 |---|---|---|---|---|
+| CACH-0051 | [Deploy] Dominio publico de app y estrategia multientorno | chore | task | p1 |
 | CACH-B0001 | Redisenar Trabajos y jerarquia proyecto-evento | feature | initiative | p1 |
 | CACH-B0002 | Simplificar experiencia mobile financiera | feature | initiative | p1 |
 | CACH-B0004 | Contratantes facturacion y liquidacion neta | feature | initiative | p1 |
@@ -72,8 +71,8 @@ _Sin entradas._
 
 | ID | Título | Workflow | Tipo | Nivel | P |
 |---|---|---|---|---|---|
-| CACH-B0020 | Validar dominio de email transaccional y cambiar remitentes definitivos | in_progress | chore | task | p0 |
 | CACH-0042 | [UX] Racionalizar navegacion inferior | ready | feature | slice | p1 |
+| CACH-0051 | [Deploy] Dominio publico de app y estrategia multientorno | backlog | chore | task | p1 |
 | CACH-B0001 | Redisenar Trabajos y jerarquia proyecto-evento | backlog | feature | initiative | p1 |
 | CACH-B0002 | Simplificar experiencia mobile financiera | backlog | feature | initiative | p1 |
 | CACH-B0004 | Contratantes facturacion y liquidacion neta | backlog | feature | initiative | p1 |

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -50,6 +50,7 @@ _Sin issues._
 
 | ID | Titulo | Tipo | Nivel | P | Componentes |
 |---|---|---|---|---|---|
+| [[../issues/CACH-0051|CACH-0051]] | [Deploy] Dominio publico de app y estrategia multientorno | chore | task | p1 | infra-deploy, supabase, email |
 | [[../issues/CACH-B0001|CACH-B0001]] | Redisenar Trabajos y jerarquia proyecto-evento | feature | initiative | p1 | work, projects, events, design-system |
 | [[../issues/CACH-B0002|CACH-B0002]] | Simplificar experiencia mobile financiera | feature | initiative | p1 | finance |
 | [[../issues/CACH-B0004|CACH-B0004]] | Contratantes facturacion y liquidacion neta | feature | initiative | p1 | finance, design-system |
@@ -69,9 +70,7 @@ _Sin issues._
 
 ## In progress
 
-| ID | Titulo | Tipo | Nivel | P | Componentes |
-|---|---|---|---|---|---|
-| [[../issues/CACH-B0020|CACH-B0020]] | Validar dominio de email transaccional y cambiar remitentes definitivos | chore | task | p0 | infra-deploy, email, supabase |
+_Sin issues._
 
 ## Review / Verify
 
@@ -84,6 +83,7 @@ _Sin issues._
 | [[../issues/CACH-0039|CACH-0039]] | [Agents] Respetar permisos reales en lanzadores OpenCode | RELEASE-0.1.0-beta.11 | Cerrada por `RELEASE-0.1.0-beta.11` en `main` mediante commit `15c0743`. |
 | [[../issues/CACH-0040|CACH-0040]] | [Agents] Separar plan draft de ejecucion mutante | RELEASE-0.1.0-beta.11 | Cerrada por `RELEASE-0.1.0-beta.11` en `main` mediante commit `15c0743`. |
 | [[../issues/CACH-0049|CACH-0049]] | Migrar Product Brain a v2 lean agile para agentes | null | Product Brain queda migrado a v2 completo. El repositorio dispone de schema, migrador, orientador, generadores, validadores, checks de cierre y contratos de agente alineados con Product Brain-first. |
+| [[../issues/CACH-B0020|CACH-B0020]] | Validar dominio de email transaccional y cambiar remitentes definitivos | RELEASE-0.1.0-beta.14 | Cerrado en `RELEASE-0.1.0-beta.14`. Cachés usa `caches.es` como dominio de email definitivo, `no-reply@caches.es` como remitente transaccional y `contacto@caches.es` como reply-to/buzón humano. Queda fuera el cambio de dominio público de la app y la estrategia multientorno, trazados en `CACH-0051`. |
 | [[../issues/CACH-0026|CACH-0026]] | Setup inicial Product Brain | null | Sin resultado documentado. |
 | [[../issues/CACH-0028|CACH-0028]] | Corregir sync iCloud y estructura versionada | null | Sin resultado documentado. |
 | [[../issues/CACH-0029|CACH-0029]] | Integrar helpers CACH-B0016 en flujos reales | RELEASE-0.1.0-beta.1 | Listo para revision. CACH-0029 integra los helpers de CACH-B0016 en flujos reales: |

--- a/docs/project/indexes/by-area.md
+++ b/docs/project/indexes/by-area.md
@@ -53,11 +53,12 @@ generated: true
 
 ## infra
 
+- [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · backlog · p1 · task
 - [[../issues/CACH-B0008|CACH-B0008]] — PWA notificaciones y offline · backlog · p2 · initiative
 - [[../issues/CACH-B0010|CACH-B0010]] — Tooling de agentes y modelos de desarrollo · backlog · p2 · initiative
-- [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · in_progress · p0 · task
 - [[../issues/CACH-0039|CACH-0039]] — [Agents] Respetar permisos reales en lanzadores OpenCode · done · p0 · task
 - [[../issues/CACH-0040|CACH-0040]] — [Agents] Separar plan draft de ejecucion mutante · done · p0 · task
+- [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · done · p0 · task
 - [[../issues/CACH-0046|CACH-0046]] — [Verify] Anadir verificacion por tipo de cambio · done · p1 · task
 - [[../issues/CACH-0050|CACH-0050]] — [Deploy] Tooling local-first de PR release y smoke · done · p1 · task
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task

--- a/docs/project/indexes/by-component.md
+++ b/docs/project/indexes/by-component.md
@@ -126,21 +126,24 @@ generated: true
 
 ## infra-deploy
 
+- [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · backlog · p1 · task
 - [[../issues/CACH-B0008|CACH-B0008]] — PWA notificaciones y offline · backlog · p2 · initiative
 - [[../issues/CACH-B0010|CACH-B0010]] — Tooling de agentes y modelos de desarrollo · backlog · p2 · initiative
-- [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · in_progress · p0 · task
 - [[../issues/CACH-0039|CACH-0039]] — [Agents] Respetar permisos reales en lanzadores OpenCode · done · p0 · task
 - [[../issues/CACH-0040|CACH-0040]] — [Agents] Separar plan draft de ejecucion mutante · done · p0 · task
 - [[../issues/CACH-0049|CACH-0049]] — Migrar Product Brain a v2 lean agile para agentes · done · p0 · task
+- [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · done · p0 · task
 - [[../issues/CACH-0046|CACH-0046]] — [Verify] Anadir verificacion por tipo de cambio · done · p1 · task
 - [[../issues/CACH-0050|CACH-0050]] — [Deploy] Tooling local-first de PR release y smoke · done · p1 · task
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task
 
 ## email
 
-- [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · in_progress · p0 · task
+- [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · backlog · p1 · task
+- [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · done · p0 · task
 - [[../issues/CACH-B0019|CACH-B0019]] — Emails transaccionales beta con Brevo · done · p1 · slice
 
 ## supabase
 
-- [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · in_progress · p0 · task
+- [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · backlog · p1 · task
+- [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · done · p0 · task

--- a/docs/project/indexes/by-level.md
+++ b/docs/project/indexes/by-level.md
@@ -52,10 +52,11 @@ generated: true
 
 ## task
 
-- [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · in_progress · p0 · task
+- [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · backlog · p1 · task
 - [[../issues/CACH-0039|CACH-0039]] — [Agents] Respetar permisos reales en lanzadores OpenCode · done · p0 · task
 - [[../issues/CACH-0040|CACH-0040]] — [Agents] Separar plan draft de ejecucion mutante · done · p0 · task
 - [[../issues/CACH-0049|CACH-0049]] — Migrar Product Brain a v2 lean agile para agentes · done · p0 · task
+- [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · done · p0 · task
 - [[../issues/CACH-0026|CACH-0026]] — Setup inicial Product Brain · done · p1 · task
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0036|CACH-0036]] — Profesionalizar flujo de ramas por beta · done · p1 · task

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -17,6 +17,7 @@ generated: true
 
 ## none
 
+- [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · backlog · p1 · task
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera · backlog · p1 · initiative
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
@@ -65,7 +66,7 @@ generated: true
 
 ## RELEASE-0.1.0-beta.14
 
-- [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · in_progress · p0 · task
+- [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · done · p0 · task
 
 ## RELEASE-0.1.0-beta.15
 

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -17,6 +17,7 @@ generated: true
 
 ## backlog
 
+- [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · backlog · p1 · task
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera · backlog · p1 · initiative
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
@@ -33,6 +34,7 @@ generated: true
 - [[../issues/CACH-0039|CACH-0039]] — [Agents] Respetar permisos reales en lanzadores OpenCode · done · p0 · task
 - [[../issues/CACH-0040|CACH-0040]] — [Agents] Separar plan draft de ejecucion mutante · done · p0 · task
 - [[../issues/CACH-0049|CACH-0049]] — Migrar Product Brain a v2 lean agile para agentes · done · p0 · task
+- [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · done · p0 · task
 - [[../issues/CACH-0026|CACH-0026]] — Setup inicial Product Brain · done · p1 · task
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada · done · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
@@ -62,10 +64,6 @@ generated: true
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos · done · p2 · slice
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task
-
-## in_progress
-
-- [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · in_progress · p0 · task
 
 ## ready
 

--- a/docs/project/indexes/by-theme.md
+++ b/docs/project/indexes/by-theme.md
@@ -17,7 +17,8 @@ generated: true
 
 ## beta-trust
 
-- [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · in_progress · p0 · task
+- [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · backlog · p1 · task
+- [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · done · p0 · task
 - [[../issues/CACH-0036|CACH-0036]] — Profesionalizar flujo de ramas por beta · done · p1 · task
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta · done · p1 · slice

--- a/docs/project/indexes/issues-open.index.md
+++ b/docs/project/indexes/issues-open.index.md
@@ -16,6 +16,7 @@ generated: true
 ---
 # Issues Open Index
 
+- [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · backlog · p1 · task
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera · backlog · p1 · initiative
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
@@ -27,4 +28,3 @@ generated: true
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
 - [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · ready · p1 · slice
-- [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · in_progress · p0 · task

--- a/docs/project/indexes/issues.index.md
+++ b/docs/project/indexes/issues.index.md
@@ -39,6 +39,7 @@ generated: true
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode
 - [[../issues/CACH-0049|CACH-0049]] — Migrar Product Brain a v2 lean agile para agentes
 - [[../issues/CACH-0050|CACH-0050]] — [Deploy] Tooling local-first de PR release y smoke
+- [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes

--- a/docs/project/issues/CACH-0051.md
+++ b/docs/project/issues/CACH-0051.md
@@ -1,0 +1,101 @@
+---
+schema_version: 2
+kind: issue
+id: CACH-0051
+title: '[Deploy] Dominio publico de app y estrategia multientorno'
+lifecycle: active
+created: '2026-05-09'
+updated: '2026-05-09'
+aliases:
+  - CACH-0051
+tags:
+  - product-brain
+  - issue
+  - deploy
+  - supabase
+  - vercel
+generated: false
+work_type: chore
+work_level: task
+issue_workflow: backlog
+priority: p1
+size: m
+area: infra
+components:
+  - infra-deploy
+  - supabase
+  - email
+parent: null
+related:
+  - CACH-B0020
+depends_on: []
+blocked_by: []
+adr: []
+release: null
+theme: beta-trust
+---
+# CACH-0051 — [Deploy] Dominio publico de app y estrategia multientorno
+
+## Objetivo
+
+Definir y aplicar el dominio publico canonico de Cachés y una estrategia multientorno minima para separar produccion, staging/beta y desarrollo local.
+
+## Alcance
+
+Incluido:
+
+- Decidir dominio de app canonico, por defecto `app.caches.es`.
+- Configurar Vercel para servir la app desde el dominio elegido.
+- Configurar DNS en Hostinger para el dominio de app.
+- Definir `VITE_APP_URL` por entorno en Vercel.
+- Actualizar `APP_URL` de la Edge Function `send-beta-invite` cuando el dominio este validado.
+- Actualizar Supabase Auth `Site URL` y `Redirect URLs`.
+- Decidir si beta/staging usa un segundo proyecto Supabase o el proyecto actual con restricciones documentadas.
+
+Fuera de alcance:
+
+- Cambiar remitentes de email transaccional, cerrado en `CACH-B0020`.
+- Redisenar landing publica de `caches.es`.
+- Migrar datos entre proyectos Supabase sin plan especifico.
+
+## Criterios de aceptacion
+
+- [ ] El dominio canonico de app queda decidido y documentado.
+- [ ] Vercel sirve la app desde el dominio elegido con SPA fallback operativo.
+- [ ] `VITE_APP_URL` esta configurado por entorno y las confirmaciones Auth no apuntan a `localhost`.
+- [ ] `APP_URL` de `send-beta-invite` apunta al dominio canonico validado.
+- [ ] Supabase Auth contiene `Site URL` y `Redirect URLs` coherentes con produccion, staging/beta y local.
+- [ ] La estrategia Supabase prod/staging/local queda documentada con riesgos y reglas de uso.
+- [ ] Smoke test de invitacion y confirmacion pasa usando el dominio canonico.
+
+## Validacion
+
+- `npm run lint`
+- `npm run build`
+- `npm run pb:guard`
+- `npm run smoke:postdeploy -- --url <dominio-canonico>`
+- Smoke manual de invitacion beta y confirmacion de cuenta.
+
+## Resultado
+
+Pendiente hasta cerrar la issue.
+
+## Desarrollo
+
+- Rama:
+- PR:
+- Estado actual: pendiente. `CACH-B0020` queda cerrado usando `https://culturapp-rho.vercel.app` como URL canonica temporal.
+
+## Notas de progreso
+
+## Cambios de alcance y decisiones
+
+## Bloqueos
+
+## Validación ejecutada
+
+Pendiente hasta ejecutar la issue.
+
+## Memoria
+
+No aplica por ahora.

--- a/docs/project/issues/CACH-B0020.md
+++ b/docs/project/issues/CACH-B0020.md
@@ -55,10 +55,10 @@ Contexto operativo: ahora mismo el envío funciona porque el remitente temporal 
 
 ## Criterios de aceptacion
 
-- [ ] El remitente definitivo existe como email o alias real.
-- [ ] Brevo marca el dominio/remitente definitivo como validado.
-- [ ] DNS de `updates.caches.es`/`caches.es` incluye los registros SPF, DKIM y DMARC requeridos.
-- [ ] Edge Function `send-beta-invite` usa el remitente definitivo solo después de validarlo en Brevo.
+- [x] El remitente definitivo existe como email o alias real.
+- [x] Brevo marca el dominio/remitente definitivo como validado.
+- [x] DNS de `updates.caches.es`/`caches.es` incluye los registros SPF, DKIM y DMARC requeridos.
+- [x] Edge Function `send-beta-invite` usa el remitente definitivo solo después de validarlo en Brevo.
 - [ ] Supabase Auth SMTP usa el remitente definitivo como `Sender email` solo después de validarlo en Brevo.
 - [ ] Una invitación enviada desde `/admin/invitaciones` llega a bandeja o aparece como entregada en logs de Brevo.
 - [ ] Un registro nuevo recibe email de confirmación y puede confirmar la cuenta.
@@ -91,16 +91,38 @@ En progreso en `RELEASE-0.1.0-beta.14`.
 ## Notas de progreso
 
 - 2026-05-09: inicio operativo de beta 14. La rama `release/0.1.0-beta.14` queda preparada para ejecutar la validacion de email transaccional definitivo.
+- 2026-05-09: `caches.es` queda registrado en Hostinger. Se crea el buzon real `contacto@caches.es` y el alias `no-reply@caches.es` apuntando a `contacto@caches.es`.
+- 2026-05-09: `caches.es` queda anadido en Brevo para autenticacion manual por DNS. Se anaden en Hostinger los registros de codigo Brevo TXT, DKIM 1, DKIM 2 y DMARC indicados por Brevo.
+- 2026-05-09: se detecta DMARC duplicado y se corrige dejando un unico registro `_dmarc` con `v=DMARC1; p=none; rua=mailto:rua@dmarc.brevo.com`. SPF revisado: solo existe un registro SPF.
+- 2026-05-09: `dig` confirma codigo Brevo TXT, SPF unico de Hostinger, DKIM 1, DKIM 2 y DMARC. Brevo marca `caches.es` como autenticado.
+- 2026-05-09: se actualizan secrets de Supabase Edge Function para usar `no-reply@caches.es` como `EMAIL_FROM_ADDRESS`, `Cachés` como `EMAIL_FROM_NAME` y `contacto@caches.es` como `EMAIL_REPLY_TO`. Se despliega `send-beta-invite`, que queda activa en version 10.
 
 ## Cambios de alcance y decisiones
 
 
 ## Bloqueos
 
+- Pendiente cambiar `Sender email` de Supabase Auth SMTP al remitente definitivo en Dashboard.
+- Pendiente smoke test real de invitacion beta y confirmacion de cuenta.
 
 ## Validación ejecutada
 
-Pendiente hasta ejecutar la issue.
+Validado por `dig`:
+
+```bash
+dig TXT caches.es
+dig CNAME brevo1._domainkey.caches.es
+dig CNAME brevo2._domainkey.caches.es
+dig TXT _dmarc.caches.es
+```
+
+Supabase Edge Function:
+
+- Secrets de remitente actualizados sin imprimir valores sensibles.
+- `send-beta-invite` desplegada en el proyecto `mkidexrkhjhrsjnjmugw`.
+- MCP/CLI confirma funcion activa en version 10.
+
+Pendiente completar validacion funcional con invitacion beta y confirmacion de cuenta.
 
 ## Memoria
 

--- a/docs/project/issues/CACH-B0020.md
+++ b/docs/project/issues/CACH-B0020.md
@@ -5,7 +5,7 @@ id: CACH-B0020
 title: Validar dominio de email transaccional y cambiar remitentes definitivos
 lifecycle: active
 created: '2026-05-07'
-updated: '2026-05-08'
+updated: '2026-05-09'
 aliases:
   - CACH-B0020
 tags:
@@ -84,12 +84,13 @@ En progreso en `RELEASE-0.1.0-beta.14`.
 
 ## Desarrollo
 
-- Rama:
-- PR:
-- Estado actual:
+- Rama: `release/0.1.0-beta.14`
+- PR: pendiente
+- Estado actual: release branch creada y alineada con `main`; pendiente de pasos manuales de email, DNS, Brevo y Supabase SMTP.
 
 ## Notas de progreso
 
+- 2026-05-09: inicio operativo de beta 14. La rama `release/0.1.0-beta.14` queda preparada para ejecutar la validacion de email transaccional definitivo.
 
 ## Cambios de alcance y decisiones
 

--- a/docs/project/issues/CACH-B0020.md
+++ b/docs/project/issues/CACH-B0020.md
@@ -17,7 +17,7 @@ tags:
 generated: false
 work_type: chore
 work_level: task
-issue_workflow: in_progress
+issue_workflow: done
 priority: p0
 size: s
 area: infra
@@ -59,10 +59,10 @@ Contexto operativo: ahora mismo el envío funciona porque el remitente temporal 
 - [x] Brevo marca el dominio/remitente definitivo como validado.
 - [x] DNS de `updates.caches.es`/`caches.es` incluye los registros SPF, DKIM y DMARC requeridos.
 - [x] Edge Function `send-beta-invite` usa el remitente definitivo solo después de validarlo en Brevo.
-- [ ] Supabase Auth SMTP usa el remitente definitivo como `Sender email` solo después de validarlo en Brevo.
-- [ ] Una invitación enviada desde `/admin/invitaciones` llega a bandeja o aparece como entregada en logs de Brevo.
-- [ ] Un registro nuevo recibe email de confirmación y puede confirmar la cuenta.
-- [ ] No quedan emails personales como remitente operativo documentado ni configurado.
+- [x] Supabase Auth SMTP usa el remitente definitivo como `Sender email` solo después de validarlo en Brevo.
+- [x] Una invitación enviada desde `/admin/invitaciones` llega a bandeja o aparece como entregada en logs de Brevo.
+- [x] Un registro nuevo recibe email de confirmación y puede confirmar la cuenta.
+- [x] No quedan emails personales como remitente operativo documentado ni configurado.
 
 ## Validacion
 
@@ -80,13 +80,13 @@ Queda fuera de `RELEASE-0.1.0-beta.11`, `RELEASE-0.1.0-beta.12` y `RELEASE-0.1.0
 
 ## Resultado
 
-En progreso en `RELEASE-0.1.0-beta.14`.
+Cerrado en `RELEASE-0.1.0-beta.14`. Cachés usa `caches.es` como dominio de email definitivo, `no-reply@caches.es` como remitente transaccional y `contacto@caches.es` como reply-to/buzón humano. Queda fuera el cambio de dominio público de la app y la estrategia multientorno, trazados en `CACH-0051`.
 
 ## Desarrollo
 
 - Rama: `release/0.1.0-beta.14`
 - PR: pendiente
-- Estado actual: release branch creada y alineada con `main`; pendiente de pasos manuales de email, DNS, Brevo y Supabase SMTP.
+- Estado actual: implementado, validado y listo para PR de release a `main`.
 
 ## Notas de progreso
 
@@ -96,14 +96,16 @@ En progreso en `RELEASE-0.1.0-beta.14`.
 - 2026-05-09: se detecta DMARC duplicado y se corrige dejando un unico registro `_dmarc` con `v=DMARC1; p=none; rua=mailto:rua@dmarc.brevo.com`. SPF revisado: solo existe un registro SPF.
 - 2026-05-09: `dig` confirma codigo Brevo TXT, SPF unico de Hostinger, DKIM 1, DKIM 2 y DMARC. Brevo marca `caches.es` como autenticado.
 - 2026-05-09: se actualizan secrets de Supabase Edge Function para usar `no-reply@caches.es` como `EMAIL_FROM_ADDRESS`, `Cachés` como `EMAIL_FROM_NAME` y `contacto@caches.es` como `EMAIL_REPLY_TO`. Se despliega `send-beta-invite`, que queda activa en version 10.
+- 2026-05-09: el redirect de confirmacion de Supabase Auth deja de depender de `window.location.origin` y pasa a usar `VITE_APP_URL` con fallback a `https://culturapp-rho.vercel.app`, evitando confirmaciones hacia `localhost` en pruebas locales.
+- 2026-05-09: smoke test real confirma recepcion de invitacion beta y email de confirmacion de Supabase Auth desde el remitente `Cachés`.
 
 ## Cambios de alcance y decisiones
 
+- El cambio del dominio publico de la app a `app.caches.es` y la configuracion multientorno quedan fuera de beta 14 y pasan a `CACH-0051`.
 
 ## Bloqueos
 
-- Pendiente cambiar `Sender email` de Supabase Auth SMTP al remitente definitivo en Dashboard.
-- Pendiente smoke test real de invitacion beta y confirmacion de cuenta.
+Sin bloqueos.
 
 ## Validación ejecutada
 
@@ -121,9 +123,11 @@ Supabase Edge Function:
 - Secrets de remitente actualizados sin imprimir valores sensibles.
 - `send-beta-invite` desplegada en el proyecto `mkidexrkhjhrsjnjmugw`.
 - MCP/CLI confirma funcion activa en version 10.
+- Supabase Auth SMTP configurado en Dashboard con `Sender email` definitivo.
+- Smoke test real: invitacion beta recibida y confirmacion de cuenta recibida.
 
-Pendiente completar validacion funcional con invitacion beta y confirmacion de cuenta.
+Pendiente fuera de esta issue: dominio publico `app.caches.es` y estrategia multientorno, trazado en `CACH-0051`.
 
 ## Memoria
 
-No aplica por ahora.
+Actualizada en `.memory/projects/email-ops.md`.

--- a/docs/project/issues/CACH-B0020.md
+++ b/docs/project/issues/CACH-B0020.md
@@ -85,7 +85,7 @@ Cerrado en `RELEASE-0.1.0-beta.14`. Cachés usa `caches.es` como dominio de emai
 ## Desarrollo
 
 - Rama: `release/0.1.0-beta.14`
-- PR: pendiente
+- PR: #94
 - Estado actual: implementado, validado y listo para PR de release a `main`.
 
 ## Notas de progreso

--- a/docs/project/releases/RELEASE-0.1.0-beta.14.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.14.md
@@ -90,9 +90,9 @@ Dejar un email/remitente definitivo real de Cachés operativo para emails transa
 
 ## Checklist de estabilizacion
 
-- [ ] DNS verificado
-- [ ] Brevo valida dominio/remitente
-- [ ] Edge Function usa remitente definitivo
+- [x] DNS verificado
+- [x] Brevo valida dominio/remitente
+- [x] Edge Function usa remitente definitivo
 - [ ] Supabase Auth SMTP usa remitente definitivo
 - [ ] Invitacion beta verificada
 - [ ] Confirmacion de cuenta verificada
@@ -131,7 +131,7 @@ Dejar un email/remitente definitivo real de Cachés operativo para emails transa
 
 ### Tecnico
 
-- Pendiente.
+- `caches.es` autenticado en Brevo y `send-beta-invite` desplegada con `no-reply@caches.es` como remitente y `contacto@caches.es` como reply-to.
 
 ## Resultado final
 

--- a/docs/project/releases/RELEASE-0.1.0-beta.14.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.14.md
@@ -17,7 +17,7 @@ release_phase: active
 release_current: true
 release_branch: release/0.1.0-beta.14
 release_tag: null
-release_pr: null
+release_pr: 'https://github.com/dignacioconde/culturApp/pull/94'
 ---
 # RELEASE-0.1.0-beta.14 — Email definitivo transaccional
 
@@ -101,7 +101,7 @@ Dejar un email/remitente definitivo real de Cachés operativo para emails transa
 
 ## Checklist de salida
 
-- [ ] PR `release/0.1.0-beta.14` -> `main` abierta si hay cambios versionados
+- [x] PR `release/0.1.0-beta.14` -> `main` abierta si hay cambios versionados
 - [ ] CI en verde si aplica
 - [ ] Revision aprobada
 - [ ] PR mergeada en `main` si aplica

--- a/docs/project/releases/RELEASE-0.1.0-beta.14.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.14.md
@@ -23,7 +23,7 @@ release_pr: null
 
 ## Estado
 
-Active
+Active, lista para PR `release/0.1.0-beta.14` -> `main`.
 
 ## Rama de release
 
@@ -57,7 +57,7 @@ Dejar un email/remitente definitivo real de Cachés operativo para emails transa
 
 | Issue | Titulo | Estado | Rama |
 |---|---|---|---|
-| [[../issues/CACH-B0020|CACH-B0020]] | Validar dominio de email transaccional y cambiar remitentes definitivos | In progress | `release/0.1.0-beta.14` |
+| [[../issues/CACH-B0020|CACH-B0020]] | Validar dominio de email transaccional y cambiar remitentes definitivos | Done | `release/0.1.0-beta.14` |
 
 ## Fuera de alcance
 
@@ -65,6 +65,7 @@ Dejar un email/remitente definitivo real de Cachés operativo para emails transa
 - Cambios de UX de proyecto-evento, cubiertos por `RELEASE-0.1.0-beta.12`.
 - Newsletter, CRM, automatizaciones y redisenos de plantillas.
 - Cambios de tooling de agentes o verificadores.
+- Dominio publico de app (`app.caches.es`) y configuracion multientorno, trazados en [[../issues/CACH-0051|CACH-0051]].
 
 ## Riesgos
 
@@ -82,21 +83,21 @@ Dejar un email/remitente definitivo real de Cachés operativo para emails transa
 
 ## Checklist de desarrollo
 
-- [ ] Todas las issues estan en progreso o cerradas
-- [ ] Commits preparados en rama release
-- [ ] No hay cambios sueltos fuera de release
-- [ ] No hay issues sin estado
-- [ ] No hay decisiones importantes sin documentar
+- [x] Todas las issues estan en progreso o cerradas
+- [x] Commits preparados en rama release
+- [x] No hay cambios sueltos fuera de release
+- [x] No hay issues sin estado
+- [x] No hay decisiones importantes sin documentar
 
 ## Checklist de estabilizacion
 
 - [x] DNS verificado
 - [x] Brevo valida dominio/remitente
 - [x] Edge Function usa remitente definitivo
-- [ ] Supabase Auth SMTP usa remitente definitivo
-- [ ] Invitacion beta verificada
-- [ ] Confirmacion de cuenta verificada
-- [ ] Documentacion actualizada
+- [x] Supabase Auth SMTP usa remitente definitivo
+- [x] Invitacion beta verificada
+- [x] Confirmacion de cuenta verificada
+- [x] Documentacion actualizada
 
 ## Checklist de salida
 
@@ -115,24 +116,27 @@ Dejar un email/remitente definitivo real de Cachés operativo para emails transa
 
 ### Aniadido
 
-- Pendiente.
+- Dominio de email definitivo `caches.es`.
+- Buzon real `contacto@caches.es` y alias transaccional `no-reply@caches.es`.
 
 ### Cambiado
 
-- Pendiente.
+- Invitaciones beta y confirmaciones de Supabase Auth pasan a usar `no-reply@caches.es` como remitente visible.
+- Los redirects de confirmacion de Supabase Auth usan `VITE_APP_URL` con fallback temporal a `https://culturapp-rho.vercel.app`.
 
 ### Corregido
 
-- Pendiente.
+- Evitado que registros hechos desde local generen confirmaciones Auth hacia `localhost`.
 
 ### Eliminado
 
-- Pendiente.
+- Remitente personal temporal como remitente operativo.
 
 ### Tecnico
 
 - `caches.es` autenticado en Brevo y `send-beta-invite` desplegada con `no-reply@caches.es` como remitente y `contacto@caches.es` como reply-to.
+- `CACH-0051` captura el trabajo pendiente de dominio publico de app y multientorno.
 
 ## Resultado final
 
-Release activa. Rama `release/0.1.0-beta.14` creada y alineada con `main` al inicio operativo de beta 14.
+Release activa y lista para PR a `main`. Email transaccional definitivo verificado; dominio publico de app y multientorno quedan fuera de scope en `CACH-0051`.

--- a/docs/project/releases/RELEASE-0.1.0-beta.14.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.14.md
@@ -5,7 +5,7 @@ id: RELEASE-0.1.0-beta.14
 title: Email definitivo transaccional
 lifecycle: active
 created: '2026-05-08'
-updated: '2026-05-08'
+updated: '2026-05-09'
 aliases:
   - RELEASE-0.1.0-beta.14
 tags:
@@ -75,7 +75,7 @@ Dejar un email/remitente definitivo real de Cachés operativo para emails transa
 ## Checklist de entrada
 
 - [x] Release creada
-- [ ] Rama de release creada
+- [x] Rama de release creada
 - [x] Issues asociadas
 - [x] Alcance definido
 - [x] Criterios de validacion definidos
@@ -135,4 +135,4 @@ Dejar un email/remitente definitivo real de Cachés operativo para emails transa
 
 ## Resultado final
 
-Release activa.
+Release activa. Rama `release/0.1.0-beta.14` creada y alineada con `main` al inicio operativo de beta 14.

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react'
 import { supabase } from '../supabaseClient'
 
+const authRedirectOrigin = (import.meta.env.VITE_APP_URL ?? 'https://culturapp-rho.vercel.app').replace(/\/$/, '')
+
 export function useAuth() {
   const [user, setUser] = useState(null)
   const [loading, setLoading] = useState(true)
@@ -39,7 +41,7 @@ export function useAuth() {
       password,
       options: {
         data: metadata,
-        emailRedirectTo: `${window.location.origin}/login?confirmed=1`,
+        emailRedirectTo: `${authRedirectOrigin}/login?confirmed=1`,
       },
     })
     return { data, error }


### PR DESCRIPTION
## Summary

Cierra `RELEASE-0.1.0-beta.14` / `CACH-B0020`: Cachés pasa a usar `caches.es` como dominio de email definitivo, `no-reply@caches.es` como remitente transaccional y `contacto@caches.es` como reply-to/buzón humano.

Incluye además un ajuste pequeño para que las confirmaciones de Supabase Auth usen `VITE_APP_URL` con fallback a `https://culturapp-rho.vercel.app`, evitando redirects a `localhost` en registros hechos desde local.

## Product Brain

- Issue cerrada: `CACH-B0020`
- Release: `RELEASE-0.1.0-beta.14`
- Pendiente fuera de scope: `CACH-0051` para `app.caches.es` y estrategia multientorno

## Validation

- `npm run lint`: OK
- `npm run test`: OK, 24 files / 130 tests
- `npm run build`: OK, con warning existente de chunk grande
- `npm run pb:guard`: OK
- `npm run pb:close-check -- CACH-B0020`: OK
- `npm run release:sync-check`: OK
- `npm run verify:pr -- --base origin/main`: OK
- Supabase MCP/CLI: `send-beta-invite` activa en version 10
- Smoke manual: invitacion beta recibida y confirmacion Supabase Auth recibida

## Memory

Actualizada `.memory/projects/email-ops.md` con dominio/remitente definitivo y cautela de Auth SMTP.