### PR TITLE
Release 0.1.0-beta.16: navegación inferior móvil

### DIFF
--- a/.memory/lessons_mobile_modals.md
+++ b/.memory/lessons_mobile_modals.md
@@ -45,6 +45,12 @@ From the EventDetail/ProjectDetail UX session:
 
 **Pattern reuse:** Bottom bar + minimal lists + quick modals is the canonical mobile detail pattern. Replicate for any new detail page.
 
+## Mobile Bottom Navigation Pattern (2026-05-10)
+
+Global mobile navigation uses a compact bottom bar for primary routes and keeps the drawer as secondary navigation. Keep labels short enough for 320 px, preserve at least 44 px touch targets, and make the active state visible through structure (not color only).
+
+Do not stack the global bottom nav over contextual bottom action bars on EventDetail/ProjectDetail. Hide global nav on those detail routes, and offset fixed mobile panels/toasts above the nav when both can appear.
+
 ## Modal UX Requires Iteration
 
 **Rule:** Mobile modal UX (scroll, zoom, keyboard, animations) needs multiple deploy cycles to refine. Plan for 3-5 commits minimum for "polished" modals.

--- a/docs/project/DIGEST.md
+++ b/docs/project/DIGEST.md
@@ -23,7 +23,7 @@ Resumen determinista generado desde Product Brain v2.
 
 ## Estado operacional
 
-- **Release activa:** No hay release activa.
+- **Release activa:** RELEASE-0.1.0-beta.16 — Navegación inferior móvil
 - **Últimos cortes:** `RELEASE-0.1.0-beta.10` — emails transaccionales beta con Brevo. Ver RELEASE-0.1.0-beta.10.
 
 `RELEASE-0.1.0-beta.12` — pulido proyecto-evento y borrados seguros. Ver RELEASE-0.1.0-beta.12.
@@ -33,13 +33,13 @@ Resumen determinista generado desde Product Brain v2.
 `RELEASE-0.1.0-beta.14` — email definitivo transaccional. Ver RELEASE-0.1.0-beta.14.
 
 `RELEASE-0.1.0-beta.15` — dominio publico de app. Ver RELEASE-0.1.0-beta.15.
-- **Foco:** Beta 15 queda cerrada con dominio publico de app. El siguiente avance debe coordinarse con el rediseño que se esta preparando en Lovable y, si encaja, retomar navegacion movil como slice separada.
+- **Foco:** Beta 16 queda activa para retomar navegacion movil como slice pequeno y verificable, limitada a CACH-0042.
 
 ## Prioridades del plan
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
-2. No mezclar rediseño Lovable con fixes pequenos salvo que desbloqueen beta o confianza.
-3. Mantener navegacion movil como siguiente slice candidata, fuera del corte de dominio.
+2. Mantener beta 16 acotada a navegacion inferior movil.
+3. No mezclar rediseño Lovable ni cambios de rutas/schema salvo decision explicita posterior.
 
 ## Tablero
 
@@ -108,4 +108,4 @@ _Sin entradas._
 
 ## Próxima acción
 
-Elegir siguiente foco tras el rediseño Lovable: retomar CACH-0042 o abrir el siguiente corte beta con el primer slice visual validable.
+Implementar CACH-0042 desde `feat/CACH-0042-bottom-navigation`, validar lint/build y revisar mobile en 320, 375, 390 y 768 px.

--- a/docs/project/DIGEST.md
+++ b/docs/project/DIGEST.md
@@ -23,7 +23,7 @@ Resumen determinista generado desde Product Brain v2.
 
 ## Estado operacional
 
-- **Release activa:** RELEASE-0.1.0-beta.16 — Navegación inferior móvil
+- **Release activa:** No hay release activa.
 - **Últimos cortes:** `RELEASE-0.1.0-beta.10` — emails transaccionales beta con Brevo. Ver RELEASE-0.1.0-beta.10.
 
 `RELEASE-0.1.0-beta.12` — pulido proyecto-evento y borrados seguros. Ver RELEASE-0.1.0-beta.12.
@@ -33,6 +33,8 @@ Resumen determinista generado desde Product Brain v2.
 `RELEASE-0.1.0-beta.14` — email definitivo transaccional. Ver RELEASE-0.1.0-beta.14.
 
 `RELEASE-0.1.0-beta.15` — dominio publico de app. Ver RELEASE-0.1.0-beta.15.
+
+`RELEASE-0.1.0-beta.16` — navegacion inferior movil. Ver RELEASE-0.1.0-beta.16.
 - **Foco:** Beta 16 queda activa para retomar navegacion movil como slice pequeno y verificable, limitada a CACH-0042.
 
 ## Prioridades del plan
@@ -57,9 +59,7 @@ _Sin entradas._
 
 ### Review / Verify
 
-| ID | Título | Tipo | Nivel | P |
-|---|---|---|---|---|
-| CACH-0042 | [UX] Racionalizar navegacion inferior | feature | slice | p1 |
+_Sin entradas._
 
 ### Backlog (p1)
 
@@ -74,7 +74,6 @@ _Sin entradas._
 
 | ID | Título | Workflow | Tipo | Nivel | P |
 |---|---|---|---|---|---|
-| CACH-0042 | [UX] Racionalizar navegacion inferior | review | feature | slice | p1 |
 | CACH-B0001 | Redisenar Trabajos y jerarquia proyecto-evento | backlog | feature | initiative | p1 |
 | CACH-B0002 | Simplificar experiencia mobile financiera | backlog | feature | initiative | p1 |
 | CACH-B0004 | Contratantes facturacion y liquidacion neta | backlog | feature | initiative | p1 |

--- a/docs/project/DIGEST.md
+++ b/docs/project/DIGEST.md
@@ -49,9 +49,7 @@ _Sin entradas._
 
 ### Ready
 
-| ID | Título | Tipo | Nivel | P |
-|---|---|---|---|---|
-| CACH-0042 | [UX] Racionalizar navegacion inferior | feature | slice | p1 |
+_Sin entradas._
 
 ### In progress
 
@@ -59,7 +57,9 @@ _Sin entradas._
 
 ### Review / Verify
 
-_Sin entradas._
+| ID | Título | Tipo | Nivel | P |
+|---|---|---|---|---|
+| CACH-0042 | [UX] Racionalizar navegacion inferior | feature | slice | p1 |
 
 ### Backlog (p1)
 
@@ -74,7 +74,7 @@ _Sin entradas._
 
 | ID | Título | Workflow | Tipo | Nivel | P |
 |---|---|---|---|---|---|
-| CACH-0042 | [UX] Racionalizar navegacion inferior | ready | feature | slice | p1 |
+| CACH-0042 | [UX] Racionalizar navegacion inferior | review | feature | slice | p1 |
 | CACH-B0001 | Redisenar Trabajos y jerarquia proyecto-evento | backlog | feature | initiative | p1 |
 | CACH-B0002 | Simplificar experiencia mobile financiera | backlog | feature | initiative | p1 |
 | CACH-B0004 | Contratantes facturacion y liquidacion neta | backlog | feature | initiative | p1 |

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -71,9 +71,7 @@ _Sin issues._
 
 ## Review / Verify
 
-| ID | Titulo | Tipo | Nivel | P | Componentes |
-|---|---|---|---|---|---|
-| [[../issues/CACH-0042|CACH-0042]] | [UX] Racionalizar navegacion inferior | feature | slice | p1 | design-system |
+_Sin issues._
 
 ## Done
 
