### PR TITLE
[codex] add learning loop skill

### DIFF
--- a/.agents/skills/cultura-learning-loop/SKILL.md
+++ b/.agents/skills/cultura-learning-loop/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: cultura-learning-loop
+description: Aprender de una conversación, bug, incidente, revisión o fallo de proceso en CulturaApp; usar cuando el usuario pida "aprende de esto", "reflexiona con agentes", "haz retrospectiva/postmortem", "revisa la conversación y aplica correcciones" o quiera convertir una lección en cambios de proceso, memoria, tests, docs o pequeñas correcciones. No usar para implementación normal sin petición de aprendizaje ni para mutaciones remotas/destructivas sin confirmación.
+---
+
+# Cultura Learning Loop
+
+## Purpose
+
+Convertir una conversación o incidente reciente en aprendizaje operativo para CulturaApp. La skill busca causa raíz, separa hechos de suposiciones, contrasta con agentes cuando procede, y aplica correcciones pequeñas en memoria, Product Brain, proceso, tests o documentación.
+
+El objetivo no es escribir un run log. Es dejar guardrails útiles para que el mismo fallo no se repita.
+
+## When to use this skill
+
+- El usuario pide "aprende de esto", "aprende de la conversación", "reflexiona con agentes" o "revisa la conversación".
+- El usuario pide una retrospectiva, postmortem, análisis de causa raíz o lecciones aprendidas.
+- Una tarea acaba de descubrir un fallo de proceso, verificación, memoria, release, Supabase, seguridad, agentes o documentación.
+- El usuario quiere "aplicar correcciones" tras una conversación, revisión o incidente.
+
+## When not to use this skill
+
+- No usar para implementar una feature normal si el usuario no pide aprendizaje o retrospectiva.
+- No usar para guardar histórico operativo, logs, ramas, commits o cronologías completas en `.memory/`.
+- No usar para reemplazar una code review normal; usa `cultura-code-review` si lo pedido es revisar un diff.
+- No usar para mutaciones de Supabase, Vercel, GitHub, producción o acciones destructivas sin confirmación explícita.
+- No usar para persistir secretos, datos personales sensibles, `.env.local`, tokens o credenciales.
+
+## Inputs to inspect
+
+- Conversación reciente y petición exacta del usuario.
+- `AGENTS.md`, `docs/agent-context-policy.md`, `.memory/MEMORY.md` y `.memory/core.md`.
+- Skills relacionadas según dominio: `cultura-agent-orchestration`, `memory-protocol`, `product-brain-orient`, `cultura-data-finance-review`, `cultura-testing-release-check`, `cultura-security-privacy-review`, `cultura-frontend-review` o `cultura-code-review`.
+- Diff actual con `git status --short` y `git diff` si ya hay cambios.
+- Issue/release/Product Brain relacionado si el incidente toca planificación, cierre o criterios.
+- Logs, comandos, rutas, migraciones, tests o archivos afectados, solo si son relevantes.
+
+## Procedure
+
+1. Clasifica el aprendizaje:
+   - `incidente`: algo falló en producción, datos, seguridad, release o verificación.
+   - `proceso`: una checklist, skill, agente o documento permitió cerrar algo mal.
+   - `producto`: una decisión o expectativa de usuario quedó ambigua.
+   - `técnico`: bug, test gap, migración, contrato de datos o integración.
+   - `colaboración`: preferencia durable del usuario o forma de trabajo.
+2. Carga solo contexto mínimo: memoria índice, regla canónica y archivos directamente relacionados. No leas histórico amplio por defecto.
+3. Reconstruye hechos verificables: qué se esperaba, qué ocurrió, cómo se detectó, qué evidencia existe y qué quedó asumido sin comprobar.
+4. Si el usuario pidió agentes, usa `cultura-agent-orchestration` y delega investigaciones read-only con preguntas distintas. Si no pidió agentes, trabaja directo salvo que la conversación actual autorice subagentes.
+5. Busca la brecha real:
+   - aceptación marcada sin verificación real;
+   - mock que sustituyó a smoke real;
+   - migración local no aplicada;
+   - memoria/proceso desactualizado;
+   - issue/release con estado contradictorio;
+   - test o guard faltante;
+   - instrucciones ambiguas entre docs.
+6. Decide el tipo de corrección más pequeño que evita repetición:
+   - actualizar `.memory/` con una lección reusable;
+   - actualizar Product Brain/process si la regla debe ser canónica;
+   - crear o ajustar un test/check si puede automatizarse;
+   - corregir una skill si el flujo pertenece a agentes;
+   - proponer una issue CACH si el arreglo es grande;
+   - declarar `Memoria: no aplica` si no hay aprendizaje durable.
+7. Antes de editar, anuncia qué vas a cambiar y por qué.
+8. Aplica cambios acotados. No mezcles refactors ni limpieza no relacionada.
+9. Verifica según el tipo de cambio:
+   - Product Brain: `npm run pb:check` y, si toca docs generados/proceso, `npm run pb:guard`.
+   - Skills: `npm run verify:skills`, `quick_validate.py` si aplica, y `git diff --check`.
+   - Memoria: revisar legibilidad, privacidad y punteros.
+   - Código/tests: comandos relevantes al blast radius.
+10. Cierra con síntesis honesta: causa raíz, correcciones aplicadas, verificaciones y riesgos restantes.
+
+## Output format
+
+Para análisis sin edición:
+
+- Causa raíz: una frase clara.
+- Evidencia: archivos, logs, líneas o comandos que sostienen la conclusión.
+- Brecha: qué permitió que pasara.
+- Correcciones recomendadas: ordenadas por impacto.
+- Memoria/Product Brain: actualizar / no aplica.
+
+Para análisis con edición:
+
+- Agentes: roles usados o `no aplica`.
+- Causa raíz: resumen.
+- Cambios aplicados: archivos y propósito.
+- Verificación: comandos y resultado.
+- Aprendizaje durable: dónde quedó guardado.
+- Pendiente: riesgos o follow-ups reales.
+
+## Severity / priority model
+
+- CRITICAL: exposición de datos, pérdida de datos, producción rota, RLS/seguridad rota, secreto filtrado o acción irreversible.
+- HIGH: release marcada como lista sin funcionalidad real, migración remota pendiente, smoke falso, estado Product Brain engañoso o bug recurrente sin guardrail.
+- MEDIUM: gap de test, checklist débil, memoria/proceso ambiguo, documentación stale o agente mal enrutado.
+- LOW: wording, catálogo, salida final incompleta o mejora de ergonomía.
+
+## Quality bar
+
+- Distingue hechos, inferencias y decisiones.
+- No convierte la memoria en diario; guarda solo lecciones reutilizables.
+- La corrección vive en la fuente adecuada: código, test, Product Brain, skill, memoria o issue.
+- Si usa agentes, sus preguntas son concretas, read-only y no duplicadas.
+- Todo cambio queda verificado con el comando más cercano al riesgo.
+- La respuesta final incluye qué se aprendió y cómo se impedirá la repetición.
+
+## Common mistakes to avoid
+
+- Culpar al síntoma visible en lugar del gate que falló.
+- Marcar "aprendido" sin cambiar nada persistente cuando sí hay una regla reusable.
+- Guardar cronologías, logs o ramas en `.memory/`.
+- Usar subagentes sin autorización explícita del usuario o con prompts vagos.
+- Tratar un smoke mockeado como validación de producción.
+- Cerrar una release como funcional si depende de una migración remota pendiente.
+- Tocar Supabase remoto, Vercel o GitHub sin confirmación explícita.
+
+## Safety notes
+
+No incluir secretos, credenciales, `.env.local`, tokens, datos personales reales ni información sensible en memoria, prompts a agentes o documentos. Las mutaciones remotas y destructivas requieren confirmación explícita y SQL/comandos exactos antes de ejecutar. Las lecciones deben ser auditables en Markdown o verificables en tests/checks.
+
+## Product Brain v2 Contract
+
+When this workflow touches Product Brain, use flat v2 frontmatter: `schema_version: 2`, `kind`, `lifecycle`, and domain fields such as `issue_workflow`, `work_type`, `work_level`, `size`, `components`, `parent`, `release`, and `theme`. Do not create new `type/status` top-level Product Brain documents.
+
+Prefer `npm run pb:orient -- --json` before reading Product Brain detail. Read only the related issue, parent, release, ADR or source-touchpoint. Generated files such as `DIGEST.md` and generated indexes are regenerated by scripts, not edited manually.
+
+Close every Product Brain-aware response with: `Contexto leído`, `Product Brain leído`, `Product Brain actualizado`, `Validación PB`, and `Feedback/Memory`.

