### PR TITLE
[codex] Add lightweight Product Brain SDD review

### DIFF
--- a/.agents/skills/product-brain-sdd-review/SKILL.md
+++ b/.agents/skills/product-brain-sdd-review/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: product-brain-sdd-review
+description: Review Product Brain CACH issues for lightweight spec-driven readiness before implementation. Use when asked for SDD review, spec readiness, issue readiness, requirements-to-validation traceability, or avoiding Product Brain token dump. Do not use to create issues, edit docs, implement code, or replace pb:ready-check.
+---
+
+# Product Brain SDD Review
+
+## Purpose
+
+Review whether a Product Brain issue is executable as a lightweight spec without turning Caches into a heavy spec framework.
+
+This skill is read-only by default. It checks semantic readiness: observable requirements, bounded scope, enough technical design for risky work, derivable tasks, validation traceability, and low risk of stale duplicated context.
+
+## When to use this skill
+
+- The user asks for "SDD review", "spec review", "ready review", "revisa si esta issue esta ready", or "comprueba trazabilidad requisitos-pruebas".
+- A `CACH-*` issue is about to move to `issue_workflow: ready`.
+- A feature, bug, or slice looks ambiguous even though `pb:ready-check` passes structurally.
+- A planner draft needs a quality pass before agents implement it.
+- You need to decide whether an idea should become a slice, spike, ADR, or stay in backlog.
+
+## When not to use this skill
+
+- Do not use for Product Brain orientation only; use `product-brain-orient`.
+- Do not use for capture or issue creation; use `product-brain-capture` or `cultura-issue-launch`.
+- Do not use for code review after implementation; use `cultura-code-review`.
+- Do not use for visual/frontend, data/finance, security, or release verification when a narrower review skill owns the work.
+- Do not use to require heavy SDD artifacts such as `.specify/`, generated task folders, or framework-specific documents.
+
+## Inputs to inspect
+
+- `AGENTS.md`
+- `docs/agent-context-policy.md`
+- `.memory/MEMORY.md`
+- `npm run pb:orient -- --json`
+- The target `docs/project/issues/CACH-*.md`
+- Parent initiative, release document, ADRs, or source touchpoints only when referenced by the issue or needed to judge readiness.
+- `docs/project/process/definition-of-ready.md`
+- `docs/project/process/definition-of-done.md`
+- `docs/project/templates/ISSUE_TEMPLATE.md`
+- `scripts/brain/ready-check.mjs` when checking script-backed gates.
+
+## Procedure
+
+1. Orient with `npm run pb:orient -- --json` unless the relevant issue context is already present.
+2. Load only the target issue and directly referenced parent, release, ADRs, or source touchpoints.
+3. Run or mentally apply `pb:ready-check` rules: ready workflow, non-initiative work level, objective, scope, checklist criteria, validation, components, and valid parent.
+4. Judge requirements:
+   - Criteria describe observable behavior or user-visible/system-visible outcomes.
+   - Criteria avoid placeholders, generic "works correctly" wording, and implementation-only chores without value.
+   - For `feature` and `bug`, prefer scenario language such as `Cuando... entonces...` or `WHEN... THEN...` when it clarifies behavior, but do not require it mechanically.
+5. Judge design sufficiency:
+   - `size: xs` can stay lightweight.
+   - `size: m`, `area: data|security|infra`, components `finance|supabase|auth-onboarding`, or multi-component work should include a short `Plan tecnico` or equivalent notes.
+   - The plan should name contracts, hooks, migrations, APIs, UX states, or affected modules when relevant, without freezing unnecessary implementation details.
+6. Judge task derivability:
+   - An implementer can identify the first files/modules to inspect.
+   - Dependencies, blockers, and out-of-scope items are explicit enough to avoid scope creep.
+   - Initiatives are not treated as executable; recommend a slice when needed.
+7. Judge validation and traceability:
+   - Each important criterion has a plausible automated, browser, manual, SQL/RLS, or review check.
+   - Validation is specific to the domain, not only generic `lint/build`.
+   - Close evidence should be possible without rewriting the spec after the fact.
+8. Judge drift and token discipline:
+   - The issue references ADRs, memory, source touchpoints, or process docs instead of copying long global rules.
+   - The issue is small enough for one focused implementation pass.
+   - No stale historical context is required to understand the executable work.
+9. Return a readiness verdict with the smallest changes that would make the issue executable.
+
+## Output format
+
+```markdown
+Verdict: Ready | Ready with risks | Not ready
+
+Gaps:
+- Requisitos: ...
+- Diseno tecnico: ...
+- Tareas derivables: ...
+- Validacion/trazabilidad: ...
+- Drift/token dump: ...
+
+Cambios minimos sugeridos:
+- ...
+
+Checks PB:
+- `npm run pb:ready-check -- CACH-XXXX`: run/skip + motivo
+- `npm run pb:guard`: run/skip + motivo
+
+Decision:
+- Implementable now / create slice / create spike / create ADR / keep in backlog
+
+Contexto leido:
+Product Brain leido:
+Product Brain actualizado:
+Validacion PB:
+Feedback/Memory:
+```
+
+Use `No gaps relevantes` for categories that are clean.
+
+## Severity / priority model
+
+- CRITICAL: issue would cause unsafe data access, auth/RLS/privacy risk, production mutation, or destructive action without explicit confirmation.
+- HIGH: not executable, missing clear user/system outcome, missing required technical plan, or validation cannot prove acceptance criteria.
+- MEDIUM: implementable but ambiguous, too broad, weak traceability, or likely to drift from canonical docs.
+- LOW: wording, naming, examples, or minor checklist clarity.
+
+## Quality bar
+
+- The review is short, specific, and actionable.
+- The verdict can be used by `cultura-planner`, `cultura-docs`, `cultura-review`, or `cultura-testing` without another interpretation pass.
+- The suggested changes are smaller than writing a full new spec.
+- The review protects Thin Product Brain: no framework migration, no duplicated global rules, no historical context dump.
+
+## Common mistakes to avoid
+
+- Turning every issue into a long PRD.
+- Requiring `WHEN/THEN` when plain criteria are already observable and testable.
+- Adding a `risk` frontmatter field; use existing `size`, `area`, `components`, ADRs, and validation notes.
+- Duplicating `product-brain-orient`, `cultura-issue-launch`, `cultura-docs`, or code review responsibilities.
+- Treating `pb:ready-check` as semantic proof; it is a structural gate.
+- Rewriting the issue or changing workflow state during a read-only review.
+
+## Safety notes
+
+Do not inspect secrets, `.env.local` values, service role keys, private customer data, or remote production systems. Do not mutate Product Brain, GitHub, Supabase, Vercel, branches, commits, or files unless the user explicitly asks for an implementation task outside this review.
+
+## Product Brain v2 Contract
+
+When this workflow touches Product Brain, use flat v2 frontmatter: `schema_version: 2`, `kind`, `lifecycle`, and domain fields such as `issue_workflow`, `work_type`, `work_level`, `size`, `components`, `parent`, `release`, and `theme`. Do not create new `type/status` top-level Product Brain documents.
+
+Prefer `npm run pb:orient -- --json` before reading Product Brain detail. Read only the related issue, parent, release, ADR or source-touchpoint. Generated files such as `DIGEST.md` and generated indexes are regenerated by scripts, not edited manually.
+
+Close every Product Brain-aware response with: `Contexto leido`, `Product Brain leido`, `Product Brain actualizado`, `Validacion PB`, and `Feedback/Memory`.

