### PR TITLE
Beta 17: feedback simple

### DIFF
--- a/docs/project/DIGEST.md
+++ b/docs/project/DIGEST.md
@@ -5,7 +5,7 @@ id: PB-DIGEST
 title: Product Brain Digest
 lifecycle: active
 created: 2026-05-05
-updated: 2026-05-10
+updated: 2026-05-11
 aliases:
   - Digest
   - Brain Digest
@@ -23,7 +23,7 @@ Resumen determinista generado desde Product Brain v2.
 
 ## Estado operacional
 
-- **Release activa:** No hay release activa.
+- **Release activa:** RELEASE-0.1.0-beta.17 — Feedback simple beta
 - **Últimos cortes:** `RELEASE-0.1.0-beta.10` — emails transaccionales beta con Brevo. Ver RELEASE-0.1.0-beta.10.
 
 `RELEASE-0.1.0-beta.12` — pulido proyecto-evento y borrados seguros. Ver RELEASE-0.1.0-beta.12.
@@ -35,13 +35,13 @@ Resumen determinista generado desde Product Brain v2.
 `RELEASE-0.1.0-beta.15` — dominio publico de app. Ver RELEASE-0.1.0-beta.15.
 
 `RELEASE-0.1.0-beta.16` — navegacion inferior movil. Ver RELEASE-0.1.0-beta.16.
-- **Foco:** Beta 16 queda activa para retomar navegacion movil como slice pequeno y verificable, limitada a CACH-0042.
+- **Foco:** Beta 17 queda activa para capturar feedback cualitativo con un formulario simple propio, limitada a CACH-0052.
 
 ## Prioridades del plan
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
-2. Mantener beta 16 acotada a navegacion inferior movil.
-3. No mezclar rediseño Lovable ni cambios de rutas/schema salvo decision explicita posterior.
+2. Mantener beta 17 acotada a feedback cualitativo simple.
+3. No introducir PostHog, Plausible ni analitica de eventos sin issue/ADR posterior.
 
 ## Tablero
 
@@ -89,11 +89,11 @@ _Sin entradas._
 
 | ID | Título | Updated | Estado |
 |---|---|---|---|
+| ADR-0014 | Beta feedback propio y Plausible comentado | 2026-05-11 | Superseded |
+| ADR-0015 | Feedback simple propio y PostHog diferido | 2026-05-11 | Accepted |
 | ADR-0001 | Mantener el modelo proyecto-evento con finanzas en ambos niveles | 2026-05-08 | Accepted |
 | ADR-0002 | Beta prioriza confianza antes que features Pro | 2026-05-08 | Accepted |
 | ADR-0003 | Product Brain repo-native y GitHub solo para implementacion | 2026-05-08 | Accepted |
-| ADR-0004 | Perfil, IRPF y datos de perfil pasan por useProfile | 2026-05-08 | Accepted |
-| ADR-0005 | Controles propios para selectores, fechas y decimales | 2026-05-08 | Accepted |
 
 ## Knowledge
 
@@ -107,4 +107,4 @@ _Sin entradas._
 
 ## Próxima acción
 
-Implementar CACH-0042 desde `feat/CACH-0042-bottom-navigation`, validar lint/build y revisar mobile en 320, 375, 390 y 768 px.
+Implementar CACH-0052 desde `release/0.1.0-beta.17`, validar lint/build/Product Brain y revisar boton/modal en mobile y desktop.

--- a/docs/project/DIGEST.md
+++ b/docs/project/DIGEST.md
@@ -5,7 +5,7 @@ id: PB-DIGEST
 title: Product Brain Digest
 lifecycle: active
 created: 2026-05-05
-updated: 2026-05-11
+updated: 2026-05-12
 aliases:
   - Digest
   - Brain Digest
@@ -23,7 +23,7 @@ Resumen determinista generado desde Product Brain v2.
 
 ## Estado operacional
 
-- **Release activa:** RELEASE-0.1.0-beta.17 — Feedback simple beta
+- **Release activa:** No hay release activa.
 - **Últimos cortes:** `RELEASE-0.1.0-beta.10` — emails transaccionales beta con Brevo. Ver RELEASE-0.1.0-beta.10.
 
 `RELEASE-0.1.0-beta.12` — pulido proyecto-evento y borrados seguros. Ver RELEASE-0.1.0-beta.12.
@@ -35,12 +35,14 @@ Resumen determinista generado desde Product Brain v2.
 `RELEASE-0.1.0-beta.15` — dominio publico de app. Ver RELEASE-0.1.0-beta.15.
 
 `RELEASE-0.1.0-beta.16` — navegacion inferior movil. Ver RELEASE-0.1.0-beta.16.
-- **Foco:** Beta 17 queda activa para capturar feedback cualitativo con un formulario simple propio, limitada a CACH-0052.
+
+`RELEASE-0.1.0-beta.17` — feedback simple beta. Ver RELEASE-0.1.0-beta.17.
+- **Foco:** Beta 17 queda cerrada con feedback cualitativo simple propio en Supabase. No hay release activa.
 
 ## Prioridades del plan
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
-2. Mantener beta 17 acotada a feedback cualitativo simple.
+2. Mantener el feedback beta simple antes de introducir analitica de producto.
 3. No introducir PostHog, Plausible ni analitica de eventos sin issue/ADR posterior.
 
 ## Tablero
@@ -107,4 +109,4 @@ _Sin entradas._
 
 ## Próxima acción
 
-Implementar CACH-0052 desde `release/0.1.0-beta.17`, validar lint/build/Product Brain y revisar boton/modal en mobile y desktop.
+Aplicar la migracion remota de Supabase de beta 17 solo con confirmacion humana explicita, y elegir el siguiente corte cuando haga falta.

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -5,7 +5,7 @@ id: PB-BACKLOG
 title: Backlog operativo
 lifecycle: active
 created: 2026-05-05
-updated: 2026-05-11
+updated: 2026-05-12
 aliases:
   - Backlog operativo
   - Backlog
@@ -101,7 +101,7 @@ _Sin issues._
 | [[../issues/CACH-0047|CACH-0047]] | [Skills] Actualizar catalogo y symlinks de skills | null | Catalogo y validacion de skills alineados con las 16 skills portables actuales. `caveman` queda integrado como modo de salida conciso en runners OpenCode, con excepciones obligatorias para seguridad, RLS, finanzas, SQL, migraciones, reviews, verificacion y acciones remotas/destructivas. |
 | [[../issues/CACH-0050|CACH-0050]] | [Deploy] Tooling local-first de PR release y smoke | null | Implementado tooling local-first de deploy/PR/release: estado y sync de release, PR body, `ship` dry-run/execute acotado, smoke postdeploy, limpieza local de ramas, `verify:ci`, `verify:pr` y `installCommand: "npm ci"` en Vercel sin tocar el rewrite SPA. |
 | [[../issues/CACH-0051|CACH-0051]] | [Deploy] Dominio publico de app y estrategia multientorno | RELEASE-0.1.0-beta.15 | Cerrado en `RELEASE-0.1.0-beta.15`. El dominio publico canonico de la app queda definido como `https://app.caches.es`, asignado al proyecto Vercel, resuelto por DNS de Hostinger y verificado con smoke de rutas SPA. `VITE_APP_URL` queda configurado en Vercel para produccion, preview y development. La Edge Function `send-beta-invite` usa `APP_URL=https://app.caches.es`. Supabase Auth URL Configuration queda actualizada con `Site URL` canonico y redirects permitidos para `app.caches.es`, alias temporal de Vercel y localhost local. |