--- a/.claude/skills/cultura-learning-loop
+++ b/.claude/skills/cultura-learning-loop
@@ -1,0 +1,1 @@
+../../.agents/skills/cultura-learning-loop

--- a/.memory/reference_supabase_mcp.md
+++ b/.memory/reference_supabase_mcp.md
@@ -20,3 +20,12 @@ Reglas duraderas:
 - Si el MCP no está disponible en la sesión, usar SQL Editor como fallback manual.
 - Los subagentes Codex heredan solo las herramientas de la sesión Codex; si Codex no tiene Supabase MCP, sus subagentes tampoco lo tienen.
 - Documento operativo canónico: `docs/project/process/supabase-db-access.md`.
+
+## 2026-05-12 - Drift remoto en features con migraciones
+
+Contexto: el formulario de feedback falló en producción porque `public.feedback` existía en migraciones locales, pero no en Supabase remoto. PostgREST devolvía `404` para `POST /rest/v1/feedback`.
+
+Durable memory:
+- Si una feature depende de una tabla/policy/RPC nueva, verificar remoto antes de marcar producción como OK: `to_regclass('public.<tabla>')`, `pg_policies` cuando aplique y smoke real o transaccional con `rollback`.
+- Si una release deja la migración remota pendiente, la feature puede estar code-complete, pero no released funcionalmente.
+- Si un hotfix remoto incluye SQL no reflejado en migraciones locales, versionar el delta o confirmar que ya queda cubierto por una migración existente.