--- a/.claude/skills/product-brain-sdd-review
+++ b/.claude/skills/product-brain-sdd-review
@@ -1,0 +1,1 @@
+../../.agents/skills/product-brain-sdd-review

--- a/.memory/topics/portable-skills.md
+++ b/.memory/topics/portable-skills.md
@@ -1,15 +1,21 @@
 # Portable Skills Memory
 
+## 2026-05-12 - product-brain-sdd-review: SDD Ligero Sin Agente Nuevo
+
+- Context: Se hizo challenge con agentes docs/testing/review y experto SDD temporal sobre como encajar Product Brain con spec-driven development.
+- Durable memory: no crear agente OpenCode experto en SDD por defecto. Usar la skill portable `product-brain-sdd-review` como compuerta semantica read-only para revisar si una issue CACH es ejecutable: requisitos observables, plan tecnico cuando aplica, tareas derivables, validacion trazable y bajo riesgo de drift/token dump.
+- Source: `.agents/skills/product-brain-sdd-review/SKILL.md`; `docs/agent-skills-strategy.md`; `scripts/brain/ready-check.mjs`.
+
 ## 2026-05-03 - Skills Use A Single Source With Claude Symlinks
 
 - Context: Commit `f542ffa` added portable skills under `.agents/skills/`, `.agents/templates/portable-skill/SKILL.md`, and `.claude/skills/*` symlinks.
 - Durable memory: `.agents/skills/<skill-name>/SKILL.md` is the canonical source; `.claude/skills/<skill-name>` should remain a relative symlink to `../../.agents/skills/<skill-name>`. Do not duplicate skill bodies into `.claude`.
 - Source: `docs/agent-skills-strategy.md`; `README.md`; `TECHDOC.md`; `AGENTS.md`.
 