-| [[../issues/CACH-0052|CACH-0052]] | [Feedback] Formulario simple de feedback beta | RELEASE-0.1.0-beta.17 | Implementado para `RELEASE-0.1.0-beta.17`. La release anade el formulario global de feedback, el hook de envio, elimina el snippet comentado de Plausible y endurece la politica de insert de la tabla `feedback`. |
+| [[../issues/CACH-0052|CACH-0052]] | [Feedback] Formulario simple de feedback beta | RELEASE-0.1.0-beta.17 | Implementado y cerrado en `RELEASE-0.1.0-beta.17`. La release anade el formulario global de feedback, el hook de envio, elimina el snippet comentado de Plausible y deja versionada la migracion que endurece la politica de insert de la tabla `feedback`. |
 | [[../issues/CACH-B0003|CACH-B0003]] | Cobro rapido y gestion de pendientes | RELEASE-0.1.0-beta.5 | Released en RELEASE-0.1.0-beta.5 por ampliacion explicita de scope. Integrado en `main` mediante PR #84. |
 | [[../issues/CACH-B0005|CACH-B0005]] | Importacion exportacion y portabilidad de datos | RELEASE-0.1.0-beta.7 | Released en RELEASE-0.1.0-beta.7. Integrado en `main` mediante PR #86. |
 | [[../issues/CACH-B0006|CACH-B0006]] | Onboarding y acceso beta | RELEASE-0.1.0-beta.8 | Released en RELEASE-0.1.0-beta.8. Integrado en `main` mediante PR #87. |

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -5,7 +5,7 @@ id: PB-BACKLOG
 title: Backlog operativo
 lifecycle: active
 created: 2026-05-05
-updated: 2026-05-10
+updated: 2026-05-11
 aliases:
   - Backlog operativo
   - Backlog
@@ -101,6 +101,7 @@ _Sin issues._
 | [[../issues/CACH-0047|CACH-0047]] | [Skills] Actualizar catalogo y symlinks de skills | null | Catalogo y validacion de skills alineados con las 16 skills portables actuales. `caveman` queda integrado como modo de salida conciso en runners OpenCode, con excepciones obligatorias para seguridad, RLS, finanzas, SQL, migraciones, reviews, verificacion y acciones remotas/destructivas. |
 | [[../issues/CACH-0050|CACH-0050]] | [Deploy] Tooling local-first de PR release y smoke | null | Implementado tooling local-first de deploy/PR/release: estado y sync de release, PR body, `ship` dry-run/execute acotado, smoke postdeploy, limpieza local de ramas, `verify:ci`, `verify:pr` y `installCommand: "npm ci"` en Vercel sin tocar el rewrite SPA. |
 | [[../issues/CACH-0051|CACH-0051]] | [Deploy] Dominio publico de app y estrategia multientorno | RELEASE-0.1.0-beta.15 | Cerrado en `RELEASE-0.1.0-beta.15`. El dominio publico canonico de la app queda definido como `https://app.caches.es`, asignado al proyecto Vercel, resuelto por DNS de Hostinger y verificado con smoke de rutas SPA. `VITE_APP_URL` queda configurado en Vercel para produccion, preview y development. La Edge Function `send-beta-invite` usa `APP_URL=https://app.caches.es`. Supabase Auth URL Configuration queda actualizada con `Site URL` canonico y redirects permitidos para `app.caches.es`, alias temporal de Vercel y localhost local. |
+| [[../issues/CACH-0052|CACH-0052]] | [Feedback] Formulario simple de feedback beta | RELEASE-0.1.0-beta.17 | Implementado para `RELEASE-0.1.0-beta.17`. La release anade el formulario global de feedback, el hook de envio, elimina el snippet comentado de Plausible y endurece la politica de insert de la tabla `feedback`. |
 | [[../issues/CACH-B0003|CACH-B0003]] | Cobro rapido y gestion de pendientes | RELEASE-0.1.0-beta.5 | Released en RELEASE-0.1.0-beta.5 por ampliacion explicita de scope. Integrado en `main` mediante PR #84. |
 | [[../issues/CACH-B0005|CACH-B0005]] | Importacion exportacion y portabilidad de datos | RELEASE-0.1.0-beta.7 | Released en RELEASE-0.1.0-beta.7. Integrado en `main` mediante PR #86. |
 | [[../issues/CACH-B0006|CACH-B0006]] | Onboarding y acceso beta | RELEASE-0.1.0-beta.8 | Released en RELEASE-0.1.0-beta.8. Integrado en `main` mediante PR #87. |

--- a/docs/project/decisions/ADR-0014-analytics-feedback.md
+++ b/docs/project/decisions/ADR-0014-analytics-feedback.md
@@ -5,7 +5,7 @@ id: ADR-0014
 title: Beta feedback propio y Plausible comentado
 lifecycle: active
 created: '2026-05-05'
-updated: '2026-05-08'
+updated: '2026-05-11'
 aliases:
   - ADR-0014
 tags:
@@ -13,9 +13,13 @@ tags:
   - adr
   - feedback
 generated: false
-decision_status: Accepted
+decision_status: Superseded
 ---
 # ADR-0014 — Beta feedback propio y Plausible comentado
+
+## Decision status
+
+Superseded por [[ADR-0015-feedback-simple-posthog-futuro|ADR-0015]].
 
 ## Contexto
 
@@ -36,3 +40,4 @@ No se anade PostHog en esta fase.
 ## Relacionado
 
 - [[../issues/CACH-B0016|CACH-B0016]]
+- [[ADR-0015-feedback-simple-posthog-futuro|ADR-0015]]

--- a/docs/project/decisions/ADR-0015-feedback-simple-posthog-futuro.md
+++ b/docs/project/decisions/ADR-0015-feedback-simple-posthog-futuro.md
@@ -1,0 +1,61 @@
+---
+schema_version: 2
+kind: decision
+id: ADR-0015
+title: Feedback simple propio y PostHog diferido
+lifecycle: active
+created: '2026-05-11'
+updated: '2026-05-11'
+aliases:
+  - ADR-0015
+tags:
+  - product-brain
+  - adr
+  - feedback
+  - privacy
+  - analytics
+generated: false
+decision_status: Accepted
+---
+# ADR-0015 — Feedback simple propio y PostHog diferido
+
+## Decision status
+
+Accepted
+
+## Contexto
+
+La beta necesita una via inmediata para recibir feedback cualitativo sin introducir una herramienta externa de analitica ni aumentar la superficie RGPD antes de validar el uso real.
+
+PostHog puede ser mejor cuando Cachés necesite funnels, cohorts, surveys gestionadas o paneles de producto, pero ahora el objetivo es capturar comentarios concretos con coste y mantenimiento minimos.
+
+## Decision
+
+Implementar en `RELEASE-0.1.0-beta.17` un formulario simple de feedback propio que escribe en la tabla `feedback` de Supabase.
+
+No se anade PostHog, Plausible, `usage_events`, autocapture, heatmaps, session replay ni dashboards de metricas en esta release.
+
+Si mas adelante hace falta analitica de producto, se abrira una ADR nueva para PostHog con region UE, consentimiento explicito, autocapture desactivado y eventos manuales allowlist.
+
+## Consecuencias
+
+- El feedback vive en la base de datos actual y no sale a un proveedor externo.
+- La UI puede recoger senales cualitativas sin crear una capa de analitica prematura.
+- El equipo pierde por ahora funnels, surveys administradas y paneles no tecnicos.
+- La migracion a PostHog sigue abierta, pero exigira decision, configuracion de privacidad y scope propio.
+
+## Alternativas consideradas
+
+- PostHog ahora: mas potente para producto, pero introduce proveedor externo y decisiones de privacidad antes de necesitarlas.
+- Supabase `usage_events`: mantiene todo en casa, pero crea trabajo de analitica que no hace falta para este corte.
+- Plausible: queda descartado para esta necesidad porque el usuario pide evitarlo y no resuelve feedback cualitativo.
+
+## Fecha
+
+2026-05-11
+
+## Relacionado con
+
+- [[../releases/RELEASE-0.1.0-beta.17|RELEASE-0.1.0-beta.17]]
+- [[../issues/CACH-0052|CACH-0052]]
+- [[ADR-0014-analytics-feedback|ADR-0014]]