--- a/.memory/topics/agent-workflows.md
+++ b/.memory/topics/agent-workflows.md
@@ -67,6 +67,7 @@ Remote database operations:
 - For production mutations, agents must show the exact SQL or migration and wait for explicit human confirmation before executing.
 - Do not store or paste PATs, connection strings, service role keys, passwords or `.env.local` values in repo, memory, issues, prompts or PRs.
 - Canonical workflow: `docs/project/process/supabase-db-access.md`.
+- Releases/features that touch `supabase/migrations/**` need an explicit remote DB state before closure: `aplicado/verificado` or `pendiente/bloquea funcionalidad`. Do not mark Supabase persistence as production-verified from mock-only smoke tests.
 
 Memory hygiene:
 - Before opening a PR, review task context, diff and commits against base.

--- a/.memory/topics/portable-skills.md
+++ b/.memory/topics/portable-skills.md
@@ -1,5 +1,11 @@
 # Portable Skills Memory
 
+## 2026-05-12 - cultura-learning-loop: Aprendizaje De Conversaciones
+
+- Context: Tras reparar el fallo del formulario de feedback, el usuario pidió una skill para aprender igual: revisar conversación, reflexionar con agentes y aplicar correcciones.
+- Durable memory: `cultura-learning-loop` vive en `.agents/skills/cultura-learning-loop/SKILL.md` y convierte incidentes, conversaciones o brechas de proceso en causa raíz, guardrails, memoria/Product Brain/tests/docs y verificación. No es diario operativo ni memoria automática.
+- Source: `.agents/skills/cultura-learning-loop/SKILL.md`; incidente feedback/Supabase remoto 2026-05-12.
+
 ## 2026-05-12 - product-brain-sdd-review: SDD Ligero Sin Agente Nuevo
 
 - Context: Se hizo challenge con agentes docs/testing/review y experto SDD temporal sobre como encajar Product Brain con spec-driven development.