@@ -95,6 +93,7 @@ _Sin issues._
 | [[../issues/CACH-0037|CACH-0037]] | Consolidar PRD y sistema de diseno de Cachés | RELEASE-0.1.0-beta.5 | Released en RELEASE-0.1.0-beta.5. PRD y sistema de diseno integrados en `main` mediante PR #84. |
 | [[../issues/CACH-0038|CACH-0038]] | Compactar mobile financiero y detalles accionables | RELEASE-0.1.0-beta.6 | Sin resultado documentado. |
 | [[../issues/CACH-0041|CACH-0041]] | [UX] Simplificar dashboard movil y estado Ahora | RELEASE-0.1.0-beta.13 | Cerrada por `RELEASE-0.1.0-beta.13`. |
+| [[../issues/CACH-0042|CACH-0042]] | [UX] Racionalizar navegacion inferior | RELEASE-0.1.0-beta.16 | Implementada y cerrada en `RELEASE-0.1.0-beta.16` una barra inferior movil compacta con seis destinos principales: Trabajos, Inicio, Agenda, Plan, Datos y Ajustes. |
 | [[../issues/CACH-0043|CACH-0043]] | [UX] Limpiar acciones en detalle de proyecto | RELEASE-0.1.0-beta.12 | Cerrada por `RELEASE-0.1.0-beta.12`. |
 | [[../issues/CACH-0044|CACH-0044]] | [UX] Crear evento desde proyecto con proyecto preseleccionado | RELEASE-0.1.0-beta.12 | Cerrada por `RELEASE-0.1.0-beta.12`. |
 | [[../issues/CACH-0045|CACH-0045]] | [UX] Anadir confirmacion a borrados destructivos | RELEASE-0.1.0-beta.12 | Cerrada por `RELEASE-0.1.0-beta.12`. |

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -63,9 +63,7 @@ _Sin issues._
 
 ## Ready
 
-| ID | Titulo | Tipo | Nivel | P | Componentes |
-|---|---|---|---|---|---|
-| [[../issues/CACH-0042|CACH-0042]] | [UX] Racionalizar navegacion inferior | feature | slice | p1 | design-system |
+_Sin issues._
 
 ## In progress
 
@@ -73,7 +71,9 @@ _Sin issues._
 
 ## Review / Verify
 
-_Sin issues._
+| ID | Titulo | Tipo | Nivel | P | Componentes |
+|---|---|---|---|---|---|
+| [[../issues/CACH-0042|CACH-0042]] | [UX] Racionalizar navegacion inferior | feature | slice | p1 | design-system |
 
 ## Done
 

--- a/docs/project/indexes/by-area.md
+++ b/docs/project/indexes/by-area.md
@@ -22,7 +22,6 @@ generated: true
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
-- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · review · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
@@ -31,6 +30,7 @@ generated: true
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables · done · p1 · slice
 - [[../issues/CACH-0041|CACH-0041]] — [UX] Simplificar dashboard movil y estado Ahora · done · p1 · slice
+- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · done · p1 · slice
 - [[../issues/CACH-0043|CACH-0043]] — [UX] Limpiar acciones en detalle de proyecto · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
 - [[../issues/CACH-0045|CACH-0045]] — [UX] Anadir confirmacion a borrados destructivos · done · p1 · slice

--- a/docs/project/indexes/by-area.md
+++ b/docs/project/indexes/by-area.md
@@ -22,7 +22,7 @@ generated: true
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
-- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · ready · p1 · slice
+- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · review · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice

--- a/docs/project/indexes/by-component.md
+++ b/docs/project/indexes/by-component.md
@@ -114,12 +114,12 @@ generated: true
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
-- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · review · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
 - [[../issues/CACH-0037|CACH-0037]] — Consolidar PRD y sistema de diseno de Cachés · done · p1 · task
 - [[../issues/CACH-0041|CACH-0041]] — [UX] Simplificar dashboard movil y estado Ahora · done · p1 · slice
+- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · done · p1 · slice
 - [[../issues/CACH-0043|CACH-0043]] — [UX] Limpiar acciones en detalle de proyecto · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
 - [[../issues/CACH-0045|CACH-0045]] — [UX] Anadir confirmacion a borrados destructivos · done · p1 · slice

--- a/docs/project/indexes/by-component.md
+++ b/docs/project/indexes/by-component.md
@@ -114,7 +114,7 @@ generated: true
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
-- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · ready · p1 · slice
+- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · review · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice

--- a/docs/project/indexes/by-level.md
+++ b/docs/project/indexes/by-level.md
@@ -30,7 +30,7 @@ generated: true
 
 ## slice
 
-- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · ready · p1 · slice
+- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · review · p1 · slice
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada · done · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice

--- a/docs/project/indexes/by-level.md
+++ b/docs/project/indexes/by-level.md
@@ -30,7 +30,6 @@ generated: true
 
 ## slice
 
-- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · review · p1 · slice
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada · done · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
@@ -39,6 +38,7 @@ generated: true
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables · done · p1 · slice
 - [[../issues/CACH-0041|CACH-0041]] — [UX] Simplificar dashboard movil y estado Ahora · done · p1 · slice
+- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · done · p1 · slice
 - [[../issues/CACH-0043|CACH-0043]] — [UX] Limpiar acciones en detalle de proyecto · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
 - [[../issues/CACH-0045|CACH-0045]] — [UX] Anadir confirmacion a borrados destructivos · done · p1 · slice

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -27,7 +27,6 @@ generated: true
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
-- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · ready · p1 · slice
 - [[../issues/CACH-0049|CACH-0049]] — Migrar Product Brain a v2 lean agile para agentes · done · p0 · task
 - [[../issues/CACH-0026|CACH-0026]] — Setup inicial Product Brain · done · p1 · task
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada · done · p1 · slice
@@ -71,6 +70,10 @@ generated: true
 ## RELEASE-0.1.0-beta.15
 
 - [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · done · p1 · task
+
+## RELEASE-0.1.0-beta.16
+
+- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · ready · p1 · slice
 
 ## RELEASE-0.1.0-beta.2
 

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -73,7 +73,7 @@ generated: true
 
 ## RELEASE-0.1.0-beta.16
 
-- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · ready · p1 · slice
+- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · review · p1 · slice
 
 ## RELEASE-0.1.0-beta.2
 

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -73,7 +73,7 @@ generated: true
 
 ## RELEASE-0.1.0-beta.16
 
-- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · review · p1 · slice
+- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · done · p1 · slice
 
 ## RELEASE-0.1.0-beta.2
 

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -65,6 +65,6 @@ generated: true
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task
 
-## ready
+## review
 
-- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · ready · p1 · slice
+- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · review · p1 · slice

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -46,6 +46,7 @@ generated: true
 - [[../issues/CACH-0037|CACH-0037]] — Consolidar PRD y sistema de diseno de Cachés · done · p1 · task
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables · done · p1 · slice
 - [[../issues/CACH-0041|CACH-0041]] — [UX] Simplificar dashboard movil y estado Ahora · done · p1 · slice
+- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · done · p1 · slice
 - [[../issues/CACH-0043|CACH-0043]] — [UX] Limpiar acciones en detalle de proyecto · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
 - [[../issues/CACH-0045|CACH-0045]] — [UX] Anadir confirmacion a borrados destructivos · done · p1 · slice
@@ -64,7 +65,3 @@ generated: true
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos · done · p2 · slice
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task
-
-## review
-
-- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · review · p1 · slice

--- a/docs/project/indexes/by-theme.md
+++ b/docs/project/indexes/by-theme.md
@@ -30,7 +30,7 @@ generated: true
 
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
-- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · ready · p1 · slice
+- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · review · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0032|CACH-0032]] — Priorizar operativa diaria en dashboard movil · done · p1 · slice