--- a/docs/project/indexes/by-area.md
+++ b/docs/project/indexes/by-area.md
@@ -5,7 +5,7 @@ id: PB-BY-AREA
 title: Issues por area
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-10
+updated: 2026-05-11
 aliases:
   - Issues por area
 tags:
@@ -34,6 +34,7 @@ generated: true
 - [[../issues/CACH-0043|CACH-0043]] — [UX] Limpiar acciones en detalle de proyecto · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
 - [[../issues/CACH-0045|CACH-0045]] — [UX] Anadir confirmacion a borrados destructivos · done · p1 · slice
+- [[../issues/CACH-0052|CACH-0052]] — [Feedback] Formulario simple de feedback beta · done · p1 · slice
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes · done · p1 · slice
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta · done · p1 · slice
 - [[../issues/CACH-B0014|CACH-B0014]] — Endurecer agenda cobros y captura del MVP · done · p1 · slice

--- a/docs/project/indexes/by-component.md
+++ b/docs/project/indexes/by-component.md
@@ -5,7 +5,7 @@ id: PB-BY-COMPONENT
 title: Issues por componente
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-10
+updated: 2026-05-11
 aliases:
   - Issues por componente
 tags:
@@ -123,6 +123,7 @@ generated: true
 - [[../issues/CACH-0043|CACH-0043]] — [UX] Limpiar acciones en detalle de proyecto · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
 - [[../issues/CACH-0045|CACH-0045]] — [UX] Anadir confirmacion a borrados destructivos · done · p1 · slice
+- [[../issues/CACH-0052|CACH-0052]] — [Feedback] Formulario simple de feedback beta · done · p1 · slice
 
 ## infra-deploy
 