-## 2026-05-08 - Skill Set Actualizado: 16 Skills Portables
+## 2026-05-08 - Skill Set Actualizado: 17 Skills Portables
 
 - Context: Product Brain v2 consolidó skills de orientación, release, revisión, memoria, contexto y comunicación concisa. `brain-orient` legacy fue sustituido por `product-brain-orient`.
-- Durable memory: las skills canónicas viven en `.agents/skills/` y se exponen como symlinks en `.claude/skills/`. El catálogo actual incluye: `agent-context-maintenance`, `caveman`, `compact-memory`, `cultura-agent-orchestration`, `cultura-code-review`, `cultura-data-finance-review`, `cultura-frontend-review`, `cultura-issue-launch`, `cultura-release-task-flow`, `cultura-security-privacy-review`, `cultura-testing-release-check`, `memory-orient`, `memory-protocol`, `portable-skill-authoring`, `product-brain-capture` y `product-brain-orient`.
+- Durable memory: las skills canónicas viven en `.agents/skills/` y se exponen como symlinks en `.claude/skills/`. El catálogo actual incluye: `agent-context-maintenance`, `caveman`, `compact-memory`, `cultura-agent-orchestration`, `cultura-code-review`, `cultura-data-finance-review`, `cultura-frontend-review`, `cultura-issue-launch`, `cultura-release-task-flow`, `cultura-security-privacy-review`, `cultura-testing-release-check`, `memory-orient`, `memory-protocol`, `portable-skill-authoring`, `product-brain-capture`, `product-brain-orient` y `product-brain-sdd-review`.
 - Source: `docs/agent-skills-strategy.md`; `npm run verify:skills`.
 
 ## 2026-05-07 - cultura-agent-orchestration: Delegación Codex/Claude/OpenCode

--- a/docs/agent-skills-strategy.md
+++ b/docs/agent-skills-strategy.md
@@ -33,6 +33,7 @@ Do not copy the same skill into both `.agents` and `.claude`. If a tool cannot f
 | `cultura-agent-orchestration` | Decide when to use native Codex/Claude subagents, OpenCode agents, parallel review, ownership, and verification. |
 | `product-brain-orient` | Orient agents on Product Brain v2 with `pb:orient` without loading the full Brain. |
 | `product-brain-capture` | Capture ideas, decisions, context, or issue candidates into Product Brain inbox. |
+| `product-brain-sdd-review` | Review CACH issues for lightweight SDD readiness before implementation. |
 | `cultura-issue-launch` | Turn rough work into Product Brain v2 issue context and, in execute mode, branch/agent setup. |
 | `memory-protocol` | File-based Markdown memory for durable agent context, recall, curation, and forgetting. |
 | `memory-orient` | Read only task-relevant memory files before implementation or planning. |