@@ -12,10 +18,10 @@
 - Durable memory: `.agents/skills/<skill-name>/SKILL.md` is the canonical source; `.claude/skills/<skill-name>` should remain a relative symlink to `../../.agents/skills/<skill-name>`. Do not duplicate skill bodies into `.claude`.
 - Source: `docs/agent-skills-strategy.md`; `README.md`; `TECHDOC.md`; `AGENTS.md`.
 
-## 2026-05-08 - Skill Set Actualizado: 17 Skills Portables
+## 2026-05-08 - Skill Set Actualizado: 18 Skills Portables
 
 - Context: Product Brain v2 consolidó skills de orientación, release, revisión, memoria, contexto y comunicación concisa. `brain-orient` legacy fue sustituido por `product-brain-orient`.
-- Durable memory: las skills canónicas viven en `.agents/skills/` y se exponen como symlinks en `.claude/skills/`. El catálogo actual incluye: `agent-context-maintenance`, `caveman`, `compact-memory`, `cultura-agent-orchestration`, `cultura-code-review`, `cultura-data-finance-review`, `cultura-frontend-review`, `cultura-issue-launch`, `cultura-release-task-flow`, `cultura-security-privacy-review`, `cultura-testing-release-check`, `memory-orient`, `memory-protocol`, `portable-skill-authoring`, `product-brain-capture`, `product-brain-orient` y `product-brain-sdd-review`.
+- Durable memory: las skills canónicas viven en `.agents/skills/` y se exponen como symlinks en `.claude/skills/`. El catálogo actual incluye: `agent-context-maintenance`, `caveman`, `compact-memory`, `cultura-agent-orchestration`, `cultura-code-review`, `cultura-data-finance-review`, `cultura-frontend-review`, `cultura-issue-launch`, `cultura-learning-loop`, `cultura-release-task-flow`, `cultura-security-privacy-review`, `cultura-testing-release-check`, `memory-orient`, `memory-protocol`, `portable-skill-authoring`, `product-brain-capture`, `product-brain-orient` y `product-brain-sdd-review`.
 - Source: `docs/agent-skills-strategy.md`; `npm run verify:skills`.
 
 ## 2026-05-07 - cultura-agent-orchestration: Delegación Codex/Claude/OpenCode

--- a/docs/agent-skills-strategy.md
+++ b/docs/agent-skills-strategy.md
@@ -31,6 +31,7 @@ Do not copy the same skill into both `.agents` and `.claude`. If a tool cannot f
 | `cultura-code-review` | Cross-cutting code review of diffs, PRs, architecture, risk, and maintainability. |
 | `cultura-release-task-flow` | Integrate finished CACH tasks and documentation into the active beta release branch with Product Brain validation. |
 | `cultura-agent-orchestration` | Decide when to use native Codex/Claude subagents, OpenCode agents, parallel review, ownership, and verification. |
+| `cultura-learning-loop` | Turn conversations, incidents, failed checks, and process gaps into root-cause learning plus durable corrections. |
 | `product-brain-orient` | Orient agents on Product Brain v2 with `pb:orient` without loading the full Brain. |
 | `product-brain-capture` | Capture ideas, decisions, context, or issue candidates into Product Brain inbox. |
 | `product-brain-sdd-review` | Review CACH issues for lightweight SDD readiness before implementation. |
@@ -127,6 +128,7 @@ Validation status for the current setup:
 | `cultura-code-review` | Valid |
 | `cultura-release-task-flow` | Valid |
 | `cultura-agent-orchestration` | Valid |