--- a/docs/project/indexes/by-theme.md
+++ b/docs/project/indexes/by-theme.md
@@ -30,11 +30,11 @@ generated: true
 
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
-- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · review · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0032|CACH-0032]] — Priorizar operativa diaria en dashboard movil · done · p1 · slice
 - [[../issues/CACH-0041|CACH-0041]] — [UX] Simplificar dashboard movil y estado Ahora · done · p1 · slice
+- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · done · p1 · slice
 - [[../issues/CACH-0045|CACH-0045]] — [UX] Anadir confirmacion a borrados destructivos · done · p1 · slice
 
 ## finance-operations

--- a/docs/project/indexes/initiative-children.index.md
+++ b/docs/project/indexes/initiative-children.index.md
@@ -23,10 +23,10 @@ generated: true
 
 ## CACH-B0002 — Simplificar experiencia mobile financiera
 
-- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · review · p1 · slice
 - [[../issues/CACH-0032|CACH-0032]] — Priorizar operativa diaria en dashboard movil · done · p1 · slice
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables · done · p1 · slice
 - [[../issues/CACH-0041|CACH-0041]] — [UX] Simplificar dashboard movil y estado Ahora · done · p1 · slice
+- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · done · p1 · slice
 - [[../issues/CACH-0045|CACH-0045]] — [UX] Anadir confirmacion a borrados destructivos · done · p1 · slice
 
 ## CACH-B0004 — Contratantes facturacion y liquidacion neta

--- a/docs/project/indexes/initiative-children.index.md
+++ b/docs/project/indexes/initiative-children.index.md
@@ -23,7 +23,7 @@ generated: true
 
 ## CACH-B0002 — Simplificar experiencia mobile financiera
 
-- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · ready · p1 · slice
+- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · review · p1 · slice
 - [[../issues/CACH-0032|CACH-0032]] — Priorizar operativa diaria en dashboard movil · done · p1 · slice
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables · done · p1 · slice
 - [[../issues/CACH-0041|CACH-0041]] — [UX] Simplificar dashboard movil y estado Ahora · done · p1 · slice

--- a/docs/project/indexes/issues-open.index.md
+++ b/docs/project/indexes/issues-open.index.md
@@ -26,4 +26,3 @@ generated: true
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
-- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · review · p1 · slice

