### PR TITLE
docs(release): mark beta 15 released

### DIFF
--- a/docs/project/DIGEST.md
+++ b/docs/project/DIGEST.md
@@ -23,7 +23,7 @@ Resumen determinista generado desde Product Brain v2.
 
 ## Estado operacional
 
-- **Release activa:** RELEASE-0.1.0-beta.15 — Dominio publico de app
+- **Release activa:** No hay release activa.
 - **Últimos cortes:** `RELEASE-0.1.0-beta.10` — emails transaccionales beta con Brevo. Ver RELEASE-0.1.0-beta.10.
 
 `RELEASE-0.1.0-beta.12` — pulido proyecto-evento y borrados seguros. Ver RELEASE-0.1.0-beta.12.
@@ -31,13 +31,15 @@ Resumen determinista generado desde Product Brain v2.
 `RELEASE-0.1.0-beta.13` — dashboard movil y estado Ahora. Ver RELEASE-0.1.0-beta.13.
 
 `RELEASE-0.1.0-beta.14` — email definitivo transaccional. Ver RELEASE-0.1.0-beta.14.
-- **Foco:** Beta 14 queda cerrada. Beta 15 se usa para cerrar el dominio publico de app y multientorno minimo antes de seguir con navegacion movil.
+
+`RELEASE-0.1.0-beta.15` — dominio publico de app. Ver RELEASE-0.1.0-beta.15.
+- **Foco:** Beta 15 queda cerrada con dominio publico de app. El siguiente avance debe coordinarse con el rediseño que se esta preparando en Lovable y, si encaja, retomar navegacion movil como slice separada.
 
 ## Prioridades del plan
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
-2. Cerrar beta 15 con dominio publico de app antes de retomar navegacion movil.
-3. Mantener navegacion movil como siguiente slice candidata, fuera de este corte.
+2. No mezclar rediseño Lovable con fixes pequenos salvo que desbloqueen beta o confianza.
+3. Mantener navegacion movil como siguiente slice candidata, fuera del corte de dominio.
 
 ## Tablero
 
@@ -106,4 +108,4 @@ _Sin entradas._
 
 ## Próxima acción
 
-Cerrar PR/tag de beta 15 y verificar produccion en `https://app.caches.es`.
+Elegir siguiente foco tras el rediseño Lovable: retomar CACH-0042 o abrir el siguiente corte beta con el primer slice visual validable.

--- a/docs/project/issues/CACH-0051.md
+++ b/docs/project/issues/CACH-0051.md
@@ -84,7 +84,7 @@ Cerrado en `RELEASE-0.1.0-beta.15`. El dominio publico canonico de la app queda 
 
 - Rama: `chore/CACH-0051-app-domain-multienv`
 - PR: https://github.com/dignacioconde/culturApp/pull/96
-- Estado actual: en PR de release.
+- Estado actual: cerrado en `RELEASE-0.1.0-beta.15`.
 
 ## Notas de progreso
 
@@ -97,6 +97,7 @@ Cerrado en `RELEASE-0.1.0-beta.15`. El dominio publico canonico de la app queda 
 - 2026-05-10: se actualiza el secret remoto `APP_URL=https://app.caches.es` de la Edge Function `send-beta-invite` en el proyecto Supabase `mkidexrkhjhrsjnjmugw`.
 - 2026-05-10: se actualiza Supabase Auth URL Configuration por Management API: `site_url=https://app.caches.es` y `uri_allow_list=https://app.caches.es/**,https://culturapp-rho.vercel.app/**,http://localhost:5173/**`.
 - 2026-05-10: se abre PR de release https://github.com/dignacioconde/culturApp/pull/96.
+- 2026-05-10: PR #96 mergeada, tag `v0.1.0-beta.15` creado y produccion verificada en `https://app.caches.es`.
 
 ## Cambios de alcance y decisiones
 
@@ -123,6 +124,8 @@ Parcial:
 - `npx supabase secrets list --project-ref mkidexrkhjhrsjnjmugw`: `APP_URL` presente con digest actualizado.
 - Supabase Management API `PATCH /v1/projects/mkidexrkhjhrsjnjmugw/config/auth`: `site_url` y `uri_allow_list` actualizados.
 - `npm run verify:pr -- --base origin/main --issue CACH-0051`: OK.
+- `gh run watch 25631744660 --interval 10`: OK en `main`.
+- `npm run smoke:postdeploy -- --url https://app.caches.es`: OK posterior a merge.
 - Smoke de invitacion/confirmacion real: pendiente de prueba manual posterior a merge si se quiere comprobar recepcion de email end-to-end. La configuracion remota de URLs queda aplicada.
 
 ## Memoria

--- a/docs/project/plans/CURRENT_PLAN.md
+++ b/docs/project/plans/CURRENT_PLAN.md
@@ -18,11 +18,11 @@ generated: false
 
 ## Foco actual
 
-Beta 14 queda cerrada. Beta 15 se usa para cerrar el dominio publico de app y multientorno minimo antes de seguir con navegacion movil.
+Beta 15 queda cerrada con dominio publico de app. El siguiente avance debe coordinarse con el rediseño que se esta preparando en Lovable y, si encaja, retomar navegacion movil como slice separada.
 
 ## Release activa
 
-Release activa: [[../releases/RELEASE-0.1.0-beta.15|RELEASE-0.1.0-beta.15]] — Dominio publico de app.
+No hay release activa.
 
 Últimos cortes:
 
@@ -46,8 +46,8 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 ## Prioridades
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
-2. Cerrar beta 15 con dominio publico de app antes de retomar navegacion movil.
-3. Mantener navegacion movil como siguiente slice candidata, fuera de este corte.
+2. No mezclar rediseño Lovable con fixes pequenos salvo que desbloqueen beta o confianza.
+3. Mantener navegacion movil como siguiente slice candidata, fuera del corte de dominio.
 
 ## Plan operativo
 