@@ -147,3 +148,4 @@ generated: true
 
 - [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · done · p0 · task
 - [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · done · p1 · task
+- [[../issues/CACH-0052|CACH-0052]] — [Feedback] Formulario simple de feedback beta · done · p1 · slice

--- a/docs/project/indexes/by-level.md
+++ b/docs/project/indexes/by-level.md
@@ -5,7 +5,7 @@ id: PB-BY-LEVEL
 title: Issues por nivel
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-10
+updated: 2026-05-11
 aliases:
   - Issues por nivel
 tags:
@@ -42,6 +42,7 @@ generated: true
 - [[../issues/CACH-0043|CACH-0043]] — [UX] Limpiar acciones en detalle de proyecto · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
 - [[../issues/CACH-0045|CACH-0045]] — [UX] Anadir confirmacion a borrados destructivos · done · p1 · slice
+- [[../issues/CACH-0052|CACH-0052]] — [Feedback] Formulario simple de feedback beta · done · p1 · slice
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes · done · p1 · slice
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta · done · p1 · slice

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -5,7 +5,7 @@ id: PB-BY-RELEASE
 title: Issues por release
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-10
+updated: 2026-05-11
 aliases:
   - Issues por release
 tags:
@@ -74,6 +74,10 @@ generated: true
 ## RELEASE-0.1.0-beta.16
 
 - [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · done · p1 · slice
+
+## RELEASE-0.1.0-beta.17
+
+- [[../issues/CACH-0052|CACH-0052]] — [Feedback] Formulario simple de feedback beta · done · p1 · slice
 
 ## RELEASE-0.1.0-beta.2
 

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -5,7 +5,7 @@ id: PB-BY-STATUS
 title: Issues por workflow
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-10
+updated: 2026-05-11
 aliases:
   - Issues por workflow
 tags:
@@ -54,6 +54,7 @@ generated: true
 - [[../issues/CACH-0047|CACH-0047]] — [Skills] Actualizar catalogo y symlinks de skills · done · p1 · task
 - [[../issues/CACH-0050|CACH-0050]] — [Deploy] Tooling local-first de PR release y smoke · done · p1 · task
 - [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · done · p1 · task
+- [[../issues/CACH-0052|CACH-0052]] — [Feedback] Formulario simple de feedback beta · done · p1 · slice
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes · done · p1 · slice
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta · done · p1 · slice

--- a/docs/project/indexes/by-theme.md
+++ b/docs/project/indexes/by-theme.md
@@ -5,7 +5,7 @@ id: PB-BY-THEME
 title: Issues por tema
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-10
+updated: 2026-05-11
 aliases:
   - Issues por tema
 tags:
@@ -20,6 +20,7 @@ generated: true
 - [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · done · p0 · task
 - [[../issues/CACH-0036|CACH-0036]] — Profesionalizar flujo de ramas por beta · done · p1 · task
 - [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · done · p1 · task
+- [[../issues/CACH-0052|CACH-0052]] — [Feedback] Formulario simple de feedback beta · done · p1 · slice
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta · done · p1 · slice
 - [[../issues/CACH-B0017|CACH-B0017]] — Panel admin para invitaciones beta · done · p1 · slice

--- a/docs/project/indexes/decisions.index.md
+++ b/docs/project/indexes/decisions.index.md
@@ -5,7 +5,7 @@ id: PB-DECISIONS-INDEX
 title: Decisions Index
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-10
+updated: 2026-05-11
 aliases:
   - Decisions Index
 tags:
@@ -29,3 +29,4 @@ generated: true
 - [[../decisions/ADR-0012-decimal-input-policy|ADR-0012]] — Decimales europeos con input text e inputmode decimal
 - [[../decisions/ADR-0013-testing-strategy|ADR-0013]] — Testing quirurgico para beta privada
 - [[../decisions/ADR-0014-analytics-feedback|ADR-0014]] — Beta feedback propio y Plausible comentado
+- [[../decisions/ADR-0015-feedback-simple-posthog-futuro|ADR-0015]] — Feedback simple propio y PostHog diferido

--- a/docs/project/indexes/issues-open.index.md
+++ b/docs/project/indexes/issues-open.index.md
@@ -5,7 +5,7 @@ id: PB-ISSUES-OPEN
 title: Issues Open Index
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-10
+updated: 2026-05-11
 aliases:
   - Issues Open Index
 tags:

--- a/docs/project/indexes/issues.index.md
+++ b/docs/project/indexes/issues.index.md
@@ -5,7 +5,7 @@ id: PB-ISSUES-INDEX
 title: Issues Index
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-10
+updated: 2026-05-11
 aliases:
   - Issues Index
 tags:
@@ -40,6 +40,7 @@ generated: true
 - [[../issues/CACH-0049|CACH-0049]] — Migrar Product Brain a v2 lean agile para agentes
 - [[../issues/CACH-0050|CACH-0050]] — [Deploy] Tooling local-first de PR release y smoke
 - [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno
+- [[../issues/CACH-0052|CACH-0052]] — [Feedback] Formulario simple de feedback beta
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes

--- a/docs/project/indexes/releases.index.md
+++ b/docs/project/indexes/releases.index.md
@@ -5,7 +5,7 @@ id: PB-RELEASES-INDEX
 title: Releases Index
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-10
+updated: 2026-05-11
 aliases:
   - Releases Index
 tags:
@@ -25,6 +25,7 @@ generated: true
 - [[../releases/RELEASE-0.1.0-beta.14|RELEASE-0.1.0-beta.14]] — Email definitivo transaccional
 - [[../releases/RELEASE-0.1.0-beta.15|RELEASE-0.1.0-beta.15]] — Dominio publico de app
 - [[../releases/RELEASE-0.1.0-beta.16|RELEASE-0.1.0-beta.16]] — Navegación inferior móvil
+- [[../releases/RELEASE-0.1.0-beta.17|RELEASE-0.1.0-beta.17]] — Feedback simple beta
 - [[../releases/RELEASE-0.1.0-beta.2|RELEASE-0.1.0-beta.2]] — Endurecer confianza de datos
 - [[../releases/RELEASE-0.1.0-beta.3|RELEASE-0.1.0-beta.3]] — Rediseño financiero del Dashboard
 - [[../releases/RELEASE-0.1.0-beta.4|RELEASE-0.1.0-beta.4]] — Planificacion anual de proyectos

--- a/docs/project/issues/CACH-0052.md
+++ b/docs/project/issues/CACH-0052.md
@@ -77,7 +77,7 @@ Fuera de alcance:
 
 ## Resultado
 
-Implementado para `RELEASE-0.1.0-beta.17`. La release anade el formulario global de feedback, el hook de envio, elimina el snippet comentado de Plausible y endurece la politica de insert de la tabla `feedback`.
+Implementado y cerrado en `RELEASE-0.1.0-beta.17`. La release anade el formulario global de feedback, el hook de envio, elimina el snippet comentado de Plausible y deja versionada la migracion que endurece la politica de insert de la tabla `feedback`.
 
 ## Desarrollo
 
@@ -89,6 +89,7 @@ Implementado para `RELEASE-0.1.0-beta.17`. La release anade el formulario global
 
 - 2026-05-11: Se crea la issue como scope unico de `RELEASE-0.1.0-beta.17`.
 - 2026-05-11: Implementacion local completada y validada con lint, tests, build y Product Brain.
+- 2026-05-11: PR #99 con CI y Vercel Preview en verde.
 
 ## Cambios de alcance y decisiones
 
@@ -110,6 +111,7 @@ Sin bloqueos.
 - `npm run release:status` OK con aviso esperado de rama remota inexistente.
 - `npm run release:sync-check` OK con aviso esperado de rama remota inexistente.
 - Smoke visual/funcional con Playwright mockeando sesion Supabase en 320 px y 1280 px OK: TopBar visible, boton tactil, modal, validacion y submit sin `user_agent`.
+- GitHub PR #99: `app`, `e2e`, Vercel Preview y Vercel Preview Comments en verde.
 
 ## Memoria
 

--- a/docs/project/issues/CACH-0052.md
+++ b/docs/project/issues/CACH-0052.md
@@ -82,7 +82,7 @@ Implementado para `RELEASE-0.1.0-beta.17`. La release anade el formulario global
 ## Desarrollo
 
 - Rama: `release/0.1.0-beta.17`
-- PR:
+- PR: https://github.com/dignacioconde/culturApp/pull/99
 - Estado actual: cerrada localmente en la rama de release.
 
 ## Notas de progreso

--- a/docs/project/issues/CACH-0052.md
+++ b/docs/project/issues/CACH-0052.md
@@ -1,0 +1,116 @@
+---
+schema_version: 2
+kind: issue
+id: CACH-0052
+title: '[Feedback] Formulario simple de feedback beta'
+lifecycle: active
+created: '2026-05-11'
+updated: '2026-05-11'
+aliases:
+  - CACH-0052
+tags:
+  - product-brain
+  - issue
+  - feedback
+  - privacy
+generated: false
+work_type: feature
+work_level: slice
+issue_workflow: done
+priority: p1
+size: s
+area: frontend
+components:
+  - design-system
+  - supabase
+parent: null
+related:
+  - CACH-B0016
+depends_on: []
+blocked_by: []
+adr:
+  - ADR-0015
+release: RELEASE-0.1.0-beta.17
+theme: beta-trust
+---
+# CACH-0052 — [Feedback] Formulario simple de feedback beta
+
+## Objetivo
+
+Capturar feedback cualitativo de beta desde la app con un formulario propio, gratuito y compatible con el stack actual.
+
+## Alcance
+
+Incluido:
+
+- Boton global de feedback en la TopBar.
+- Modal con area opcional, comentario obligatorio y consentimiento explicito.
+- Hook `useFeedback` para que la UI no llame Supabase directamente.
+- Insercion en la tabla `feedback` existente.
+- Hardening de RLS para insertar solo como usuario autenticado y con `user_id = auth.uid()`.
+
+Fuera de alcance:
+
+- PostHog SDK.
+- Plausible.
+- Tabla `usage_events`.
+- Dashboard interno de metricas, autocapture, heatmaps o session replay.
+
+## Criterios de aceptacion
+
+- [x] El boton de feedback aparece en la TopBar sin romper mobile ni desktop.
+- [x] El formulario valida comentario y consentimiento antes de enviar.
+- [x] El envio guarda feedback propio en Supabase via hook.
+- [x] El payload no incluye `user_agent` completo ni datos editables para `user_id`.
+- [x] La RLS permite insert autenticado propio y no expone lectura a usuarios.
+- [x] PostHog queda documentado como posible migracion posterior, no implementado.
+
+## Validacion
+
+- `npm run lint`
+- `npm run build`
+- `npm run test`
+- `npm run pb:check`
+- `npm run pb:guard`
+- Revision responsive manual del boton/modal en ancho movil y desktop.
+- Revision RLS de la migracion local.
+
+## Resultado
+
+Implementado para `RELEASE-0.1.0-beta.17`. La release anade el formulario global de feedback, el hook de envio, elimina el snippet comentado de Plausible y endurece la politica de insert de la tabla `feedback`.
+
+## Desarrollo
+
+- Rama: `release/0.1.0-beta.17`
+- PR:
+- Estado actual: cerrada localmente en la rama de release.
+
+## Notas de progreso
+
+- 2026-05-11: Se crea la issue como scope unico de `RELEASE-0.1.0-beta.17`.
+- 2026-05-11: Implementacion local completada y validada con lint, tests, build y Product Brain.
+
+## Cambios de alcance y decisiones
+
+- Se descarta Plausible para esta beta.
+- Se descarta PostHog en esta release y se deja como migracion futura si hacen falta funnels, surveys o analitica de producto.
+
+## Bloqueos
+
+Sin bloqueos.
+
+## Validación ejecutada
+
+- `npm run lint` OK.
+- `npm run test` OK: 26 archivos, 142 tests.
+- `npm run build` OK.
+- `npm run pb:check` OK.
+- `npm run pb:guard` OK tras regenerar indices y digest.
+- `git diff --check` OK.
+- `npm run release:status` OK con aviso esperado de rama remota inexistente.
+- `npm run release:sync-check` OK con aviso esperado de rama remota inexistente.
+- Smoke visual/funcional con Playwright mockeando sesion Supabase en 320 px y 1280 px OK: TopBar visible, boton tactil, modal, validacion y submit sin `user_agent`.
+
+## Memoria
+
+No aplica por ahora.

--- a/docs/project/plans/CURRENT_PLAN.md
+++ b/docs/project/plans/CURRENT_PLAN.md
@@ -18,11 +18,11 @@ generated: false
 
 ## Foco actual
 
-Beta 17 queda activa para capturar feedback cualitativo con un formulario simple propio, limitada a [[../issues/CACH-0052|CACH-0052]].
+Beta 17 queda cerrada con feedback cualitativo simple propio en Supabase. No hay release activa.
 
 ## Release activa
 
-Release activa: [[../releases/RELEASE-0.1.0-beta.17|RELEASE-0.1.0-beta.17]] — Feedback simple beta.
+No hay release activa.
 
 Últimos cortes:
 
@@ -43,12 +43,12 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 - Beta 14 cierra `CACH-B0020`: email/DNS/Brevo/Supabase SMTP definitivo con `caches.es`.
 - Beta 15 cierra `CACH-0051`: dominio publico canonico `app.caches.es`, Vercel, Supabase Auth redirects y Edge Function `APP_URL`.
 - Beta 16 cierra `CACH-0042`: racionalizar navegacion inferior movil.
-- Beta 17 queda activa para `CACH-0052`: feedback simple propio en Supabase y PostHog diferido.
+- Beta 17 cierra `CACH-0052`: feedback simple propio en Supabase y PostHog diferido.
 
 ## Prioridades
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
-2. Mantener beta 17 acotada a feedback cualitativo simple.
+2. Mantener el feedback beta simple antes de introducir analitica de producto.
 3. No introducir PostHog, Plausible ni analitica de eventos sin issue/ADR posterior.
 
 ## Plan operativo
@@ -62,7 +62,7 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 
 ## Próximo checkpoint
 
-Implementar [[../issues/CACH-0052|CACH-0052]] desde `release/0.1.0-beta.17`, validar lint/build/Product Brain y revisar boton/modal en mobile y desktop.
+Aplicar la migracion remota de Supabase de beta 17 solo con confirmacion humana explicita, y elegir el siguiente corte cuando haga falta.
 
 ## Siguiente release candidata
 

--- a/docs/project/plans/CURRENT_PLAN.md
+++ b/docs/project/plans/CURRENT_PLAN.md
@@ -5,7 +5,7 @@ id: PB-CURRENT-PLAN
 title: Current Plan
 lifecycle: active
 created: '2026-05-05'
-updated: '2026-05-10'
+updated: '2026-05-11'
 aliases:
   - Current Plan
 tags:
@@ -18,11 +18,11 @@ generated: false
 
 ## Foco actual
 
-Beta 16 queda activa para retomar navegacion movil como slice pequeno y verificable, limitada a [[../issues/CACH-0042|CACH-0042]].
+Beta 17 queda activa para capturar feedback cualitativo con un formulario simple propio, limitada a [[../issues/CACH-0052|CACH-0052]].
 
 ## Release activa
 
-Release activa: [[../releases/RELEASE-0.1.0-beta.16|RELEASE-0.1.0-beta.16]] — Navegación inferior móvil.
+Release activa: [[../releases/RELEASE-0.1.0-beta.17|RELEASE-0.1.0-beta.17]] — Feedback simple beta.
 
 Últimos cortes:
 
@@ -42,13 +42,14 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 - Beta 13 vuelve a ser un corte normal de desarrollo: `CACH-0041` simplifica el dashboard movil y estado "Ahora".
 - Beta 14 cierra `CACH-B0020`: email/DNS/Brevo/Supabase SMTP definitivo con `caches.es`.
 - Beta 15 cierra `CACH-0051`: dominio publico canonico `app.caches.es`, Vercel, Supabase Auth redirects y Edge Function `APP_URL`.
-- Beta 16 queda activa para `CACH-0042`: racionalizar navegacion inferior movil.
+- Beta 16 cierra `CACH-0042`: racionalizar navegacion inferior movil.
+- Beta 17 queda activa para `CACH-0052`: feedback simple propio en Supabase y PostHog diferido.
 
 ## Prioridades
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
-2. Mantener beta 16 acotada a navegacion inferior movil.
-3. No mezclar rediseño Lovable ni cambios de rutas/schema salvo decision explicita posterior.
+2. Mantener beta 17 acotada a feedback cualitativo simple.
+3. No introducir PostHog, Plausible ni analitica de eventos sin issue/ADR posterior.
 
 ## Plan operativo
 
@@ -61,8 +62,8 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 
 ## Próximo checkpoint
 
-Implementar [[../issues/CACH-0042|CACH-0042]] desde `feat/CACH-0042-bottom-navigation`, validar lint/build y revisar mobile en 320, 375, 390 y 768 px.
+Implementar [[../issues/CACH-0052|CACH-0052]] desde `release/0.1.0-beta.17`, validar lint/build/Product Brain y revisar boton/modal en mobile y desktop.
 
 ## Siguiente release candidata
 
-Tras beta 16, elegir el siguiente corte segun resultado de navegacion movil y estado del rediseño Lovable.
+Tras beta 17, evaluar si basta el feedback propio o si conviene abrir una ADR/issue especifica para PostHog con region UE y consentimiento explicito.

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -13,17 +13,17 @@ tags:
   - release
   - current
 generated: false
-release_current: true
+release_current: false
 ---
 # Current Release
 
 ## Release activa
 
-[[RELEASE-0.1.0-beta.17|RELEASE-0.1.0-beta.17]] — Feedback simple beta.
+No hay release activa.
 
 ## Rama activa
 
-`release/0.1.0-beta.17`
+No aplica.
 
 ## Últimos cortes
 
@@ -39,9 +39,11 @@ release_current: true
 
 `RELEASE-0.1.0-beta.16` — navegacion inferior movil. Ver [[RELEASE-0.1.0-beta.16]].
 
+`RELEASE-0.1.0-beta.17` — feedback simple beta. Ver [[RELEASE-0.1.0-beta.17]].
+
 ## Scope actual
 
-Beta 17 queda activa para capturar feedback cualitativo desde la app con formulario propio en Supabase, sin PostHog, Plausible ni analitica de eventos.
+Beta 17 queda cerrada. La app incorpora un formulario global de feedback propio en Supabase, sin PostHog, Plausible ni analitica de eventos.
 
 Issues incluidas:
 
@@ -49,8 +51,8 @@ Issues incluidas:
 
 ## Regla de trabajo para esta release
 
-Mantener el corte acotado a feedback cualitativo simple y hardening de RLS. Cualquier analitica de producto, PostHog o dashboard de metricas requiere issue/ADR propia posterior.
+No iniciar trabajo nuevo desde una release activa hasta activar explicitamente el siguiente corte.
 
 ## Como cerrar esta release
 
-Abrir PR `release/0.1.0-beta.17` -> `main`, validar CI, mergear, crear tag `v0.1.0-beta.17` si aplica y verificar produccion en `https://app.caches.es`.
+Cerrada mediante PR #99. Tag `v0.1.0-beta.17` y smoke de produccion sobre `https://app.caches.es` tras merge a `main`. La migracion remota de Supabase queda pendiente de confirmacion humana explicita.

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -5,7 +5,7 @@ id: PB-CURRENT-RELEASE
 title: Current Release
 lifecycle: active
 created: '2026-05-05'
-updated: '2026-05-10'
+updated: '2026-05-11'
 aliases:
   - Current Release
 tags:
@@ -13,17 +13,17 @@ tags:
   - release
   - current
 generated: false
-release_current: false
+release_current: true
 ---
 # Current Release
 
 ## Release activa
 
-No hay release activa.
+[[RELEASE-0.1.0-beta.17|RELEASE-0.1.0-beta.17]] — Feedback simple beta.
 
 ## Rama activa
 
-No aplica.
+`release/0.1.0-beta.17`
 
 ## Últimos cortes
 
@@ -41,16 +41,16 @@ No aplica.
 
 ## Scope actual
 
-Beta 16 queda cerrada. La navegacion inferior movil se racionaliza con accesos a Trabajos, Inicio, Agenda, Plan, Datos y Ajustes; la barra cabe en 320 px y mantiene targets tactiles razonables.
+Beta 17 queda activa para capturar feedback cualitativo desde la app con formulario propio en Supabase, sin PostHog, Plausible ni analitica de eventos.
 
-Issues cerradas:
+Issues incluidas:
 
-- [[../issues/CACH-0042|CACH-0042]] — Racionalizar navegacion inferior.
+- [[../issues/CACH-0052|CACH-0052]] — Formulario simple de feedback beta.
 
 ## Regla de trabajo para esta release
 
-No iniciar trabajo nuevo desde una release activa hasta activar explicitamente el siguiente corte.
+Mantener el corte acotado a feedback cualitativo simple y hardening de RLS. Cualquier analitica de producto, PostHog o dashboard de metricas requiere issue/ADR propia posterior.
 
 ## Como cerrar esta release
 
-Cerrada mediante PR #98, tag `v0.1.0-beta.16` y smoke de produccion sobre `https://app.caches.es`.
+Abrir PR `release/0.1.0-beta.17` -> `main`, validar CI, mergear, crear tag `v0.1.0-beta.17` si aplica y verificar produccion en `https://app.caches.es`.

--- a/docs/project/releases/RELEASE-0.1.0-beta.17.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.17.md
@@ -1,0 +1,144 @@
+---
+schema_version: 2
+kind: release
+id: RELEASE-0.1.0-beta.17
+title: Feedback simple beta
+lifecycle: active
+created: '2026-05-11'
+updated: '2026-05-11'
+aliases:
+  - RELEASE-0.1.0-beta.17
+tags:
+  - product-brain
+  - release
+  - beta
+  - feedback
+generated: false
+release_phase: active
+release_current: true
+release_branch: release/0.1.0-beta.17
+release_tag: null
+release_pr: null
+---
+# RELEASE-0.1.0-beta.17 — Feedback simple beta
+
+## Estado
+
+Active.
+
+## Rama de release
+
+`release/0.1.0-beta.17`
+
+## Ciclo
+
+`0.1` es el ciclo organizativo. `0.1.0-beta.17` es un corte pequeno para abrir una via de feedback cualitativo dentro de la app.
+
+## Objetivo de la release
+
+Permitir que usuarios de beta envien feedback desde Cachés sin introducir analitica externa ni proveedores nuevos.
+
+## Alcance funcional
+
+- Formulario global de feedback desde la TopBar.
+- Comentario obligatorio, area opcional y consentimiento explicito.
+- Persistencia en la tabla propia `feedback` de Supabase.
+- RLS endurecida para insercion autenticada propia.
+- Decision documentada: PostHog queda diferido a una release futura si hace falta analitica real.
+
+## Scope
+
+- [[../issues/CACH-0052|CACH-0052]] — Formulario simple de feedback beta.
+
+## Issues incluidas
+
+| Issue | Titulo | Workflow | Rama |
+|---|---|---|---|
+| [[../issues/CACH-0052|CACH-0052]] | Formulario simple de feedback beta | done | `release/0.1.0-beta.17` |
+
+## Fuera de alcance
+
+- PostHog SDK.
+- Plausible.
+- Tabla `usage_events`.
+- Dashboard interno de metricas.
+- Session replay, heatmaps, autocapture o tracking de navegacion.
+
+## Riesgos
+
+- La TopBar puede quedar justa en 320 px si el boton global compite con titulo y salida.
+- La politica de RLS debe impedir inserts anonimos y spoofing de `user_id`.
+- El texto libre puede contener datos sensibles si la UI no advierte de forma clara.
+
+## Decisiones relacionadas
+
+- [[../decisions/ADR-0015-feedback-simple-posthog-futuro|ADR-0015]] — Feedback simple propio y PostHog diferido.
+
+## Checklist de entrada
+
+- [x] Release creada
+- [x] Rama de release definida
+- [x] Issues asociadas
+- [x] Alcance definido
+- [x] Criterios de validacion definidos
+
+## Checklist de desarrollo
+
+- [x] Todas las issues estan cerradas o listas para release
+- [ ] Commits integrados en rama release
+- [ ] No hay cambios sueltos fuera de release
+- [ ] No hay issues sin `issue_workflow`
+- [x] No hay decisiones importantes sin documentar
+
+## Checklist de estabilizacion
+
+- [x] `npm run lint`
+- [x] `npm run test`
+- [x] `npm run build`
+- [x] `npm run pb:check`
+- [x] `npm run pb:guard`
+- [x] Revision responsive del boton/modal en mobile y desktop
+- [x] Revision RLS de la migracion local
+
+## Checklist de salida
+
+- [ ] PR `release/0.1.0-beta.17` -> `main` abierta
+- [ ] CI en verde
+- [ ] PR mergeada en `main`
+- [ ] Tag creado desde `main` si aplica
+- [ ] Produccion verificada o marcada no aplica
+- [ ] Rama remota `release/0.1.0-beta.17` eliminada si aplica
+- [ ] Release notes actualizadas
+- [x] Issues marcadas como `done`
+- [ ] Estado actual actualizado
+- [ ] Backlog actualizado
+- [ ] Proximos pasos documentados
+
+## Release notes
+
+### Aniadido
+
+- Boton global de feedback y modal para enviar comentarios de beta.
+
+### Cambiado
+
+- El feedback propio queda endurecido para inserts autenticados con consentimiento.
+
+### Corregido
+
+- No aplica por ahora.
+
+### Eliminado
+
+- Comentario pendiente de Plausible en `index.html`.
+
+### Tecnico
+
+- `CACH-0052` se implementa como scope unico de `RELEASE-0.1.0-beta.17`.
+- PostHog queda fuera del bundle y documentado como migracion futura.
+- Validacion local completada: lint, tests, build, Product Brain, release status y diff check.
+- Smoke visual/funcional con Playwright en 320 px y 1280 px usando sesion Supabase mockeada.
+
+## Resultado final
+
+Pendiente hasta cerrar la release.

--- a/docs/project/releases/RELEASE-0.1.0-beta.17.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.17.md
@@ -14,17 +14,17 @@ tags:
   - beta
   - feedback
 generated: false
-release_phase: active
-release_current: true
+release_phase: released
+release_current: false
 release_branch: release/0.1.0-beta.17
-release_tag: null
+release_tag: v0.1.0-beta.17
 release_pr: https://github.com/dignacioconde/culturApp/pull/99
 ---
 # RELEASE-0.1.0-beta.17 — Feedback simple beta
 
 ## Estado
 
-Active.
+Released.
 
 ## Rama de release
 
@@ -85,9 +85,9 @@ Permitir que usuarios de beta envien feedback desde Cachés sin introducir anali
 ## Checklist de desarrollo
 
 - [x] Todas las issues estan cerradas o listas para release
-- [ ] Commits integrados en rama release
-- [ ] No hay cambios sueltos fuera de release
-- [ ] No hay issues sin `issue_workflow`
+- [x] Commits integrados en rama release
+- [x] No hay cambios sueltos fuera de release
+- [x] No hay issues sin `issue_workflow`
 - [x] No hay decisiones importantes sin documentar
 
 ## Checklist de estabilizacion
@@ -103,12 +103,12 @@ Permitir que usuarios de beta envien feedback desde Cachés sin introducir anali
 ## Checklist de salida
 
 - [x] PR `release/0.1.0-beta.17` -> `main` abierta
-- [ ] CI en verde
-- [ ] PR mergeada en `main`
-- [ ] Tag creado desde `main` si aplica
-- [ ] Produccion verificada o marcada no aplica
-- [ ] Rama remota `release/0.1.0-beta.17` eliminada si aplica
-- [ ] Release notes actualizadas
+- [x] CI en verde
+- [x] PR mergeada en `main`
+- [x] Tag creado desde `main` si aplica
+- [x] Produccion verificada
+- [x] Rama remota `release/0.1.0-beta.17` conservada para trazabilidad local/remota
+- [x] Release notes actualizadas
 - [x] Issues marcadas como `done`
 - [ ] Estado actual actualizado
 - [ ] Backlog actualizado
@@ -139,7 +139,9 @@ Permitir que usuarios de beta envien feedback desde Cachés sin introducir anali
 - Validacion local completada: lint, tests, build, Product Brain, release status y diff check.
 - Smoke visual/funcional con Playwright en 320 px y 1280 px usando sesion Supabase mockeada.
 - PR #99 abierta hacia `main`.
+- GitHub PR #99 con `app`, `e2e`, Vercel Preview y Vercel Preview Comments en verde.
+- La migracion Supabase queda versionada en `supabase/migrations/20260511110000_feedback_authenticated_rls.sql`; aplicarla en remoto requiere confirmacion humana explicita.
 
 ## Resultado final
 
-Pendiente hasta cerrar la release.
+Release cerrada mediante PR #99. Tag `v0.1.0-beta.17` creado desde `main`; produccion verificada en `https://app.caches.es` con smoke de rutas SPA. La prueba auth/CRUD queda saltada sin `SMOKE_EMAIL`/`SMOKE_PASSWORD`; la migracion remota de Supabase queda pendiente de aplicacion confirmada.

--- a/docs/project/releases/RELEASE-0.1.0-beta.17.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.17.md
@@ -18,7 +18,7 @@ release_phase: active
 release_current: true
 release_branch: release/0.1.0-beta.17
 release_tag: null
-release_pr: null
+release_pr: https://github.com/dignacioconde/culturApp/pull/99
 ---
 # RELEASE-0.1.0-beta.17 — Feedback simple beta
 
@@ -102,7 +102,7 @@ Permitir que usuarios de beta envien feedback desde Cachés sin introducir anali
 
 ## Checklist de salida
 
-- [ ] PR `release/0.1.0-beta.17` -> `main` abierta
+- [x] PR `release/0.1.0-beta.17` -> `main` abierta
 - [ ] CI en verde
 - [ ] PR mergeada en `main`
 - [ ] Tag creado desde `main` si aplica
@@ -138,6 +138,7 @@ Permitir que usuarios de beta envien feedback desde Cachés sin introducir anali
 - PostHog queda fuera del bundle y documentado como migracion futura.
 - Validacion local completada: lint, tests, build, Product Brain, release status y diff check.
 - Smoke visual/funcional con Playwright en 320 px y 1280 px usando sesion Supabase mockeada.
+- PR #99 abierta hacia `main`.
 
 ## Resultado final
 

--- a/index.html
+++ b/index.html
@@ -8,9 +8,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Instrument+Sans:wght@400;500;600&family=DM+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
-    <!-- TODO(CACH-B0016): activar Plausible al lanzar beta privada. Cookieless,
-         EU-hosted, sin banner de consentimiento necesario. -->
-    <!-- <script defer data-domain="caches.es" src="https://plausible.io/js/script.js"></script> -->
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/layout/FeedbackDialog.jsx
+++ b/src/components/layout/FeedbackDialog.jsx
@@ -1,0 +1,127 @@
+import { useId, useState } from 'react'
+import { Button } from '../ui/Button'
+import { Modal } from '../ui/Modal'
+import { Select, Textarea } from '../ui/Input'
+import { useFeedback } from '../../hooks/useFeedback'
+
+const feedbackAreaOptions = [
+  { value: '', label: 'General' },
+  { value: 'trabajos', label: 'Trabajos' },
+  { value: 'agenda', label: 'Agenda' },
+  { value: 'finanzas', label: 'Finanzas' },
+  { value: 'ajustes', label: 'Ajustes' },
+  { value: 'datos', label: 'Datos' },
+]
+
+export function FeedbackDialog({ isOpen, onClose, userId, onSubmitted }) {
+  const consentId = useId()
+  const consentErrorId = `${consentId}-error`
+  const [message, setMessage] = useState('')
+  const [area, setArea] = useState('')
+  const [consentGiven, setConsentGiven] = useState(false)
+  const [messageError, setMessageError] = useState('')
+  const [consentError, setConsentError] = useState('')
+  const [formError, setFormError] = useState('')
+  const { submitFeedback, submitting } = useFeedback(userId)
+
+  const resetForm = () => {
+    setMessage('')
+    setArea('')
+    setConsentGiven(false)
+    setMessageError('')
+    setConsentError('')
+    setFormError('')
+  }
+
+  const handleClose = () => {
+    resetForm()
+    onClose()
+  }
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    const trimmedMessage = message.trim()
+    const nextMessageError = trimmedMessage ? '' : 'Escribe al menos una frase.'
+    const nextConsentError = consentGiven ? '' : 'Acepta el consentimiento para enviar el feedback.'
+
+    setMessageError(nextMessageError)
+    setConsentError(nextConsentError)
+    setFormError('')
+
+    if (nextMessageError || nextConsentError) return
+
+    const { error } = await submitFeedback({
+      message: trimmedMessage,
+      area,
+      consentGiven,
+    })
+
+    if (error) {
+      setFormError('No hemos podido enviar el feedback. Vuelve a intentarlo.')
+      return
+    }
+
+    onSubmitted?.()
+    handleClose()
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} title="Cuéntanos qué mejorar">
+      <form className="flex flex-col gap-4" onSubmit={handleSubmit} noValidate>
+        <Select label="Área" name="area" value={area} onChange={(event) => setArea(event.target.value)}>
+          {feedbackAreaOptions.map((option) => (
+            <option key={option.value} value={option.value}>{option.label}</option>
+          ))}
+        </Select>
+
+        <Textarea
+          label="Tu comentario *"
+          name="message"
+          value={message}
+          onChange={(event) => {
+            setMessage(event.target.value)
+            setMessageError('')
+            setFormError('')
+          }}
+          maxLength={4000}
+          rows={5}
+          required
+          error={messageError}
+          placeholder="Qué te ha frenado, qué echas en falta o qué deberíamos pulir."
+          className="min-h-36"
+        />
+
+        <label className="flex items-start gap-3 rounded-lg border border-[var(--color-paper-mid)] bg-[#FDFBF6] p-4 text-sm text-[var(--color-ink)]">
+          <input
+            id={consentId}
+            type="checkbox"
+            checked={consentGiven}
+            onChange={(event) => {
+              setConsentGiven(event.target.checked)
+              setConsentError('')
+              setFormError('')
+            }}
+            aria-describedby={consentError ? consentErrorId : undefined}
+            className="mt-1 h-5 w-5 shrink-0 rounded border-[var(--color-paper-mid)] accent-[var(--color-red)]"
+          />
+          <span className="min-w-0">
+            <span className="block font-medium">Acepto enviar este comentario para mejorar la beta.</span>
+            <span className="mt-1 block text-[var(--color-ink-muted)]">No incluyas datos sensibles de clientes.</span>
+            {consentError && <span id={consentErrorId} className="mt-2 block text-xs font-medium text-red-600">{consentError}</span>}
+          </span>
+        </label>
+
+        {formError && <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{formError}</p>}
+
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button type="button" variant="secondary" onClick={handleClose} disabled={submitting} className="justify-center">
+            Cancelar
+          </Button>
+          <Button type="submit" disabled={submitting} className="justify-center">
+            {submitting ? 'Enviando...' : 'Enviar feedback'}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  )
+}

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -1,40 +1,63 @@
+import { useState } from 'react'
 import { useAuth } from '../../hooks/useAuth'
-import { Drama, LogOut, User, Menu } from 'lucide-react'
+import { Drama, LogOut, User, Menu, MessageSquare } from 'lucide-react'
+import { ToastContainer, useToast } from '../ui/Toast'
+import { FeedbackDialog } from './FeedbackDialog'
 
 export function TopBar({ title, onMenuClick, showMenuButton }) {
   const { user, signOut } = useAuth()
+  const [isFeedbackOpen, setIsFeedbackOpen] = useState(false)
+  const { toasts, addToast, removeToast } = useToast()
 
   return (
-    <header className="flex min-h-16 items-center justify-between gap-4 border-b border-[#E2D9C2] bg-[#F5EFE0] px-4 py-3 sm:px-6">
-      <div className="flex min-w-0 items-center gap-2">
-        {showMenuButton && (
+    <>
+      <header className="flex min-h-16 items-center justify-between gap-4 border-b border-[#E2D9C2] bg-[#F5EFE0] px-4 py-3 sm:px-6">
+        <div className="flex min-w-0 items-center gap-2">
+          {showMenuButton && (
+            <button
+              type="button"
+              onClick={onMenuClick}
+              className="flex lg:hidden items-center justify-center p-2 -ml-2 rounded-lg text-[#5C5149] hover:bg-[#EBE3CE] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035]"
+              aria-label="Abrir menú de navegación"
+            >
+              <Menu size={24} />
+            </button>
+          )}
+          <Drama size={28} strokeWidth={1.5} className="hidden sm:block text-[#C94035]" />
+          <h1 className="min-w-0 truncate text-lg font-semibold leading-7 text-[#211C18] font-['DM_Serif_Display']">{title}</h1>
+        </div>
+        <div className="flex min-w-0 shrink-0 items-center gap-1 sm:gap-2">
           <button
             type="button"
-            onClick={onMenuClick}
-            className="flex lg:hidden items-center justify-center p-2 -ml-2 rounded-lg text-[#5C5149] hover:bg-[#EBE3CE] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035]"
-            aria-label="Abrir menú de navegación"
+            onClick={() => setIsFeedbackOpen(true)}
+            className="inline-flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg text-sm font-medium text-[#5C5149] transition-colors hover:bg-[#EBE3CE] hover:text-[#211C18] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2 md:w-auto md:px-3"
+            aria-label="Enviar feedback"
           >
-            <Menu size={24} />
+            <MessageSquare size={16} className="shrink-0" />
+            <span className="hidden md:inline">Feedback</span>
           </button>
-        )}
-        <Drama size={28} strokeWidth={1.5} className="hidden sm:block text-[#C94035]" />
-        <h1 className="min-w-0 truncate text-lg font-semibold leading-7 text-[#211C18] font-['DM_Serif_Display']">{title}</h1>
-      </div>
-      <div className="flex min-w-0 shrink-0 items-center gap-2 sm:gap-3">
-        <div className="hidden min-w-0 items-center gap-2 rounded-lg bg-[#EBE3CE] px-3 py-2 text-sm text-[#5C5149] ring-1 ring-inset ring-[#E2D9C2] sm:flex">
-          <User size={16} className="shrink-0 text-[#5C5149]" />
-          <span className="max-w-48 truncate">{user?.email}</span>
+          <div className="hidden min-w-0 items-center gap-2 rounded-lg bg-[#EBE3CE] px-3 py-2 text-sm text-[#5C5149] ring-1 ring-inset ring-[#E2D9C2] sm:flex">
+            <User size={16} className="shrink-0 text-[#5C5149]" />
+            <span className="max-w-48 truncate">{user?.email}</span>
+          </div>
+          <button
+            type="button"
+            onClick={signOut}
+            className="inline-flex h-10 shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg px-2 text-sm font-medium text-[#5C5149] transition-colors hover:bg-[#EBE3CE] hover:text-[#211C18] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2 sm:px-3"
+          >
+            <LogOut size={16} className="shrink-0" />
+            <span className="hidden sm:inline">Salir</span>
+            <span className="sr-only sm:hidden">Salir</span>
+          </button>
         </div>
-        <button
-          type="button"
-          onClick={signOut}
-          className="inline-flex h-10 shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg px-3 text-sm font-medium text-[#5C5149] transition-colors hover:bg-[#EBE3CE] hover:text-[#211C18] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2"
-        >
-          <LogOut size={16} className="shrink-0" />
-          <span className="hidden sm:inline">Salir</span>
-          <span className="sr-only sm:hidden">Salir</span>
-        </button>
-      </div>
-    </header>
+      </header>
+      <FeedbackDialog
+        isOpen={isFeedbackOpen}
+        onClose={() => setIsFeedbackOpen(false)}
+        userId={user?.id}
+        onSubmitted={() => addToast('Gracias, lo revisamos para la beta.')}
+      />
+      <ToastContainer toasts={toasts} onRemove={removeToast} />
+    </>
   )
 }

--- a/src/hooks/useFeedback.js
+++ b/src/hooks/useFeedback.js
@@ -1,0 +1,50 @@
+import { useCallback, useState } from 'react'
+import { submitFeedback as insertFeedback } from '../lib/feedback'
+
+export function useFeedback(userId) {
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState(null)
+
+  const submitFeedback = useCallback(async ({ message, area, consentGiven }) => {
+    const trimmedMessage = message.trim()
+
+    if (!userId) {
+      const authError = new Error('Necesitas iniciar sesión para enviar feedback.')
+      setError(authError)
+      return { error: authError }
+    }
+
+    if (!trimmedMessage) {
+      const validationError = new Error('Escribe al menos una frase.')
+      setError(validationError)
+      return { error: validationError }
+    }
+
+    if (!consentGiven) {
+      const consentError = new Error('Necesitamos tu consentimiento para guardar el feedback.')
+      setError(consentError)
+      return { error: consentError }
+    }
+
+    setSubmitting(true)
+    setError(null)
+
+    try {
+      await insertFeedback({
+        message: trimmedMessage,
+        area: area || null,
+        source: 'widget',
+        userId,
+        consent_given: true,
+      })
+      return { error: null }
+    } catch (nextError) {
+      setError(nextError)
+      return { error: nextError }
+    } finally {
+      setSubmitting(false)
+    }
+  }, [userId])
+
+  return { submitFeedback, submitting, error }
+}

--- a/src/lib/feedback.ts
+++ b/src/lib/feedback.ts
@@ -5,12 +5,11 @@ export type FeedbackSeverity = 'low' | 'medium' | 'high'
 
 export type FeedbackPayload = {
   message: string
-  consent_given: boolean
+  consent_given: true
+  userId: string
   source?: FeedbackSource
   severity?: FeedbackSeverity
-  area?: string
-  user_agent?: string
-  user_id?: string | null
+  area?: string | null
 }
 
 export async function submitFeedback(payload: FeedbackPayload) {
@@ -21,8 +20,7 @@ export async function submitFeedback(payload: FeedbackPayload) {
       severity: payload.severity ?? null,
       area: payload.area ?? null,
       message: payload.message,
-      user_agent: payload.user_agent ?? (typeof navigator !== 'undefined' ? navigator.userAgent : null),
-      user_id: payload.user_id ?? null,
+      user_id: payload.userId,
       consent_given: payload.consent_given,
     })
 

--- a/supabase/migrations/20260511110000_feedback_authenticated_rls.sql
+++ b/supabase/migrations/20260511110000_feedback_authenticated_rls.sql
@@ -1,0 +1,12 @@
+drop policy if exists feedback_insert_with_consent on public.feedback;
+drop policy if exists feedback_insert_authenticated_own_user on public.feedback;
+
+create policy feedback_insert_authenticated_own_user on public.feedback
+  for insert to authenticated
+  with check (
+    consent_given = true
+    and user_id = auth.uid()
+  );
+
+comment on table public.feedback is
+  'Beta feedback captured from authenticated users with explicit consent. No anon/authenticated SELECT policy by design.';


### PR DESCRIPTION
## Summary

CACH-0052 — [Feedback] Formulario simple de feedback beta

Implementado para `RELEASE-0.1.0-beta.17`. La release anade el formulario global de feedback, el hook de envio, elimina el snippet comentado de Plausible y endurece la politica de insert de la tabla `feedback`.

## Product Brain

- Issue: `CACH-0052`
- Parent: no aplica
- Release: `RELEASE-0.1.0-beta.17`
- Base: `origin/main`

## Validation

- `npm run lint`
- `npm run build`
- `npm run test`
- `npm run pb:check`
- `npm run pb:guard`
- Revision responsive manual del boton/modal en ancho movil y desktop.
- Revision RLS de la migracion local.

## Deploy

- Preview/produccion: Vercel preview en PR; producción requiere merge a main, aplicar migración Supabase y smoke posterior.
- Produccion requiere merge a `main` y smoke posterior si el cambio debe verse publicado.

## Memory

Memoria: no aplica