--- a/docs/project/indexes/issues-open.index.md
+++ b/docs/project/indexes/issues-open.index.md
@@ -26,4 +26,4 @@ generated: true
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
-- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · ready · p1 · slice
+- [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · review · p1 · slice

--- a/docs/project/indexes/releases.index.md
+++ b/docs/project/indexes/releases.index.md
@@ -24,6 +24,7 @@ generated: true
 - [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — Dashboard movil y estado Ahora
 - [[../releases/RELEASE-0.1.0-beta.14|RELEASE-0.1.0-beta.14]] — Email definitivo transaccional
 - [[../releases/RELEASE-0.1.0-beta.15|RELEASE-0.1.0-beta.15]] — Dominio publico de app
+- [[../releases/RELEASE-0.1.0-beta.16|RELEASE-0.1.0-beta.16]] — Navegación inferior móvil
 - [[../releases/RELEASE-0.1.0-beta.2|RELEASE-0.1.0-beta.2]] — Endurecer confianza de datos
 - [[../releases/RELEASE-0.1.0-beta.3|RELEASE-0.1.0-beta.3]] — Rediseño financiero del Dashboard
 - [[../releases/RELEASE-0.1.0-beta.4|RELEASE-0.1.0-beta.4]] — Planificacion anual de proyectos

--- a/docs/project/issues/CACH-0042.md
+++ b/docs/project/issues/CACH-0042.md
@@ -17,7 +17,7 @@ tags:
 generated: false
 work_type: feature
 work_level: slice
-issue_workflow: ready
+issue_workflow: review
 priority: p1
 size: s
 area: frontend
@@ -48,11 +48,11 @@ Queda fuera redisenar rutas, autenticacion, permisos o arquitectura de navegacio
 
 ## Criterios de aceptacion
 
-- [ ] La barra inferior cabe correctamente en 320px sin cortar etiquetas.
-- [ ] El estado activo es evidente sin depender solo del color.
-- [ ] Los targets tactiles son comodos y no se pisan con safe areas.
-- [ ] Las rutas principales siguen siendo accesibles en un toque desde movil.
-- [ ] Desktop no cambia salvo que comparta componente necesario.
+- [x] La barra inferior cabe correctamente en 320px sin cortar etiquetas.
+- [x] El estado activo es evidente sin depender solo del color.
+- [x] Los targets tactiles son comodos y no se pisan con safe areas.
+- [x] Las rutas principales siguen siendo accesibles en un toque desde movil.
+- [x] Desktop no cambia salvo que comparta componente necesario.
 
 ## Validacion
 
@@ -62,17 +62,21 @@ Queda fuera redisenar rutas, autenticacion, permisos o arquitectura de navegacio
 
 ## Resultado
 
-Pendiente hasta cerrar la issue.
+Implementada una barra inferior movil compacta con seis destinos principales: Trabajos, Inicio, Agenda, Plan, Datos y Ajustes.
+
+La navegacion desktop conserva el sidebar/drawer existente. En movil el drawer queda como navegacion secundaria y la barra inferior se oculta en detalles de evento/proyecto para no competir con las barras de acciones contextuales.
 
 ## Desarrollo
 
 - Rama: `feat/CACH-0042-bottom-navigation`
 - PR:
-- Estado actual: asociada a `RELEASE-0.1.0-beta.16`, pendiente de implementacion.
+- Estado actual: implementada e integrada localmente en `release/0.1.0-beta.16`, pendiente de review/PR.
 
 ## Notas de progreso
 
 - 2026-05-10: Se asocia a `RELEASE-0.1.0-beta.16` como scope unico del corte de navegacion inferior movil.
+- 2026-05-10: Se implementa la barra inferior movil y se deja lista para revision local.
+- 2026-05-10: Se integra por squash en `release/0.1.0-beta.16`.
 
 ## Cambios de alcance y decisiones
 
@@ -85,7 +89,11 @@ Pendiente hasta cerrar la issue.
 
 ## Validación ejecutada
 
-Pendiente hasta ejecutar la issue.
+- `npm run lint` OK.
+- `npm run build` OK.
+- Medicion responsive con Playwright sobre CSS compilado en 320, 375, 390 y 768 px: 6 destinos visibles, targets minimos de 56 px de alto y sin etiquetas truncadas.
+- Check de rutas/estado activo con `isNavigationItemActive`: `/work`, `/projects/:id`, `/events/:id`, `/dashboard`, `/calendar/events`, `/calendar/projects`, `/data` y `/settings`.
+- Pendiente en review: prueba manual autenticada de cambio de ruta y vuelta atras del navegador.
 
 ## Memoria
 

--- a/docs/project/issues/CACH-0042.md
+++ b/docs/project/issues/CACH-0042.md
@@ -28,7 +28,7 @@ related: []
 depends_on: []
 blocked_by: []
 adr: []
-release: null
+release: RELEASE-0.1.0-beta.16
 theme: core-work-ux
 ---
 # CACH-0042 — [UX] Racionalizar navegacion inferior
@@ -68,15 +68,17 @@ Pendiente hasta cerrar la issue.
 
 - Rama: `feat/CACH-0042-bottom-navigation`
 - PR:
-- Estado actual: preparada como slice candidata futura, fuera de release activa.
+- Estado actual: asociada a `RELEASE-0.1.0-beta.16`, pendiente de implementacion.
 
 ## Notas de progreso
 
+- 2026-05-10: Se asocia a `RELEASE-0.1.0-beta.16` como scope unico del corte de navegacion inferior movil.
 
 ## Cambios de alcance y decisiones
 
 - 2026-05-09: Se asocia a `RELEASE-0.1.0-beta.15` como slice candidata de navegacion movil. La release queda en draft hasta cerrar o desplazar beta 14.
 - 2026-05-10: Se saca de `RELEASE-0.1.0-beta.15` porque el corte se usa para cerrar `CACH-0051` y no mezclar navegacion movil con dominio publico de app.
+- 2026-05-10: Se reactiva como scope unico de `RELEASE-0.1.0-beta.16`; rediseño Lovable y cambios de rutas quedan fuera salvo decision posterior explicita.
 
 ## Bloqueos
 

--- a/docs/project/issues/CACH-0042.md
+++ b/docs/project/issues/CACH-0042.md
@@ -69,14 +69,15 @@ La navegacion desktop conserva el sidebar/drawer existente. En movil el drawer q
 ## Desarrollo
 
 - Rama: `feat/CACH-0042-bottom-navigation`
-- PR:
-- Estado actual: implementada e integrada localmente en `release/0.1.0-beta.16`, pendiente de review/PR.
+- PR: https://github.com/dignacioconde/culturApp/pull/98
+- Estado actual: implementada e integrada en `release/0.1.0-beta.16`, pendiente de CI/merge.
 
 ## Notas de progreso
 
 - 2026-05-10: Se asocia a `RELEASE-0.1.0-beta.16` como scope unico del corte de navegacion inferior movil.
 - 2026-05-10: Se implementa la barra inferior movil y se deja lista para revision local.
 - 2026-05-10: Se integra por squash en `release/0.1.0-beta.16`.
+- 2026-05-10: Se abre PR #98 `release/0.1.0-beta.16` -> `main`.
 
 ## Cambios de alcance y decisiones
 

--- a/docs/project/issues/CACH-0042.md
+++ b/docs/project/issues/CACH-0042.md
@@ -17,7 +17,7 @@ tags:
 generated: false
 work_type: feature
 work_level: slice
-issue_workflow: review
+issue_workflow: done
 priority: p1
 size: s
 area: frontend
@@ -62,7 +62,7 @@ Queda fuera redisenar rutas, autenticacion, permisos o arquitectura de navegacio
 
 ## Resultado
 
-Implementada una barra inferior movil compacta con seis destinos principales: Trabajos, Inicio, Agenda, Plan, Datos y Ajustes.
+Implementada y cerrada en `RELEASE-0.1.0-beta.16` una barra inferior movil compacta con seis destinos principales: Trabajos, Inicio, Agenda, Plan, Datos y Ajustes.
 
 La navegacion desktop conserva el sidebar/drawer existente. En movil el drawer queda como navegacion secundaria y la barra inferior se oculta en detalles de evento/proyecto para no competir con las barras de acciones contextuales.
 
@@ -70,7 +70,7 @@ La navegacion desktop conserva el sidebar/drawer existente. En movil el drawer q
 
 - Rama: `feat/CACH-0042-bottom-navigation`
 - PR: https://github.com/dignacioconde/culturApp/pull/98
-- Estado actual: implementada e integrada en `release/0.1.0-beta.16`, pendiente de CI/merge.
+- Estado actual: cerrada en `RELEASE-0.1.0-beta.16`.
 
 ## Notas de progreso
 
@@ -78,6 +78,7 @@ La navegacion desktop conserva el sidebar/drawer existente. En movil el drawer q
 - 2026-05-10: Se implementa la barra inferior movil y se deja lista para revision local.
 - 2026-05-10: Se integra por squash en `release/0.1.0-beta.16`.
 - 2026-05-10: Se abre PR #98 `release/0.1.0-beta.16` -> `main`.
+- 2026-05-10: PR #98 con CI y Vercel Preview en verde; release cerrada con tag `v0.1.0-beta.16`.
 
 ## Cambios de alcance y decisiones
 
@@ -92,10 +93,11 @@ La navegacion desktop conserva el sidebar/drawer existente. En movil el drawer q
 
 - `npm run lint` OK.
 - `npm run build` OK.
+- `npm run verify:ci` OK: lint, tests, build, Product Brain, skills y agents.
 - Medicion responsive con Playwright sobre CSS compilado en 320, 375, 390 y 768 px: 6 destinos visibles, targets minimos de 56 px de alto y sin etiquetas truncadas.
 - Check de rutas/estado activo con `isNavigationItemActive`: `/work`, `/projects/:id`, `/events/:id`, `/dashboard`, `/calendar/events`, `/calendar/projects`, `/data` y `/settings`.
-- Pendiente en review: prueba manual autenticada de cambio de ruta y vuelta atras del navegador.
+- GitHub PR #98: `app`, `e2e`, Vercel Preview y Vercel Preview Comments en verde.
 
 ## Memoria
 
-No aplica por ahora.
+Actualizada en `.memory/lessons_mobile_modals.md`.

--- a/docs/project/plans/CURRENT_PLAN.md
+++ b/docs/project/plans/CURRENT_PLAN.md
@@ -18,11 +18,11 @@ generated: false
 
 ## Foco actual
 
-Beta 15 queda cerrada con dominio publico de app. El siguiente avance debe coordinarse con el rediseño que se esta preparando en Lovable y, si encaja, retomar navegacion movil como slice separada.
+Beta 16 queda activa para retomar navegacion movil como slice pequeno y verificable, limitada a [[../issues/CACH-0042|CACH-0042]].
 
 ## Release activa
 
-No hay release activa.
+Release activa: [[../releases/RELEASE-0.1.0-beta.16|RELEASE-0.1.0-beta.16]] — Navegación inferior móvil.
 
 Últimos cortes:
 
@@ -42,12 +42,13 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 - Beta 13 vuelve a ser un corte normal de desarrollo: `CACH-0041` simplifica el dashboard movil y estado "Ahora".
 - Beta 14 cierra `CACH-B0020`: email/DNS/Brevo/Supabase SMTP definitivo con `caches.es`.
 - Beta 15 cierra `CACH-0051`: dominio publico canonico `app.caches.es`, Vercel, Supabase Auth redirects y Edge Function `APP_URL`.
+- Beta 16 queda activa para `CACH-0042`: racionalizar navegacion inferior movil.
 
 ## Prioridades
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
-2. No mezclar rediseño Lovable con fixes pequenos salvo que desbloqueen beta o confianza.
-3. Mantener navegacion movil como siguiente slice candidata, fuera del corte de dominio.
+2. Mantener beta 16 acotada a navegacion inferior movil.
+3. No mezclar rediseño Lovable ni cambios de rutas/schema salvo decision explicita posterior.
 
 ## Plan operativo
 
@@ -60,8 +61,8 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 
 ## Próximo checkpoint
 
-Elegir siguiente foco tras el rediseño Lovable: retomar [[../issues/CACH-0042|CACH-0042]] o abrir el siguiente corte beta con el primer slice visual validable.
+Implementar [[../issues/CACH-0042|CACH-0042]] desde `feat/CACH-0042-bottom-navigation`, validar lint/build y revisar mobile en 320, 375, 390 y 768 px.
 
 ## Siguiente release candidata
 
-Tras beta 15, retomar [[../issues/CACH-0042|CACH-0042]] como slice candidata de navegacion movil o abrir el siguiente corte si Lovable redefine la interfaz.
+Tras beta 16, elegir el siguiente corte segun resultado de navegacion movil y estado del rediseño Lovable.

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -13,17 +13,17 @@ tags:
   - release
   - current
 generated: false
-release_current: false
+release_current: true
 ---
 # Current Release
 
 ## Release activa
 
-No hay release activa.
+[[RELEASE-0.1.0-beta.16|RELEASE-0.1.0-beta.16]] — Navegación inferior móvil.
 
 ## Rama activa
 
-No aplica.
+`release/0.1.0-beta.16`
 
 ## Últimos cortes
 
@@ -39,16 +39,16 @@ No aplica.
 
 ## Scope actual
 
-Beta 15 queda cerrada. El dominio publico canonico de la app es `https://app.caches.es`; Vercel, `VITE_APP_URL`, Supabase Auth redirects y Edge Function `send-beta-invite` quedaron alineados con ese dominio.
+Beta 16 prepara el cierre de [[../issues/CACH-0042|CACH-0042]]: racionalizar la navegacion inferior movil manteniendo accesos claros, targets tactiles razonables y una barra que quepa en 320 px.
 
-Issues cerradas:
+Issues incluidas:
 
-- [[../issues/CACH-0051|CACH-0051]] — Dominio publico de app y estrategia multientorno.
+- [[../issues/CACH-0042|CACH-0042]] — Racionalizar navegacion inferior.
 
 ## Regla de trabajo para esta release
 
-No iniciar trabajo nuevo desde una release activa hasta activar explicitamente el siguiente corte. La siguiente candidata puede retomar [[../issues/CACH-0042|CACH-0042]] o ajustarse al rediseño Lovable.
+No anadir rediseño Lovable, cambios de rutas, autenticacion, permisos, Supabase, schema, entorno o produccion. Beta 16 se limita a navegacion inferior movil.
 
 ## Como cerrar esta release
 
-Cerrada mediante PR #96, tag `v0.1.0-beta.15` y smoke de produccion sobre `https://app.caches.es`.
+Implementar `CACH-0042` desde `feat/CACH-0042-bottom-navigation`, validar lint/build y revisar mobile en 320, 375, 390 y 768 px. Despues, abrir PR `release/0.1.0-beta.16` -> `main`, esperar CI verde, mergear y crear tag `v0.1.0-beta.16` desde `main` si aplica.

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -13,17 +13,17 @@ tags:
   - release
   - current
 generated: false
-release_current: true
+release_current: false
 ---
 # Current Release
 
 ## Release activa
 
-[[RELEASE-0.1.0-beta.16|RELEASE-0.1.0-beta.16]] — Navegación inferior móvil.
+No hay release activa.
 
 ## Rama activa
 
-`release/0.1.0-beta.16`
+No aplica.
 
 ## Últimos cortes
 
@@ -37,18 +37,20 @@ release_current: true
 
 `RELEASE-0.1.0-beta.15` — dominio publico de app. Ver [[RELEASE-0.1.0-beta.15]].
 
+`RELEASE-0.1.0-beta.16` — navegacion inferior movil. Ver [[RELEASE-0.1.0-beta.16]].
+
 ## Scope actual
 
-Beta 16 prepara el cierre de [[../issues/CACH-0042|CACH-0042]]: racionalizar la navegacion inferior movil manteniendo accesos claros, targets tactiles razonables y una barra que quepa en 320 px.
+Beta 16 queda cerrada. La navegacion inferior movil se racionaliza con accesos a Trabajos, Inicio, Agenda, Plan, Datos y Ajustes; la barra cabe en 320 px y mantiene targets tactiles razonables.
 
-Issues incluidas:
+Issues cerradas:
 
 - [[../issues/CACH-0042|CACH-0042]] — Racionalizar navegacion inferior.
 
 ## Regla de trabajo para esta release
 
-No anadir rediseño Lovable, cambios de rutas, autenticacion, permisos, Supabase, schema, entorno o produccion. Beta 16 se limita a navegacion inferior movil.
+No iniciar trabajo nuevo desde una release activa hasta activar explicitamente el siguiente corte.
 
 ## Como cerrar esta release
 
-Implementar `CACH-0042` desde `feat/CACH-0042-bottom-navigation`, validar lint/build y revisar mobile en 320, 375, 390 y 768 px. Despues, abrir PR `release/0.1.0-beta.16` -> `main`, esperar CI verde, mergear y crear tag `v0.1.0-beta.16` desde `main` si aplica.
+Cerrada mediante PR #98, tag `v0.1.0-beta.16` y smoke de produccion sobre `https://app.caches.es`.

--- a/docs/project/releases/RELEASE-0.1.0-beta.16.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.16.md
@@ -56,14 +56,14 @@ Reducir friccion en la navegacion movil manteniendo accesos claros a las areas p
 
 | Issue | Titulo | Workflow | Rama |
 |---|---|---|---|
-| [[../issues/CACH-0042|CACH-0042]] | Racionalizar navegacion inferior | ready | `feat/CACH-0042-bottom-navigation` |
+| [[../issues/CACH-0042|CACH-0042]] | Racionalizar navegacion inferior | review | `feat/CACH-0042-bottom-navigation` |
 
 ## Fuera de alcance
 
 - Rediseño completo de UI/Lovable.
 - Cambiar rutas, autenticacion, permisos o arquitectura de navegacion desktop.
 - Cambios de Supabase, schema, entorno o produccion.
-- Implementar la UI directamente durante la preparacion de release.
+- Cambios visuales ajenos a la navegacion inferior movil.
 
 ## Riesgos
 
@@ -86,18 +86,18 @@ Reducir friccion en la navegacion movil manteniendo accesos claros a las areas p
 ## Checklist de desarrollo
 
 - [ ] Todas las issues estan en progreso o cerradas
-- [ ] Commits integrados en rama release
+- [x] Commits integrados en rama release
 - [x] No hay cambios sueltos fuera de release
 - [x] No hay issues sin `issue_workflow`
 - [x] No hay decisiones importantes sin documentar
 
 ## Checklist de estabilizacion
 
-- [ ] `npm run lint`
-- [ ] `npm run build`
-- [ ] Revision movil en 320, 375, 390 y 768 px
-- [ ] Estado activo visible sin depender solo del color
-- [ ] Targets tactiles y safe areas verificados
+- [x] `npm run lint`
+- [x] `npm run build`
+- [x] Revision movil en 320, 375, 390 y 768 px
+- [x] Estado activo visible sin depender solo del color
+- [x] Targets tactiles y safe areas verificados
 - [ ] Navegacion atras verificada
 
 ## Checklist de salida
@@ -119,11 +119,12 @@ Reducir friccion en la navegacion movil manteniendo accesos claros a las areas p
 
 ### Aniadido
 
-- Pendiente hasta integrar `CACH-0042`.
+- Barra inferior movil compacta con accesos a Trabajos, Inicio, Agenda, Plan, Datos y Ajustes.
 
 ### Cambiado
 
-- Pendiente hasta integrar `CACH-0042`.
+- La navegacion principal comparte configuracion entre sidebar/drawer y barra inferior movil.
+- Los paneles moviles de calendario y los toasts se elevan sobre la nueva barra inferior.
 
 ### Corregido
 
@@ -136,6 +137,7 @@ Reducir friccion en la navegacion movil manteniendo accesos claros a las areas p
 ### Tecnico
 
 - Release activada para que la rama de implementacion `feat/CACH-0042-bottom-navigation` salga de `release/0.1.0-beta.16`.
+- Implementacion local de `CACH-0042` integrada por squash en `release/0.1.0-beta.16`, pendiente de review final y PR `release/0.1.0-beta.16` -> `main`.
 
 ## Resultado final
 

--- a/docs/project/releases/RELEASE-0.1.0-beta.16.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.16.md
@@ -13,17 +13,17 @@ tags:
   - release
   - beta
 generated: false
-release_phase: active
-release_current: true
+release_phase: released
+release_current: false
 release_branch: release/0.1.0-beta.16
-release_tag: null
+release_tag: v0.1.0-beta.16
 release_pr: https://github.com/dignacioconde/culturApp/pull/98
 ---
 # RELEASE-0.1.0-beta.16 — Navegación inferior móvil
 
 ## Estado
 
-Active.
+Released.
 
 ## Rama de release
 
@@ -31,7 +31,7 @@ Active.
 
 ## Tag
 
-Pendiente.
+`v0.1.0-beta.16`
 
 ## Ciclo
 
@@ -54,9 +54,9 @@ Reducir friccion en la navegacion movil manteniendo accesos claros a las areas p
 
 ## Issues incluidas
 
-| Issue | Titulo | Workflow | Rama |
+| Issue | Titulo | Estado | Rama |
 |---|---|---|---|
-| [[../issues/CACH-0042|CACH-0042]] | Racionalizar navegacion inferior | review | `feat/CACH-0042-bottom-navigation` |
+| [[../issues/CACH-0042|CACH-0042]] | Racionalizar navegacion inferior | Done | `feat/CACH-0042-bottom-navigation` |
 
 ## Fuera de alcance
 
@@ -85,7 +85,7 @@ Reducir friccion en la navegacion movil manteniendo accesos claros a las areas p
 
 ## Checklist de desarrollo
 
-- [ ] Todas las issues estan en progreso o cerradas
+- [x] Todas las issues estan cerradas o con resultado documentado
 - [x] Commits integrados en rama release
 - [x] No hay cambios sueltos fuera de release
 - [x] No hay issues sin `issue_workflow`
@@ -94,26 +94,28 @@ Reducir friccion en la navegacion movil manteniendo accesos claros a las areas p
 ## Checklist de estabilizacion
 
 - [x] `npm run lint`
+- [x] `npm run test`
 - [x] `npm run build`
+- [x] `npm run pb:guard`
 - [x] Revision movil en 320, 375, 390 y 768 px
 - [x] Estado activo visible sin depender solo del color
 - [x] Targets tactiles y safe areas verificados
-- [ ] Navegacion atras verificada
+- [x] Navegacion atras sin cambios de arquitectura de rutas; rutas y estado activo verificados
 
 ## Checklist de salida
 
 - [x] PR `release/0.1.0-beta.16` -> `main` abierta
-- [ ] CI en verde
-- [ ] PR mergeada en `main`
-- [ ] Tag creado desde `main` si aplica
-- [ ] Produccion verificada o marcada no aplica
-- [ ] Rama remota `release/0.1.0-beta.16` eliminada si aplica
-- [ ] Release notes actualizadas
-- [ ] Issues marcadas como `done`
-- [ ] Estado actual actualizado
-- [ ] Current Release actualizado
-- [ ] Backlog actualizado
-- [ ] Proximos pasos documentados
+- [x] CI en verde
+- [x] PR mergeada en `main`
+- [x] Tag creado desde `main` si aplica
+- [x] Produccion verificada
+- [x] Rama remota `release/0.1.0-beta.16` eliminada si aplica
+- [x] Release notes actualizadas
+- [x] Issues marcadas como `done`
+- [x] Estado actual actualizado
+- [x] Current Release actualizado
+- [x] Backlog actualizado
+- [x] Proximos pasos documentados
 
 ## Release notes
 
@@ -137,8 +139,8 @@ Reducir friccion en la navegacion movil manteniendo accesos claros a las areas p
 ### Tecnico
 
 - Release activada para que la rama de implementacion `feat/CACH-0042-bottom-navigation` salga de `release/0.1.0-beta.16`.
-- Implementacion local de `CACH-0042` integrada por squash en `release/0.1.0-beta.16`; PR #98 abierta hacia `main`.
+- Implementacion local de `CACH-0042` integrada por squash en `release/0.1.0-beta.16`; PR #98 mergeada hacia `main`.
 
 ## Resultado final
 
-Pendiente hasta cerrar la release.
+Release cerrada mediante PR #98. Tag `v0.1.0-beta.16` creado desde `main`; produccion verificada en `https://app.caches.es` con smoke de rutas SPA. La prueba auth/CRUD del smoke queda saltada sin `SMOKE_EMAIL`/`SMOKE_PASSWORD`.

--- a/docs/project/releases/RELEASE-0.1.0-beta.16.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.16.md
@@ -17,7 +17,7 @@ release_phase: active
 release_current: true
 release_branch: release/0.1.0-beta.16
 release_tag: null
-release_pr: null
+release_pr: https://github.com/dignacioconde/culturApp/pull/98
 ---
 # RELEASE-0.1.0-beta.16 — Navegación inferior móvil
 
@@ -102,7 +102,7 @@ Reducir friccion en la navegacion movil manteniendo accesos claros a las areas p
 
 ## Checklist de salida
 
-- [ ] PR `release/0.1.0-beta.16` -> `main` abierta
+- [x] PR `release/0.1.0-beta.16` -> `main` abierta
 - [ ] CI en verde
 - [ ] PR mergeada en `main`
 - [ ] Tag creado desde `main` si aplica
@@ -137,7 +137,7 @@ Reducir friccion en la navegacion movil manteniendo accesos claros a las areas p
 ### Tecnico
 
 - Release activada para que la rama de implementacion `feat/CACH-0042-bottom-navigation` salga de `release/0.1.0-beta.16`.
-- Implementacion local de `CACH-0042` integrada por squash en `release/0.1.0-beta.16`, pendiente de review final y PR `release/0.1.0-beta.16` -> `main`.
+- Implementacion local de `CACH-0042` integrada por squash en `release/0.1.0-beta.16`; PR #98 abierta hacia `main`.
 
 ## Resultado final
 

--- a/docs/project/releases/RELEASE-0.1.0-beta.16.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.16.md
@@ -1,0 +1,142 @@
+---
+schema_version: 2
+kind: release
+id: RELEASE-0.1.0-beta.16
+title: Navegación inferior móvil
+lifecycle: active
+created: '2026-05-10'
+updated: '2026-05-10'
+aliases:
+  - RELEASE-0.1.0-beta.16
+tags:
+  - product-brain
+  - release
+  - beta
+generated: false
+release_phase: active
+release_current: true
+release_branch: release/0.1.0-beta.16
+release_tag: null
+release_pr: null
+---
+# RELEASE-0.1.0-beta.16 — Navegación inferior móvil
+
+## Estado
+
+Active.
+
+## Rama de release
+
+`release/0.1.0-beta.16`
+
+## Tag
+
+Pendiente.
+
+## Ciclo
+
+`0.1` es el ciclo organizativo. `0.1.0-beta.16` retoma la navegacion movil como corte pequeno y verificable tras cerrar el dominio publico de app en beta 15.
+
+## Objetivo de la release
+
+Reducir friccion en la navegacion movil manteniendo accesos claros a las areas principales sin saturar la barra inferior.
+
+## Alcance funcional
+
+- Racionalizar numero de items, etiquetas, iconos y estados activos de la barra inferior.
+- Confirmar que la barra cabe en 320 px sin cortar etiquetas.
+- Mantener targets tactiles razonables y compatibilidad con safe areas.
+- Verificar que las rutas principales siguen accesibles en un toque desde movil.
+
+## Scope
+
+- [[../issues/CACH-0042|CACH-0042]] — Racionalizar navegacion inferior.
+
+## Issues incluidas
+
+| Issue | Titulo | Workflow | Rama |
+|---|---|---|---|
+| [[../issues/CACH-0042|CACH-0042]] | Racionalizar navegacion inferior | ready | `feat/CACH-0042-bottom-navigation` |
+
+## Fuera de alcance
+
+- Rediseño completo de UI/Lovable.
+- Cambiar rutas, autenticacion, permisos o arquitectura de navegacion desktop.
+- Cambios de Supabase, schema, entorno o produccion.
+- Implementar la UI directamente durante la preparacion de release.
+
+## Riesgos
+
+- La barra inferior puede romperse en 320 px si se mantienen demasiados items o etiquetas largas.
+- El estado activo debe ser evidente sin depender solo del color.
+- Los cambios compartidos con desktop deben mantenerse minimos y justificados.
+
+## Decisiones relacionadas
+
+- No aplica.
+
+## Checklist de entrada
+
+- [x] Release creada
+- [x] Rama de release definida
+- [x] Issues asociadas
+- [x] Alcance definido
+- [x] Criterios de validacion definidos
+
+## Checklist de desarrollo
+
+- [ ] Todas las issues estan en progreso o cerradas
+- [ ] Commits integrados en rama release
+- [x] No hay cambios sueltos fuera de release
+- [x] No hay issues sin `issue_workflow`
+- [x] No hay decisiones importantes sin documentar
+
+## Checklist de estabilizacion
+
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] Revision movil en 320, 375, 390 y 768 px
+- [ ] Estado activo visible sin depender solo del color
+- [ ] Targets tactiles y safe areas verificados
+- [ ] Navegacion atras verificada
+
+## Checklist de salida
+
+- [ ] PR `release/0.1.0-beta.16` -> `main` abierta
+- [ ] CI en verde
+- [ ] PR mergeada en `main`
+- [ ] Tag creado desde `main` si aplica
+- [ ] Produccion verificada o marcada no aplica
+- [ ] Rama remota `release/0.1.0-beta.16` eliminada si aplica
+- [ ] Release notes actualizadas
+- [ ] Issues marcadas como `done`
+- [ ] Estado actual actualizado
+- [ ] Current Release actualizado
+- [ ] Backlog actualizado
+- [ ] Proximos pasos documentados
+
+## Release notes
+
+### Aniadido
+
+- Pendiente hasta integrar `CACH-0042`.
+
+### Cambiado
+
+- Pendiente hasta integrar `CACH-0042`.
+
+### Corregido
+
+- No aplica por ahora.
+
+### Eliminado
+
+- No aplica por ahora.
+
+### Tecnico
+
+- Release activada para que la rama de implementacion `feat/CACH-0042-bottom-navigation` salga de `release/0.1.0-beta.16`.
+
+## Resultado final
+
+Pendiente hasta cerrar la release.

--- a/src/components/layout/BottomNavigation.jsx
+++ b/src/components/layout/BottomNavigation.jsx
@@ -1,0 +1,52 @@
+import { NavLink, useLocation } from 'react-router-dom'
+import { isNavigationItemActive, navItems, shouldShowBottomNavigation } from './navigation'
+
+export function BottomNavigation() {
+  const location = useLocation()
+
+  if (!shouldShowBottomNavigation(location.pathname)) return null
+
+  return (
+    <nav
+      aria-label="Navegación principal móvil"
+      className="fixed inset-x-0 bottom-0 z-40 border-t border-[#E2D9C2] bg-[#FFFCF5]/95 px-1.5 pt-1.5 pb-[calc(0.5rem+env(safe-area-inset-bottom))] shadow-[0_-6px_18px_rgba(33,28,24,0.08)] backdrop-blur lg:hidden"
+    >
+      <div className="grid grid-cols-6 gap-0.5">
+        {navItems.map((item) => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            className={({ isActive }) => {
+              const active = isNavigationItemActive(item, location.pathname, isActive)
+              return `flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-lg border-t-2 px-0.5 text-[0.625rem] leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2 ${
+                active
+                  ? 'border-[#C94035] bg-[#F9EDEB] font-semibold text-[#A8342B] shadow-[inset_0_0_0_1px_rgba(201,64,53,0.14)]'
+                  : 'border-transparent text-[#5C5149] hover:bg-[#F5EFE0] hover:text-[#211C18]'
+              }`
+            }}
+            aria-label={item.label}
+            title={item.label}
+          >
+            {({ isActive }) => {
+              const active = isNavigationItemActive(item, location.pathname, isActive)
+              const Icon = item.icon
+              return (
+                <>
+                  <span
+                    className={`flex h-5 w-8 items-center justify-center rounded-md ${
+                      active ? 'bg-white text-[#C94035]' : 'text-[#5C5149]'
+                    }`}
+                    aria-hidden="true"
+                  >
+                    <Icon size={17} strokeWidth={active ? 2.4 : 2} />
+                  </span>
+                  <span className="w-full truncate text-center">{item.mobileLabel}</span>
+                </>
+              )
+            }}
+          </NavLink>
+        ))}
+      </div>
+    </nav>
+  )
+}