@@ -60,7 +60,7 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 
 ## Próximo checkpoint
 
-Cerrar PR/tag de beta 15 y verificar produccion en `https://app.caches.es`.
+Elegir siguiente foco tras el rediseño Lovable: retomar [[../issues/CACH-0042|CACH-0042]] o abrir el siguiente corte beta con el primer slice visual validable.
 
 ## Siguiente release candidata
 

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -13,17 +13,17 @@ tags:
   - release
   - current
 generated: false
-release_current: true
+release_current: false
 ---
 # Current Release
 
 ## Release activa
 
-[[RELEASE-0.1.0-beta.15|RELEASE-0.1.0-beta.15]] — Dominio publico de app.
+No hay release activa.
 
 ## Rama activa
 
-`release/0.1.0-beta.15`
+No aplica.
 
 ## Últimos cortes
 
@@ -35,18 +35,20 @@ release_current: true
 
 `RELEASE-0.1.0-beta.14` — email definitivo transaccional. Ver [[RELEASE-0.1.0-beta.14]].
 
+`RELEASE-0.1.0-beta.15` — dominio publico de app. Ver [[RELEASE-0.1.0-beta.15]].
+
 ## Scope actual
 
-Beta 15 prepara el cierre de [[../issues/CACH-0051|CACH-0051]]: dominio publico canonico `https://app.caches.es`, variables de entorno, Supabase Auth redirects y Edge Function `send-beta-invite`.
+Beta 15 queda cerrada. El dominio publico canonico de la app es `https://app.caches.es`; Vercel, `VITE_APP_URL`, Supabase Auth redirects y Edge Function `send-beta-invite` quedaron alineados con ese dominio.
 
-Issues incluidas:
+Issues cerradas:
 
 - [[../issues/CACH-0051|CACH-0051]] — Dominio publico de app y estrategia multientorno.
 
 ## Regla de trabajo para esta release
 
-No anadir navegacion movil, redisenos Lovable ni cambios de schema. Beta 15 se limita al dominio publico de app y configuracion multientorno minima.
+No iniciar trabajo nuevo desde una release activa hasta activar explicitamente el siguiente corte. La siguiente candidata puede retomar [[../issues/CACH-0042|CACH-0042]] o ajustarse al rediseño Lovable.
 
 ## Como cerrar esta release
 
-Abrir PR `release/0.1.0-beta.15` -> `main`, esperar CI verde, mergear, crear tag `v0.1.0-beta.15` desde `main` y verificar produccion en `https://app.caches.es`.
+Cerrada mediante PR #96, tag `v0.1.0-beta.15` y smoke de produccion sobre `https://app.caches.es`.

--- a/docs/project/releases/RELEASE-0.1.0-beta.15.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.15.md
@@ -13,17 +13,17 @@ tags:
   - release
   - beta
 generated: false
-release_phase: active
-release_current: true
+release_phase: released
+release_current: false
 release_branch: release/0.1.0-beta.15
 release_tag: v0.1.0-beta.15
-release_pr: https://github.com/dignacioconde/culturApp/pull/96
+release_pr: 'https://github.com/dignacioconde/culturApp/pull/96'
 ---
 # RELEASE-0.1.0-beta.15 — Dominio publico de app
 
 ## Estado
 
-PR abierta: https://github.com/dignacioconde/culturApp/pull/96.
+Released.
 
 ## Rama de release
 
@@ -108,14 +108,14 @@ Dejar `https://app.caches.es` como dominio publico canonico de Cachés para app,
 ## Checklist de salida
 
 - [x] PR `release/0.1.0-beta.15` -> `main` abierta
-- [ ] CI en verde
-- [ ] Revision aprobada
-- [ ] PR mergeada en `main`
-- [ ] Tag creado desde `main`
-- [ ] Produccion verificada
+- [x] CI en verde
+- [x] Revision aprobada
+- [x] PR mergeada en `main`
+- [x] Tag creado desde `main`
+- [x] Produccion verificada
 - [x] Release notes actualizadas
 - [x] Issues marcadas como `done`
-- [x] Current Release actualizado para preparar el corte
+- [x] Current Release actualizado
 - [x] Backlog actualizado
 
 ## Release notes
@@ -147,4 +147,4 @@ Dejar `https://app.caches.es` como dominio publico canonico de Cachés para app,
 
 ## Resultado final
 
-PR #96 abierta. Pendiente de CI, revision, merge, tag y smoke posterior a produccion.
+Release cerrada y mergeada en `main` mediante PR #96. Tag `v0.1.0-beta.15` creado desde `main`; produccion verificada en `https://app.caches.es` con smoke de rutas SPA. La prueba auth/CRUD del smoke queda saltada sin `SMOKE_EMAIL`/`SMOKE_PASSWORD`; la recepcion real de email puede repetirse como smoke manual si se quiere comprobar entrega end-to-end.


### PR DESCRIPTION
## Summary

Marca `RELEASE-0.1.0-beta.15` como released tras PR #96, tag `v0.1.0-beta.15`, CI de main y smoke de produccion en `https://app.caches.es`.

## Product Brain

- Release: `RELEASE-0.1.0-beta.15`
- Issue: `CACH-0051`
- Current release: queda sin release activa

## Validation

- `npm run pb:guard`
- `npm run pb:close-check -- CACH-0051`
- `git diff --check`

## Memory

Memoria: no aplica; ya estaba actualizada en `.memory/projects/routing-deploy.md` desde PR #96.