+| `cultura-learning-loop` | Valid |
 | `product-brain-orient` | Valid |
 | `product-brain-capture` | Valid |
 | `product-brain-sdd-review` | Valid |

--- a/docs/project/process/WORKFLOW.md
+++ b/docs/project/process/WORKFLOW.md
@@ -184,6 +184,7 @@ Son bloqueantes para PR o merge:
 - `npm run test` — requerido por CI `app`; no tratarlo como solo aviso.
 - `npm run build` — si se toca código de app o tooling que afecta build.
 - `npm run pb:guard` — si se toca `docs/project/` o `scripts/brain/`.
+- Verificación DB remoto — si se toca `supabase/migrations/` o la feature depende de schema/policy/RPC nuevo: confirmar migración aplicada/verificada en remoto, o declarar explícitamente que la funcionalidad no está lista en producción.
 
 ### Solo aviso (no bloquean merge)
 
@@ -193,6 +194,10 @@ Son bloqueantes para PR o merge:
 ### Validación visual
 
 Si se toca UI: verificar en navegador en la ruta afectada, con viewport relevante. Para calendarios: verificar que toolbar, cabecera y filas del mes son visibles.
+
+### Validación de Supabase remoto
+
+Si el cambio introduce o depende de objetos nuevos de Supabase, el smoke mockeado no basta para cerrar la funcionalidad como producción verificada. Antes de marcar una release como `released`, confirmar el schema remoto con SQL read-only, revisar RLS/policies cuando aplique y ejecutar un smoke real o transaccional con `rollback` del flujo afectado.
 
 ---
 

--- a/docs/project/process/supabase-db-access.md
+++ b/docs/project/process/supabase-db-access.md
@@ -66,13 +66,15 @@ rollback;
 - Todo cambio de schema, trigger, policy o RPC debe vivir primero en `supabase/migrations/`.
 - Antes de aplicar en producción, el agente debe mostrar el SQL exacto y esperar confirmación explícita.
 - Aplicar con MCP `apply_migration` cuando esté disponible; si no, pegar la migración completa en SQL Editor.
+- Si una feature o release depende de una tabla, policy, trigger o RPC nueva, no marcarla como verificada en producción hasta confirmar el remoto con SQL read-only y smoke real o transaccional con `rollback`.
+- Si la migración remota queda pendiente, la release puede estar code-complete, pero la funcionalidad afectada no está released funcionalmente; documentarlo como pendiente o bloqueante.
 - Después de cambiar RPCs, ejecutar:
 
 ```sql
 notify pgrst, 'reload schema';
 ```
 
-- Verificar con SQL read-only y después con la app.
+- Verificar con SQL read-only y después con la app. Para tablas nuevas, incluir al menos `to_regclass('public.<tabla>')`; para RLS, revisar `pg_policies` y probar el flujo autenticado que usa la UI.
 
 ## Reglas de seguridad
 


### PR DESCRIPTION
## Summary

- Adds the `cultura-learning-loop` portable skill for learning from conversations, incidents, failed checks, and process gaps.
- Adds the Claude Code symlink and updates the portable skills catalog/memory.
- Records the Supabase remote migration drift lesson as a release/process guardrail so mock-only smoke tests do not count as production verification for DB-backed features.

## Why

The feedback form incident showed that a feature can look complete in code and preview while production is missing the required Supabase schema. This PR turns that lesson into a repeatable workflow and a concrete remote DB verification rule.

## Validation

- `npm run verify:skills`
- `python3 /Users/diconde/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/cultura-learning-loop`
- `python3 /Users/diconde/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/templates/portable-skill`
- `npm run pb:guard`
- `npm run context:check`
- `git diff --check`

## Memoria

Actualizada en `.memory/reference_supabase_mcp.md`, `.memory/topics/agent-workflows.md` y `.memory/topics/portable-skills.md`.