@@ -128,6 +129,7 @@ Validation status for the current setup:
 | `cultura-agent-orchestration` | Valid |
 | `product-brain-orient` | Valid |
 | `product-brain-capture` | Valid |
+| `product-brain-sdd-review` | Valid |
 | `cultura-issue-launch` | Valid |
 | `memory-protocol` | Valid |
 | `memory-orient` | Valid |

--- a/docs/project/templates/ISSUE_TEMPLATE.md
+++ b/docs/project/templates/ISSUE_TEMPLATE.md
@@ -41,11 +41,15 @@ Que esta incluido y que queda fuera.
 
 ## Criterios de aceptacion
 
-- [ ] ...
+- [ ] Criterio observable y verificable desde comportamiento de usuario, sistema o datos.
+
+## Plan tecnico
+
+Solo si aplica: obligatorio para `size: m`, datos/RLS/seguridad/infra, `finance`, `supabase`, `auth-onboarding` o cambios multi-componente. Mantener corto: contratos afectados, hooks/modulos esperados, migraciones, estados UX o riesgos de integracion. No copiar reglas globales ni cerrar una solucion innecesariamente.
 
 ## Validacion
 
-Que comandos o checks se ejecutaran al terminar.
+Checks esperados al terminar. Deben demostrar los criterios de aceptacion y ser especificos del dominio cuando toque datos, seguridad, infra, finanzas, Supabase, calendario o sistema visual.
 
 ## Resultado
 

--- a/scripts/brain/ready-check.mjs
+++ b/scripts/brain/ready-check.mjs
@@ -7,9 +7,59 @@ import { IssueFrontmatter } from './schema.mjs'
 const issueId = process.argv.slice(2).find((arg) => !arg.startsWith('--'))
 const jsonOutput = process.argv.includes('--json')
 const errors = []