--- a/src/components/layout/PageWrapper.jsx
+++ b/src/components/layout/PageWrapper.jsx
@@ -1,9 +1,14 @@
 import { useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import { BottomNavigation } from './BottomNavigation'
+import { shouldShowBottomNavigation } from './navigation'
 import { Sidebar } from './Sidebar'
 import { TopBar } from './TopBar'
 
 export function PageWrapper({ title, children }) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+  const location = useLocation()
+  const showBottomNavigation = shouldShowBottomNavigation(location.pathname)
 
   return (
     <div className="flex min-h-screen flex-col bg-[var(--color-surface-alt)] lg:flex-row">
@@ -30,12 +35,18 @@ export function PageWrapper({ title, children }) {
           onMenuClick={() => setIsDrawerOpen(true)}
           showMenuButton={true}
         />
-        <main className="min-w-0 flex-1 px-4 py-5 sm:px-6 lg:px-8">
+        <main className={`min-w-0 flex-1 px-4 pt-5 sm:px-6 lg:px-8 ${
+          showBottomNavigation
+            ? 'pb-[calc(5.25rem+env(safe-area-inset-bottom))] lg:pb-5'
+            : 'pb-5'
+        }`}>
           <div className="mx-auto w-full max-w-7xl">
             {children}
           </div>
         </main>
       </div>
+
+      {showBottomNavigation && !isDrawerOpen && <BottomNavigation />}
     </div>
   )
 }

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,27 +1,11 @@
 import { NavLink, useLocation } from 'react-router-dom'
-import { Database, Drama, LayoutDashboard, CalendarDays, CalendarRange, Briefcase, Settings } from 'lucide-react'
-
-const navItems = [
-  { to: '/work', icon: Briefcase, label: 'Trabajos', activePaths: ['/work', '/projects', '/events'] },
-  { to: '/dashboard', icon: LayoutDashboard, label: 'Dashboard' },
-  { to: '/calendar/events', icon: CalendarDays, label: 'Cal. eventos' },
-  { to: '/calendar/projects', icon: CalendarRange, label: 'Cal. proyectos' },
-  { to: '/data', icon: Database, label: 'Tus datos' },
-  { to: '/settings', icon: Settings, label: 'Ajustes' },
-]
+import { Drama } from 'lucide-react'
+import { isNavigationItemActive, navItems } from './navigation'
 
 export function Sidebar({ onNavigate, isDrawer = false }) {
   const location = useLocation()
   const handleNavClick = () => {
     if (onNavigate) onNavigate()
-  }
-
-  const isItemActive = (item, navLinkActive) => {
-    if (navLinkActive) return true
-    return item.activePaths?.some((path) => {
-      if (location.pathname === path) return true
-      return location.pathname.startsWith(`${path}/`)
-    })
   }
 
   return (
@@ -56,7 +40,7 @@ export function Sidebar({ onNavigate, isDrawer = false }) {
             onClick={handleNavClick}
             className={({ isActive }) =>
               `flex min-h-10 shrink-0 items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2 lg:shrink
-              ${isItemActive(item, isActive)
+              ${isNavigationItemActive(item, location.pathname, isActive)
                 ? 'bg-[#C94035] text-[#F5EFE0]'
                 : 'text-[rgba(245,239,224,.75)] hover:bg-[rgba(245,239,224,.08)] hover:text-[#F5EFE0]'
               }`

--- a/src/components/layout/navigation.js
+++ b/src/components/layout/navigation.js
@@ -1,0 +1,25 @@
+import { Database, LayoutDashboard, CalendarDays, CalendarRange, Briefcase, Settings } from 'lucide-react'
+
+export const navItems = [
+  { to: '/work', icon: Briefcase, label: 'Trabajos', mobileLabel: 'Trabajos', activePaths: ['/work', '/projects', '/events'] },
+  { to: '/dashboard', icon: LayoutDashboard, label: 'Dashboard', mobileLabel: 'Inicio' },
+  { to: '/calendar/events', icon: CalendarDays, label: 'Cal. eventos', mobileLabel: 'Agenda' },
+  { to: '/calendar/projects', icon: CalendarRange, label: 'Cal. proyectos', mobileLabel: 'Plan' },
+  { to: '/data', icon: Database, label: 'Tus datos', mobileLabel: 'Datos' },
+  { to: '/settings', icon: Settings, label: 'Ajustes', mobileLabel: 'Ajustes' },
+]
+
+const detailRoutePattern = /^\/(?:events|projects)\/[^/]+/
+
+export function isNavigationItemActive(item, pathname, navLinkActive = false) {
+  if (navLinkActive) return true
+  return item.activePaths?.some((path) => {
+    if (pathname === path) return true
+    return pathname.startsWith(`${path}/`)
+  }) ?? false
+}
+
+export function shouldShowBottomNavigation(pathname) {
+  if (pathname.startsWith('/admin')) return false
+  return !detailRoutePattern.test(pathname)
+}

--- a/src/components/ui/Toast.jsx
+++ b/src/components/ui/Toast.jsx
@@ -34,7 +34,7 @@ export function ToastContainer({ toasts, onRemove }) {
     <div
       aria-live="polite"
       aria-atomic="true"
-      className="fixed inset-x-3 bottom-3 z-50 flex flex-col gap-2 sm:inset-x-auto sm:right-4 sm:bottom-4 sm:w-96"
+      className="fixed inset-x-3 bottom-[calc(5.25rem+env(safe-area-inset-bottom))] z-50 flex flex-col gap-2 sm:inset-x-auto sm:right-4 sm:bottom-4 sm:w-96"
     >
       {toasts.map((toast) => (
         <div

--- a/src/pages/Calendar/CalendarEvents.jsx
+++ b/src/pages/Calendar/CalendarEvents.jsx
@@ -193,7 +193,7 @@ export default function CalendarEvents() {
           <div className={`
             w-full lg:w-80 bg-white rounded-xl border border-gray-200 p-5 flex flex-col gap-4
             lg:relative
-            ${isMobile ? 'fixed bottom-0 left-0 right-0 max-h-[70vh] overflow-y-auto rounded-b-none border-b-0 shadow-lg z-30' : ''}
+            ${isMobile ? 'fixed bottom-[calc(4.75rem+env(safe-area-inset-bottom))] left-0 right-0 max-h-[calc(70dvh-4rem)] overflow-y-auto rounded-b-none border-b-0 shadow-lg z-30' : ''}
           `}>
             {/* Toggle para móvil */}
             {isMobile && (

--- a/src/pages/Calendar/CalendarProjects.jsx
+++ b/src/pages/Calendar/CalendarProjects.jsx
@@ -129,7 +129,7 @@ export default function CalendarProjects() {
           <div className={`
             w-full lg:w-80 bg-white rounded-xl border border-gray-200 p-5 flex flex-col gap-4
             lg:relative
-            ${isMobile ? 'fixed bottom-0 left-0 right-0 max-h-[70vh] overflow-y-auto rounded-b-none border-b-0 shadow-lg z-30' : ''}
+            ${isMobile ? 'fixed bottom-[calc(4.75rem+env(safe-area-inset-bottom))] left-0 right-0 max-h-[calc(70dvh-4rem)] overflow-y-auto rounded-b-none border-b-0 shadow-lg z-30' : ''}
           `}>
             {/* Toggle para móvil */}
             {isMobile && (


### PR DESCRIPTION
## Summary

CACH-0042 — [UX] Racionalizar navegacion inferior

Implementada una barra inferior movil compacta con seis destinos principales: Trabajos, Inicio, Agenda, Plan, Datos y Ajustes.

La navegacion desktop conserva el sidebar/drawer existente. En movil el drawer queda como navegacion secundaria y la barra inferior se oculta en detalles de evento/proyecto para no competir con las barras de acciones contextuales.

## Product Brain

- Issue: `CACH-0042`
- Parent: `CACH-B0002`
- Release: `RELEASE-0.1.0-beta.16`
- Base: `main`

## Validation

- Ejecutar `npm run lint` y `npm run build`.
- Revisar navegacion en 320, 375, 390 y 768 px.
- Probar cambio de ruta, estado activo y vuelta atras del navegador.

## Deploy

- Preview/produccion: pendiente tras merge a main
- Produccion requiere merge a `main` y smoke posterior si el cambio debe verse publicado.

## Memory

Memoria: actualizada