+const structuralPlaceholderPattern = /\b(tbd|todo|pendiente|por definir|placeholder)\b|\.{3}|<[^>]+>|Que debe quedar|Que esta incluido|Que comandos o checks|Criterio observable y verificable|Solo si aplica: obligatorio|Checks esperados/i
+const genericCriterionPattern = /^(funciona correctamente|se mejora|mejora general|implementar|hacer|actualizar|validar)$/i
+const riskyAreas = new Set(['data', 'infra', 'security'])
+const technicalPlanComponents = new Set(['finance', 'supabase', 'auth-onboarding'])
+const specificValidationComponents = new Set(['finance', 'supabase', 'calendar', 'design-system'])
+const genericValidationCommands = ['npm run lint', 'npm run build', 'npm run pb:check', 'npm run pb:guard', 'git diff --check']
 
 function fail(message) {
   errors.push(message)
+}
+
+function meaningful(text) {
+  return Boolean(text && !structuralPlaceholderPattern.test(text))
+}
+
+function checklistItems(text) {
+  return text
+    .split('\n')
+    .filter((line) => /^\s*-\s+\[[ xX]\]/.test(line))
+    .map((line) => line.replace(/^\s*-\s+\[[ xX]\]\s*/, '').trim())
+}
+
+function requiresTechnicalPlan(data) {
+  return (
+    data.size === 'm' ||
+    riskyAreas.has(data.area) ||
+    data.components.some((component) => technicalPlanComponents.has(component)) ||
+    data.components.length > 1
+  )
+}
+
+function requiresSpecificValidation(data) {
+  return (
+    ['data', 'infra', 'security'].includes(data.area) ||
+    data.components.some((component) => specificValidationComponents.has(component))
+  )
+}
+
+function hasSpecificValidation(data, validation) {
+  const lines = validation
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) => {
+      const normalized = line.replace(/^-\s*/, '').replace(/`/g, '').replace(/[.;]$/, '').trim()
+      return !genericValidationCommands.some((command) => normalized === command || normalized.startsWith(`${command} `))
+    })
+
+  if (data.components.some((component) => ['calendar', 'design-system'].includes(component))) {
+    return lines.some((line) => /browser|manual|responsive|visual|playwright|viewport|smoke|captura|navegador/i.test(line))
+  }
+
+  return lines.some((line) => !structuralPlaceholderPattern.test(line))
 }
 
 if (!issueId) {
@@ -30,9 +80,21 @@ if (!issueId) {
       if (!hasSection(doc.content, ['Objetivo', 'Summary', 'Problem'])) fail('Falta seccion de objetivo/problema')
       if (!hasSection(doc.content, ['Alcance', 'Scope', 'Proposed Solution'])) fail('Falta seccion de alcance')
       if (!hasSection(doc.content, ['Criterios de aceptacion', 'Criterios de aceptación', 'Acceptance Criteria'])) fail('Falta criterios de aceptacion')
-      if (!/^\s*-\s+\[[ xX]\]/m.test(sectionContent(doc.content, ['Criterios de aceptacion', 'Criterios de aceptación', 'Acceptance Criteria']))) fail('Los criterios deben ser checklist')
+      const criteria = sectionContent(doc.content, ['Criterios de aceptacion', 'Criterios de aceptación', 'Acceptance Criteria'])
+      const items = checklistItems(criteria)
+      if (items.length === 0) fail('Los criterios deben ser checklist')
+      for (const item of items) {
+        if (!meaningful(item) || genericCriterionPattern.test(item)) fail(`Criterio de aceptacion demasiado generico o placeholder: ${item || '(vacio)'}`)
+      }
       const validation = sectionContent(doc.content, ['Validacion', 'Validación'])
-      if (!validation || /pendiente hasta cerrar/i.test(validation)) fail('Validacion debe indicar checks esperados antes de ejecutar')
+      if (!meaningful(validation) || /pendiente hasta cerrar/i.test(validation)) fail('Validacion debe indicar checks esperados antes de ejecutar')
+      if (requiresTechnicalPlan(data)) {
+        const plan = sectionContent(doc.content, ['Plan tecnico', 'Plan técnico', 'Technical Plan', 'Implementation Plan'])
+        if (!meaningful(plan)) fail('Plan tecnico requerido para size m, area/componente de riesgo o trabajo multi-componente')
+      }
+      if (requiresSpecificValidation(data) && !hasSpecificValidation(data, validation)) {
+        fail('Validacion debe incluir checks especificos del dominio, no solo lint/build/pb:check')
+      }
       if (data.components.length === 0) fail('components no puede estar vacio')
       if (data.parent) {
         const docs = readAllDocs()


### PR DESCRIPTION
## Que cambia

- Anade la skill portable `product-brain-sdd-review` y su symlink en `.claude/skills/`.
- Refuerza `ISSUE_TEMPLATE.md` con criterios observables, `Plan tecnico` solo cuando aplica y validacion especifica por dominio.
- Ajusta `pb:ready-check` para detectar placeholders/genericidad, exigir plan tecnico en trabajos de riesgo o multi-componente, y pedir validacion especifica en areas sensibles.
- Actualiza el catalogo de skills y la memoria durable de portable skills.

## Por que

El plan acordado era encajar SDD en Product Brain sin adoptar Spec Kit completo ni crear un agente OpenCode experto todavia. Esta PR introduce una compuerta semantica ligera, read-only y repo-native.

## Impacto

Las issues `xs` siguen siendo ligeras. Las issues `size: m`, de datos/seguridad/infra, finance/Supabase/auth-onboarding o multi-componente necesitan suficiente plan tecnico para ser ejecutables. Areas como data/security/finance/supabase/calendar/design-system necesitan validacion especifica, no solo lint/build.

## Validacion

- `npm run verify:skills`
- `npm run pb:check -- --strict --json`
- `npm run test:brain`
- `npm run lint`
- `npm run pb:guard`
- `git diff --check`
- `npm run verify:pr -- --base origin/main`

## Memoria

Actualizada `.memory/topics/portable-skills.md` con la decision durable: no crear agente SDD nuevo por defecto; usar `product-brain-sdd-review` como compuerta semantica ligera.