### PR TITLE
Release 0.1.0-beta.18: cierre P1 UX core

### DIFF
--- a/docs/project/DIGEST.md
+++ b/docs/project/DIGEST.md
@@ -23,7 +23,7 @@ Resumen determinista generado desde Product Brain v2.
 
 ## Estado operacional
 
-- **Release activa:** No hay release activa.
+- **Release activa:** RELEASE-0.1.0-beta.18 — Cierre P1 UX core
 - **Últimos cortes:** `RELEASE-0.1.0-beta.10` — emails transaccionales beta con Brevo. Ver RELEASE-0.1.0-beta.10.
 
 `RELEASE-0.1.0-beta.12` — pulido proyecto-evento y borrados seguros. Ver RELEASE-0.1.0-beta.12.
@@ -37,13 +37,14 @@ Resumen determinista generado desde Product Brain v2.
 `RELEASE-0.1.0-beta.16` — navegacion inferior movil. Ver RELEASE-0.1.0-beta.16.
 
 `RELEASE-0.1.0-beta.17` — feedback simple beta. Ver RELEASE-0.1.0-beta.17.
-- **Foco:** Beta 17 queda cerrada con feedback cualitativo simple propio en Supabase. No hay release activa.
+- **Foco:** Beta 18 activa: cerrar P1 visible de UX core con notas contextuales, pulido financiero movil y calendarios separados más claros, sin tocar `CACH-B0004` ni modelo financiero.
 
 ## Prioridades del plan
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
 2. Mantener el feedback beta simple antes de introducir analitica de producto.
 3. No introducir PostHog, Plausible ni analitica de eventos sin issue/ADR posterior.
+4. No mezclar beta 18 con contratantes, facturacion, liquidacion neta, migraciones, RLS ni cambios de formulas financieras.
 
 ## Tablero
 
@@ -61,7 +62,11 @@ _Sin entradas._
 
 ### Review / Verify
 
-_Sin entradas._
+| ID | Título | Tipo | Nivel | P |
+|---|---|---|---|---|
+| CACH-0054 | Editar notas desde detalles de proyecto y evento | feature | slice | p1 |
+| CACH-0055 | Pulido financiero movil sin cambiar formulas | feature | slice | p1 |
+| CACH-0056 | Calendario de eventos y plan anual separados | feature | slice | p1 |
 
 ### Backlog (p1)
 
@@ -76,6 +81,9 @@ _Sin entradas._
 
 | ID | Título | Workflow | Tipo | Nivel | P |
 |---|---|---|---|---|---|
+| CACH-0054 | Editar notas desde detalles de proyecto y evento | review | feature | slice | p1 |
+| CACH-0055 | Pulido financiero movil sin cambiar formulas | review | feature | slice | p1 |
+| CACH-0056 | Calendario de eventos y plan anual separados | review | feature | slice | p1 |
 | CACH-B0001 | Redisenar Trabajos y jerarquia proyecto-evento | backlog | feature | initiative | p1 |
 | CACH-B0002 | Simplificar experiencia mobile financiera | backlog | feature | initiative | p1 |
 | CACH-B0004 | Contratantes facturacion y liquidacion neta | backlog | feature | initiative | p1 |
@@ -109,4 +117,4 @@ _Sin entradas._
 
 ## Próxima acción
 
-Aplicar la migracion remota de Supabase de beta 17 solo con confirmacion humana explicita, y elegir el siguiente corte cuando haga falta.
+Completar beta 18 y verificar visualmente dashboard, detalles y calendarios en mobile/desktop.

--- a/docs/project/DIGEST.md
+++ b/docs/project/DIGEST.md
@@ -23,7 +23,7 @@ Resumen determinista generado desde Product Brain v2.
 
 ## Estado operacional
 
-- **Release activa:** RELEASE-0.1.0-beta.18 — Cierre P1 UX core
+- **Release activa:** No hay release activa.
 - **Últimos cortes:** `RELEASE-0.1.0-beta.10` — emails transaccionales beta con Brevo. Ver RELEASE-0.1.0-beta.10.
 
 `RELEASE-0.1.0-beta.12` — pulido proyecto-evento y borrados seguros. Ver RELEASE-0.1.0-beta.12.
@@ -37,14 +37,16 @@ Resumen determinista generado desde Product Brain v2.
 `RELEASE-0.1.0-beta.16` — navegacion inferior movil. Ver RELEASE-0.1.0-beta.16.
 
 `RELEASE-0.1.0-beta.17` — feedback simple beta. Ver RELEASE-0.1.0-beta.17.
-- **Foco:** Beta 18 activa: cerrar P1 visible de UX core con notas contextuales, pulido financiero movil y calendarios separados más claros, sin tocar `CACH-B0004` ni modelo financiero.
+
+`RELEASE-0.1.0-beta.18` — cierre P1 UX core. Ver RELEASE-0.1.0-beta.18.
+- **Foco:** Beta 18 queda cerrada con notas contextuales, pulido financiero movil y calendarios separados más claros. No hay release activa.
 
 ## Prioridades del plan
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
 2. Mantener el feedback beta simple antes de introducir analitica de producto.
 3. No introducir PostHog, Plausible ni analitica de eventos sin issue/ADR posterior.
-4. No mezclar beta 18 con contratantes, facturacion, liquidacion neta, migraciones, RLS ni cambios de formulas financieras.
+4. No abrir contratantes, facturacion, liquidacion neta, migraciones, RLS ni cambios de formulas financieras sin release nueva.
 
 ## Tablero
 
@@ -62,11 +64,7 @@ _Sin entradas._
 
 ### Review / Verify
 
-| ID | Título | Tipo | Nivel | P |
-|---|---|---|---|---|
-| CACH-0054 | Editar notas desde detalles de proyecto y evento | feature | slice | p1 |
-| CACH-0055 | Pulido financiero movil sin cambiar formulas | feature | slice | p1 |
-| CACH-0056 | Calendario de eventos y plan anual separados | feature | slice | p1 |
+_Sin entradas._
 
 ### Backlog (p1)
 
@@ -81,9 +79,6 @@ _Sin entradas._
 
 | ID | Título | Workflow | Tipo | Nivel | P |
 |---|---|---|---|---|---|
-| CACH-0054 | Editar notas desde detalles de proyecto y evento | review | feature | slice | p1 |
-| CACH-0055 | Pulido financiero movil sin cambiar formulas | review | feature | slice | p1 |
-| CACH-0056 | Calendario de eventos y plan anual separados | review | feature | slice | p1 |
 | CACH-B0001 | Redisenar Trabajos y jerarquia proyecto-evento | backlog | feature | initiative | p1 |
 | CACH-B0002 | Simplificar experiencia mobile financiera | backlog | feature | initiative | p1 |
 | CACH-B0004 | Contratantes facturacion y liquidacion neta | backlog | feature | initiative | p1 |
@@ -117,4 +112,4 @@ _Sin entradas._
 
 ## Próxima acción
 
-Completar beta 18 y verificar visualmente dashboard, detalles y calendarios en mobile/desktop.
+Elegir siguiente corte. Candidato principal: `CACH-B0004` como release de datos separada para contratantes, facturacion y liquidacion neta.

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -71,11 +71,7 @@ _Sin issues._
 
 ## Review / Verify
 
-| ID | Titulo | Tipo | Nivel | P | Componentes |
-|---|---|---|---|---|---|
-| [[../issues/CACH-0054|CACH-0054]] | Editar notas desde detalles de proyecto y evento | feature | slice | p1 | work, projects, events |
-| [[../issues/CACH-0055|CACH-0055]] | Pulido financiero movil sin cambiar formulas | feature | slice | p1 | finance, design-system |
-| [[../issues/CACH-0056|CACH-0056]] | Calendario de eventos y plan anual separados | feature | slice | p1 | calendar, design-system |
+_Sin issues._
 
 ## Done
 
@@ -107,6 +103,9 @@ _Sin issues._
 | [[../issues/CACH-0051|CACH-0051]] | [Deploy] Dominio publico de app y estrategia multientorno | RELEASE-0.1.0-beta.15 | Cerrado en `RELEASE-0.1.0-beta.15`. El dominio publico canonico de la app queda definido como `https://app.caches.es`, asignado al proyecto Vercel, resuelto por DNS de Hostinger y verificado con smoke de rutas SPA. `VITE_APP_URL` queda configurado en Vercel para produccion, preview y development. La Edge Function `send-beta-invite` usa `APP_URL=https://app.caches.es`. Supabase Auth URL Configuration queda actualizada con `Site URL` canonico y redirects permitidos para `app.caches.es`, alias temporal de Vercel y localhost local. |
 | [[../issues/CACH-0052|CACH-0052]] | [Feedback] Formulario simple de feedback beta | RELEASE-0.1.0-beta.17 | Implementado y cerrado en `RELEASE-0.1.0-beta.17`. La release anade el formulario global de feedback, el hook de envio, elimina el snippet comentado de Plausible y deja versionada la migracion que endurece la politica de insert de la tabla `feedback`. |
 | [[../issues/CACH-0053|CACH-0053]] | [Bug] Mantener foco al escribir feedback | null | Implementado localmente. El modal ya no reinstala el focus trap al cambiar la identidad de `onClose`, y el scroll lock expone funciones estables. El textarea de feedback conserva el foco mientras se escribe. |
+| [[../issues/CACH-0054|CACH-0054]] | Editar notas desde detalles de proyecto y evento | RELEASE-0.1.0-beta.18 | Implementado y cerrado en `RELEASE-0.1.0-beta.18`. |
+| [[../issues/CACH-0055|CACH-0055]] | Pulido financiero movil sin cambiar formulas | RELEASE-0.1.0-beta.18 | Implementado y cerrado en `RELEASE-0.1.0-beta.18`. |
+| [[../issues/CACH-0056|CACH-0056]] | Calendario de eventos y plan anual separados | RELEASE-0.1.0-beta.18 | Implementado y cerrado en `RELEASE-0.1.0-beta.18`. |
 | [[../issues/CACH-B0003|CACH-B0003]] | Cobro rapido y gestion de pendientes | RELEASE-0.1.0-beta.5 | Released en RELEASE-0.1.0-beta.5 por ampliacion explicita de scope. Integrado en `main` mediante PR #84. |
 | [[../issues/CACH-B0005|CACH-B0005]] | Importacion exportacion y portabilidad de datos | RELEASE-0.1.0-beta.7 | Released en RELEASE-0.1.0-beta.7. Integrado en `main` mediante PR #86. |
 | [[../issues/CACH-B0006|CACH-B0006]] | Onboarding y acceso beta | RELEASE-0.1.0-beta.8 | Released en RELEASE-0.1.0-beta.8. Integrado en `main` mediante PR #87. |

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -71,7 +71,11 @@ _Sin issues._
 
 ## Review / Verify
 
-_Sin issues._
+| ID | Titulo | Tipo | Nivel | P | Componentes |
+|---|---|---|---|---|---|
+| [[../issues/CACH-0054|CACH-0054]] | Editar notas desde detalles de proyecto y evento | feature | slice | p1 | work, projects, events |
+| [[../issues/CACH-0055|CACH-0055]] | Pulido financiero movil sin cambiar formulas | feature | slice | p1 | finance, design-system |
+| [[../issues/CACH-0056|CACH-0056]] | Calendario de eventos y plan anual separados | feature | slice | p1 | calendar, design-system |
 
 ## Done
 

--- a/docs/project/indexes/by-area.md
+++ b/docs/project/indexes/by-area.md
@@ -22,9 +22,6 @@ generated: true
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
-- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
-- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
-- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
@@ -39,6 +36,9 @@ generated: true
 - [[../issues/CACH-0045|CACH-0045]] — [UX] Anadir confirmacion a borrados destructivos · done · p1 · slice
 - [[../issues/CACH-0052|CACH-0052]] — [Feedback] Formulario simple de feedback beta · done · p1 · slice
 - [[../issues/CACH-0053|CACH-0053]] — [Bug] Mantener foco al escribir feedback · done · p1 · task
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · done · p1 · slice
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · done · p1 · slice
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes · done · p1 · slice
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta · done · p1 · slice
 - [[../issues/CACH-B0014|CACH-B0014]] — Endurecer agenda cobros y captura del MVP · done · p1 · slice

--- a/docs/project/indexes/by-area.md
+++ b/docs/project/indexes/by-area.md
@@ -22,6 +22,9 @@ generated: true
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice

--- a/docs/project/indexes/by-component.md
+++ b/docs/project/indexes/by-component.md
@@ -18,8 +18,8 @@ generated: true
 ## work
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
-- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain · done · p1 · task
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task
 
@@ -27,23 +27,23 @@ generated: true
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
-- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
 - [[../issues/CACH-0043|CACH-0043]] — [UX] Limpiar acciones en detalle de proyecto · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos · done · p2 · slice
 
 ## events
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
-- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
 
 ## calendar
 
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
-- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · done · p1 · slice
 - [[../issues/CACH-B0014|CACH-B0014]] — Endurecer agenda cobros y captura del MVP · done · p1 · slice
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos · done · p2 · slice
 
@@ -59,10 +59,10 @@ generated: true
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera · backlog · p1 · initiative
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
-- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables · done · p1 · slice
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · done · p1 · slice
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes · done · p1 · slice
 - [[../issues/CACH-B0014|CACH-B0014]] — Endurecer agenda cobros y captura del MVP · done · p1 · slice
 
@@ -119,8 +119,6 @@ generated: true
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
-- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
-- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
@@ -132,6 +130,8 @@ generated: true
 - [[../issues/CACH-0045|CACH-0045]] — [UX] Anadir confirmacion a borrados destructivos · done · p1 · slice
 - [[../issues/CACH-0052|CACH-0052]] — [Feedback] Formulario simple de feedback beta · done · p1 · slice
 - [[../issues/CACH-0053|CACH-0053]] — [Bug] Mantener foco al escribir feedback · done · p1 · task
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · done · p1 · slice
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · done · p1 · slice
 
 ## infra-deploy
 

--- a/docs/project/indexes/by-component.md
+++ b/docs/project/indexes/by-component.md
@@ -18,6 +18,7 @@ generated: true
 ## work
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain · done · p1 · task
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task
@@ -26,6 +27,7 @@ generated: true
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
 - [[../issues/CACH-0043|CACH-0043]] — [UX] Limpiar acciones en detalle de proyecto · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos · done · p2 · slice
@@ -34,12 +36,14 @@ generated: true
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
 
 ## calendar
 
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice
 - [[../issues/CACH-B0014|CACH-B0014]] — Endurecer agenda cobros y captura del MVP · done · p1 · slice
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos · done · p2 · slice
 
@@ -55,6 +59,7 @@ generated: true
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera · backlog · p1 · initiative
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables · done · p1 · slice
@@ -114,6 +119,8 @@ generated: true
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice

--- a/docs/project/indexes/by-level.md
+++ b/docs/project/indexes/by-level.md
@@ -30,6 +30,9 @@ generated: true
 
 ## slice
 
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada · done · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice

--- a/docs/project/indexes/by-level.md
+++ b/docs/project/indexes/by-level.md
@@ -30,9 +30,6 @@ generated: true
 
 ## slice
 
-- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
-- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
-- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada · done · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
@@ -46,6 +43,9 @@ generated: true
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
 - [[../issues/CACH-0045|CACH-0045]] — [UX] Anadir confirmacion a borrados destructivos · done · p1 · slice
 - [[../issues/CACH-0052|CACH-0052]] — [Feedback] Formulario simple de feedback beta · done · p1 · slice
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · done · p1 · slice
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · done · p1 · slice
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes · done · p1 · slice
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta · done · p1 · slice

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -80,6 +80,12 @@ generated: true
 
 - [[../issues/CACH-0052|CACH-0052]] — [Feedback] Formulario simple de feedback beta · done · p1 · slice
 
+## RELEASE-0.1.0-beta.18
+
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice
+
 ## RELEASE-0.1.0-beta.2
 
 - [[../issues/CACH-B0014|CACH-B0014]] — Endurecer agenda cobros y captura del MVP · done · p1 · slice

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -82,9 +82,9 @@ generated: true
 
 ## RELEASE-0.1.0-beta.18
 
-- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
-- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
-- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · done · p1 · slice
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · done · p1 · slice
 
 ## RELEASE-0.1.0-beta.2
 

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -67,3 +67,9 @@ generated: true
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos · done · p2 · slice
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task
+
+## review
+
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -56,6 +56,9 @@ generated: true
 - [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · done · p1 · task
 - [[../issues/CACH-0052|CACH-0052]] — [Feedback] Formulario simple de feedback beta · done · p1 · slice
 - [[../issues/CACH-0053|CACH-0053]] — [Bug] Mantener foco al escribir feedback · done · p1 · task
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · done · p1 · slice
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · done · p1 · slice
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes · done · p1 · slice
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta · done · p1 · slice
@@ -67,9 +70,3 @@ generated: true
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos · done · p2 · slice
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task
-
-## review
-
-- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
-- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
-- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice

--- a/docs/project/indexes/by-theme.md
+++ b/docs/project/indexes/by-theme.md
@@ -32,6 +32,7 @@ generated: true
 
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0032|CACH-0032]] — Priorizar operativa diaria en dashboard movil · done · p1 · slice
@@ -44,6 +45,7 @@ generated: true
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera · backlog · p1 · initiative
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables · done · p1 · slice
@@ -59,6 +61,7 @@ _Sin issues._
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
 - [[../issues/CACH-0043|CACH-0043]] — [UX] Limpiar acciones en detalle de proyecto · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice

--- a/docs/project/indexes/by-theme.md
+++ b/docs/project/indexes/by-theme.md
@@ -32,23 +32,23 @@ generated: true
 
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
-- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0032|CACH-0032]] — Priorizar operativa diaria en dashboard movil · done · p1 · slice
 - [[../issues/CACH-0041|CACH-0041]] — [UX] Simplificar dashboard movil y estado Ahora · done · p1 · slice
 - [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · done · p1 · slice
 - [[../issues/CACH-0045|CACH-0045]] — [UX] Anadir confirmacion a borrados destructivos · done · p1 · slice
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · done · p1 · slice
 
 ## finance-operations
 
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera · backlog · p1 · initiative
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
-- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables · done · p1 · slice
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · done · p1 · slice
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes · done · p1 · slice
 - [[../issues/CACH-B0014|CACH-B0014]] — Endurecer agenda cobros y captura del MVP · done · p1 · slice
 
@@ -61,10 +61,10 @@ _Sin issues._
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
-- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
 - [[../issues/CACH-0043|CACH-0043]] — [UX] Limpiar acciones en detalle de proyecto · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos · done · p2 · slice
 
 ## internal-agent-ops

--- a/docs/project/indexes/initiative-children.index.md
+++ b/docs/project/indexes/initiative-children.index.md
@@ -5,7 +5,7 @@ id: PB-INITIATIVE-CHILDREN
 title: Initiative Children Index
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-10
+updated: 2026-05-12
 aliases:
   - Initiative Children Index
 tags:
@@ -18,11 +18,13 @@ generated: true
 
 ## CACH-B0001 — Redisenar Trabajos y jerarquia proyecto-evento
 
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
 - [[../issues/CACH-0043|CACH-0043]] — [UX] Limpiar acciones en detalle de proyecto · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
 
 ## CACH-B0002 — Simplificar experiencia mobile financiera
 
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
 - [[../issues/CACH-0032|CACH-0032]] — Priorizar operativa diaria en dashboard movil · done · p1 · slice
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables · done · p1 · slice
 - [[../issues/CACH-0041|CACH-0041]] — [UX] Simplificar dashboard movil y estado Ahora · done · p1 · slice
@@ -35,6 +37,7 @@ _Sin children._
 
 ## CACH-B0007 — Calendario unificado e interaccion rapida
 
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos · done · p2 · slice
 
 ## CACH-B0008 — PWA notificaciones y offline

--- a/docs/project/indexes/initiative-children.index.md
+++ b/docs/project/indexes/initiative-children.index.md
@@ -18,18 +18,18 @@ generated: true
 
 ## CACH-B0001 — Redisenar Trabajos y jerarquia proyecto-evento
 
-- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
 - [[../issues/CACH-0043|CACH-0043]] — [UX] Limpiar acciones en detalle de proyecto · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
 
 ## CACH-B0002 — Simplificar experiencia mobile financiera
 
-- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
 - [[../issues/CACH-0032|CACH-0032]] — Priorizar operativa diaria en dashboard movil · done · p1 · slice
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables · done · p1 · slice
 - [[../issues/CACH-0041|CACH-0041]] — [UX] Simplificar dashboard movil y estado Ahora · done · p1 · slice
 - [[../issues/CACH-0042|CACH-0042]] — [UX] Racionalizar navegacion inferior · done · p1 · slice
 - [[../issues/CACH-0045|CACH-0045]] — [UX] Anadir confirmacion a borrados destructivos · done · p1 · slice
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · done · p1 · slice
 
 ## CACH-B0004 — Contratantes facturacion y liquidacion neta
 
@@ -37,7 +37,7 @@ _Sin children._
 
 ## CACH-B0007 — Calendario unificado e interaccion rapida
 
-- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · done · p1 · slice
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos · done · p2 · slice
 
 ## CACH-B0008 — PWA notificaciones y offline

--- a/docs/project/indexes/issues-open.index.md
+++ b/docs/project/indexes/issues-open.index.md
@@ -26,6 +26,3 @@ generated: true
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
-- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
-- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
-- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice

--- a/docs/project/indexes/issues-open.index.md
+++ b/docs/project/indexes/issues-open.index.md
@@ -5,7 +5,7 @@ id: PB-ISSUES-OPEN
 title: Issues Open Index
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-11
+updated: 2026-05-12
 aliases:
   - Issues Open Index
 tags:
@@ -26,3 +26,6 @@ generated: true
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · review · p1 · slice
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · review · p1 · slice
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · review · p1 · slice

--- a/docs/project/indexes/issues.index.md
+++ b/docs/project/indexes/issues.index.md
@@ -42,6 +42,9 @@ generated: true
 - [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno
 - [[../issues/CACH-0052|CACH-0052]] — [Feedback] Formulario simple de feedback beta
 - [[../issues/CACH-0053|CACH-0053]] — [Bug] Mantener foco al escribir feedback
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes

--- a/docs/project/indexes/releases.index.md
+++ b/docs/project/indexes/releases.index.md
@@ -5,7 +5,7 @@ id: PB-RELEASES-INDEX
 title: Releases Index
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-11
+updated: 2026-05-12
 aliases:
   - Releases Index
 tags:
@@ -26,6 +26,7 @@ generated: true
 - [[../releases/RELEASE-0.1.0-beta.15|RELEASE-0.1.0-beta.15]] — Dominio publico de app
 - [[../releases/RELEASE-0.1.0-beta.16|RELEASE-0.1.0-beta.16]] — Navegación inferior móvil
 - [[../releases/RELEASE-0.1.0-beta.17|RELEASE-0.1.0-beta.17]] — Feedback simple beta
+- [[../releases/RELEASE-0.1.0-beta.18|RELEASE-0.1.0-beta.18]] — Cierre P1 UX core
 - [[../releases/RELEASE-0.1.0-beta.2|RELEASE-0.1.0-beta.2]] — Endurecer confianza de datos
 - [[../releases/RELEASE-0.1.0-beta.3|RELEASE-0.1.0-beta.3]] — Rediseño financiero del Dashboard
 - [[../releases/RELEASE-0.1.0-beta.4|RELEASE-0.1.0-beta.4]] — Planificacion anual de proyectos

--- a/docs/project/issues/CACH-0054.md
+++ b/docs/project/issues/CACH-0054.md
@@ -1,0 +1,99 @@
+---
+schema_version: 2
+kind: issue
+id: CACH-0054
+title: Editar notas desde detalles de proyecto y evento
+lifecycle: active
+created: '2026-05-12'
+updated: '2026-05-12'
+aliases:
+  - CACH-0054
+tags:
+  - product-brain
+  - issue
+  - ux
+generated: false
+work_type: feature
+work_level: slice
+issue_workflow: review
+priority: p1
+size: s
+area: frontend
+components:
+  - work
+  - projects
+  - events
+parent: CACH-B0001
+related: []
+depends_on: []
+blocked_by: []
+adr: []
+release: RELEASE-0.1.0-beta.18
+theme: pro-growth
+---
+# CACH-0054 — Editar notas desde detalles de proyecto y evento
+
+## Objetivo
+
+Permitir añadir, editar y limpiar notas desde el contexto del detalle de proyecto o evento sin abrir el formulario completo de la entidad.
+
+## Alcance
+
+- Añadir una card de notas siempre visible en `ProjectDetail` y `EventDetail`.
+- Usar el campo `notes` existente de `projects` y `events`.
+- Guardar con `updateProject` y `updateEvent`.
+- Mostrar estados de edición, guardado, cancelación, error y nota vacía.
+- Fuera de alcance: migraciones, adjuntos, CRM, privacidad avanzada, gestión documental y cambios en formularios generales.
+
+## Criterios de aceptacion
+
+- [x] En un proyecto sin notas se ve una card contextual con acción para añadir nota.
+- [x] En un evento sin notas se ve una card contextual con acción para añadir nota.
+- [x] Una nota de proyecto se puede añadir, editar, cancelar y limpiar desde el detalle sin abrir el formulario completo.
+- [x] Una nota de evento se puede añadir, editar, cancelar y limpiar desde el detalle sin abrir el formulario completo.
+- [x] Al guardar correctamente aparece feedback y la nota persiste al recargar los datos.
+- [x] Si falla el guardado, el texto escrito no se pierde y se muestra un error.
+
+## Plan tecnico
+
+Crear un bloque reutilizable pequeño para notas contextuales o implementar el patrón de forma equivalente en ambos detalles. La edición usa textarea controlado, conserva `notes.trim()` al guardar y manda `notes: ''` para limpiar. No se toca Supabase schema ni RLS; la persistencia sigue pasando por hooks existentes.
+
+## Validacion
+
+- `npm run lint`
+- `npm run build`
+- Smoke manual en `/projects/:id` y `/events/:id` con nota vacía, nota larga multilinea, guardar, cancelar y limpiar en 320 px, 390 px y desktop.
+
+## Resultado
+
+Implementado en `release/0.1.0-beta.18`. Pendiente de review, PR y cierre de release.
+
+## Desarrollo
+
+- Rama: `release/0.1.0-beta.18`
+- PR:
+- Estado actual: Implementado localmente y listo para review.
+
+## Notas de progreso
+
+- Se añade `ContextNotesCard` reutilizable para detalle de proyecto y evento.
+- La persistencia usa `updateProject` / `updateEvent` con el campo `notes` existente.
+- No hay migraciones, RLS ni cambios de schema.
+
+## Cambios de alcance y decisiones
+
+## Bloqueos
+
+Sin bloqueos.
+
+## Validación ejecutada
+
+- `npm run lint`
+- `npm run test`
+- `npm run build`
+- `npm run test:e2e -- e2e/beta18.spec.ts`
+- Smoke de notas: proyecto y evento permiten editar, guardar, recargar datos mock y limpiar.
+
+## Memoria
+
+Memoria: no aplica.

--- a/docs/project/issues/CACH-0054.md
+++ b/docs/project/issues/CACH-0054.md
@@ -15,7 +15,7 @@ tags:
 generated: false
 work_type: feature
 work_level: slice
-issue_workflow: review
+issue_workflow: done
 priority: p1
 size: s
 area: frontend
@@ -66,19 +66,20 @@ Crear un bloque reutilizable pequeño para notas contextuales o implementar el p
 
 ## Resultado
 
-Implementado en `release/0.1.0-beta.18`. Pendiente de review, PR y cierre de release.
+Implementado y cerrado en `RELEASE-0.1.0-beta.18`.
 
 ## Desarrollo
 
 - Rama: `release/0.1.0-beta.18`
-- PR:
-- Estado actual: Implementado localmente y listo para review.
+- PR: https://github.com/dignacioconde/culturApp/pull/104
+- Estado actual: cerrada en la rama de release.
 
 ## Notas de progreso
 
 - Se añade `ContextNotesCard` reutilizable para detalle de proyecto y evento.
 - La persistencia usa `updateProject` / `updateEvent` con el campo `notes` existente.
 - No hay migraciones, RLS ni cambios de schema.
+- PR #104 abierta hacia `main`.
 
 ## Cambios de alcance y decisiones
 
@@ -93,6 +94,7 @@ Sin bloqueos.
 - `npm run build`
 - `npm run test:e2e -- e2e/beta18.spec.ts`
 - Smoke de notas: proyecto y evento permiten editar, guardar, recargar datos mock y limpiar.
+- `npm run verify:pr -- --base origin/main`
 
 ## Memoria
 

--- a/docs/project/issues/CACH-0055.md
+++ b/docs/project/issues/CACH-0055.md
@@ -16,7 +16,7 @@ tags:
 generated: false
 work_type: feature
 work_level: slice
-issue_workflow: review
+issue_workflow: done
 priority: p1
 size: m
 area: frontend
@@ -68,19 +68,20 @@ Reutilizar `normalizeIncomeForm`, `normalizeExpenseForm`, `paymentDate` e `isPai
 
 ## Resultado
 
-Implementado en `release/0.1.0-beta.18`. Pendiente de review, PR y cierre de release.
+Implementado y cerrado en `RELEASE-0.1.0-beta.18`.
 
 ## Desarrollo
 
 - Rama: `release/0.1.0-beta.18`
-- PR:
-- Estado actual: Implementado localmente y listo para review.
+- PR: https://github.com/dignacioconde/culturApp/pull/104
+- Estado actual: cerrada en la rama de release.
 
 ## Notas de progreso
 
 - Quick cobro y quick gasto en proyecto/evento tienen concepto editable.
 - Los quick forms usan `normalizeIncomeForm`, `normalizeExpenseForm` y `paymentDate`.
 - No se toca `dashboardFinance`, hooks públicos financieros, schema, RLS, migraciones ni fórmulas.
+- PR #104 abierta hacia `main`.
 
 ## Cambios de alcance y decisiones
 
@@ -98,6 +99,7 @@ Sin bloqueos.
 - `npm run test:e2e -- e2e/beta18.spec.ts`
 - Smoke visual en `/dashboard`, `/projects/:id` y `/events/:id` en 320, 390, 768 y desktop.
 - Challenge data/finance read-only: confirma sin cambios en `dashboardFinance`, hooks financieros sensibles, schema, RLS ni fórmulas.
+- `npm run verify:pr -- --base origin/main`
 
 ## Memoria
 

--- a/docs/project/issues/CACH-0055.md
+++ b/docs/project/issues/CACH-0055.md
@@ -1,0 +1,104 @@
+---
+schema_version: 2
+kind: issue
+id: CACH-0055
+title: Pulido financiero movil sin cambiar formulas
+lifecycle: active
+created: '2026-05-12'
+updated: '2026-05-12'
+aliases:
+  - CACH-0055
+tags:
+  - product-brain
+  - issue
+  - mobile
+  - finance
+generated: false
+work_type: feature
+work_level: slice
+issue_workflow: review
+priority: p1
+size: m
+area: frontend
+components:
+  - finance
+  - design-system
+parent: CACH-B0002
+related: []
+depends_on: []
+blocked_by: []
+adr: []
+release: RELEASE-0.1.0-beta.18
+theme: finance-operations
+---
+# CACH-0055 — Pulido financiero móvil sin cambiar fórmulas
+
+## Objetivo
+
+Cerrar la fricción móvil pendiente en las finanzas de detalles y dashboard con cambios de ergonomía y presentación, sin cambiar fórmulas, KPIs, hooks públicos, RLS ni schema.
+
+## Alcance
+
+- Mantener resúmenes financieros compactos y escaneables en detalle de proyecto/evento.
+- Mejorar formularios rápidos de cobro y gasto para permitir concepto editable, importe y estado cobrado/pendiente cuando aplique.
+- Mantener listas móviles de ingresos/gastos usables, con targets táctiles razonables y sin depender de tablas.
+- Verificar que bottom bars, modales y listas no se solapan con navegación inferior o teclado.
+- Fuera de alcance: `CACH-B0004`, contratantes, facturación, liquidación neta, gastos repercutibles, migraciones y cambios de fórmulas.
+
+## Criterios de aceptacion
+
+- [x] En `/events/:id`, el modal `Cobro rápido` permite escribir un concepto distinto al nombre del evento, guardar un importe con coma decimal y elegir si nace cobrado o por cobrar.
+- [x] En `/projects/:id`, el modal `Cobro rápido` permite escribir un concepto distinto al nombre del proyecto, guardar un importe con coma decimal y elegir si nace cobrado o por cobrar.
+- [x] El gasto rápido en detalle de evento permite editar concepto, importe y categoría sin cambiar schema ni fórmulas.
+- [x] El gasto rápido en detalle de proyecto permite editar concepto, importe y categoría sin cambiar schema ni fórmulas.
+- [x] En 320 px, las listas móviles de ingresos/gastos de proyecto y evento mantienen botones de edición y alternancia de cobro con targets de al menos 40 px.
+- [x] Dashboard y detalles conservan los mismos totales y reglas de `cobro bruto/hora`.
+
+## Plan tecnico
+
+Reutilizar `normalizeIncomeForm`, `normalizeExpenseForm`, `paymentDate` e `isPaid` donde se cambien quick forms. No tocar `dashboardFinance` salvo que una regresión visual lo haga imprescindible; si se toca, añadir tests de regresión. Confirmar que ProjectDetail mantiene KPIs agregados de proyecto + eventos, pero tablas editables solo para ingresos/gastos directos.
+
+## Validacion
+
+- `npm run lint`
+- `npm run test`
+- `npm run build`
+- Smoke manual en `/dashboard`, `/projects/:id` y `/events/:id` en 320 px, 390 px, 768 px y desktop con capturas o notas de verificación visual.
+- Regresión manual de importes: cobro por cobrar, cobro ya cobrado, alternar entre cobrado y por cobrar, evento sin `end_datetime` y proyecto con ingresos directos e ingresos de eventos.
+
+## Resultado
+
+Implementado en `release/0.1.0-beta.18`. Pendiente de review, PR y cierre de release.
+
+## Desarrollo
+
+- Rama: `release/0.1.0-beta.18`
+- PR:
+- Estado actual: Implementado localmente y listo para review.
+
+## Notas de progreso
+
+- Quick cobro y quick gasto en proyecto/evento tienen concepto editable.
+- Los quick forms usan `normalizeIncomeForm`, `normalizeExpenseForm` y `paymentDate`.
+- No se toca `dashboardFinance`, hooks públicos financieros, schema, RLS, migraciones ni fórmulas.
+
+## Cambios de alcance y decisiones
+
+`CACH-B0004`, contratantes, facturación, gastos repercutibles y liquidación neta siguen fuera de scope.
+
+## Bloqueos
+
+Sin bloqueos.
+
+## Validación ejecutada
+
+- `npm run lint`
+- `npm run test`
+- `npm run build`
+- `npm run test:e2e -- e2e/beta18.spec.ts`
+- Smoke visual en `/dashboard`, `/projects/:id` y `/events/:id` en 320, 390, 768 y desktop.
+- Challenge data/finance read-only: confirma sin cambios en `dashboardFinance`, hooks financieros sensibles, schema, RLS ni fórmulas.
+
+## Memoria
+
+Memoria: no aplica.

--- a/docs/project/issues/CACH-0056.md
+++ b/docs/project/issues/CACH-0056.md
@@ -1,0 +1,105 @@
+---
+schema_version: 2
+kind: issue
+id: CACH-0056
+title: Calendario de eventos y plan anual separados
+lifecycle: active
+created: '2026-05-12'
+updated: '2026-05-13'
+aliases:
+  - CACH-0056
+tags:
+  - product-brain
+  - issue
+  - calendar
+  - ux
+generated: false
+work_type: feature
+work_level: slice
+issue_workflow: review
+priority: p1
+size: m
+area: frontend
+components:
+  - calendar
+  - design-system
+parent: CACH-B0007
+related: []
+depends_on: []
+blocked_by: []
+adr: []
+release: RELEASE-0.1.0-beta.18
+theme: core-work-ux
+---
+# CACH-0056 — Calendario de eventos y plan anual separados
+
+## Objetivo
+
+Mantener una separación clara entre el calendario operativo de eventos y el plan anual de proyectos, evitando una vista unificada que mezcla dos modelos de trabajo distintos.
+
+## Alcance
+
+- Mantener `/calendar/events` como calendario operativo de eventos.
+- Redirigir `/calendar` a `/calendar/events` por compatibilidad.
+- Mantener `/calendar/projects` como `Plan anual` sin cambiar su misión.
+- Actualizar navegación para que `Agenda` apunte al calendario de eventos y `Plan` siga apuntando a `/calendar/projects`.
+- Conservar el calendario de eventos con altura real, toolbar, cabeceras, filas/celdas y panel rápido visibles.
+- Fuera de alcance: disponibilidad, PWA, notificaciones, offline y rediseño completo de la vista semana móvil.
+
+## Criterios de aceptacion
+
+- [x] `/calendar` redirige a `/calendar/events`.
+- [x] `/calendar/events` muestra el calendario de eventos y mantiene creación rápida de eventos desde slot.
+- [x] `/calendar/projects` sigue mostrando la planificación anual de proyectos.
+- [x] La navegación muestra `Agenda` para eventos y `Plan anual` / `Plan` para proyectos.
+- [x] En móvil y desktop se ven toolbar, cabeceras, filas/celdas y eventos del calendario de eventos.
+- [x] No se mantiene vista unificada ni filtro `tipo`.
+
+## Plan tecnico
+
+Usar `CalendarEvents` para `/calendar/events` y `CalendarProjects` para `/calendar/projects`. Dejar `/calendar` como redirect simple a eventos. No crear vista unificada ni filtro `tipo`; la separación reduce ambigüedad y conserva el modelo mental evento exacto / proyecto por rango. Ajustar la vista de eventos para que no conserve `week` si el viewport pasa a móvil.
+
+## Validacion
+
+- `npm run lint`
+- `npm run build`
+- Smoke visual de `/calendar`, `/calendar/events` y `/calendar/projects` en 320 px, 390 px, 768 px y desktop.
+- Verificar que React Big Calendar mantiene altura real y que toolbar, cabeceras, filas/celdas y eventos son visibles.
+
+## Resultado
+
+Implementado en `release/0.1.0-beta.18`. Pendiente de review, PR y cierre de release.
+
+## Desarrollo
+
+- Rama: `release/0.1.0-beta.18`
+- PR:
+- Estado actual: Implementado localmente y listo para review.
+
+## Notas de progreso
+
+- Se elimina la vista unificada tras revisión visual negativa.
+- `/calendar` queda como redirect a `/calendar/events`.
+- `/calendar/events` vuelve a ser el calendario operativo de eventos.
+- `/calendar/projects` se mantiene como planificación anual y la navegación usa `Agenda` / `Plan anual`.
+- La vista de eventos evita mantener `week` cuando el viewport pasa a móvil.
+
+## Cambios de alcance y decisiones
+
+Decisión del 2026-05-13: no mantener agenda unificada en beta 18. La experiencia es peor que separar evento y plan. No se toca Supabase, RLS, schema ni rediseño mayor de semana móvil.
+
+## Bloqueos
+
+Sin bloqueos.
+
+## Validación ejecutada
+
+- `npm run lint`
+- `npm run test`
+- `npm run build`
+- `npm run test:e2e -- e2e/beta18.spec.ts`
+- Smoke visual de `/calendar`, `/calendar/events` y `/calendar/projects` en 320, 390, 768 y desktop.
+
+## Memoria
+
+Memoria: no aplica.

--- a/docs/project/issues/CACH-0056.md
+++ b/docs/project/issues/CACH-0056.md
@@ -16,7 +16,7 @@ tags:
 generated: false
 work_type: feature
 work_level: slice
-issue_workflow: review
+issue_workflow: done
 priority: p1
 size: m
 area: frontend
@@ -68,13 +68,13 @@ Usar `CalendarEvents` para `/calendar/events` y `CalendarProjects` para `/calend
 
 ## Resultado
 
-Implementado en `release/0.1.0-beta.18`. Pendiente de review, PR y cierre de release.
+Implementado y cerrado en `RELEASE-0.1.0-beta.18`.
 
 ## Desarrollo
 
 - Rama: `release/0.1.0-beta.18`
-- PR:
-- Estado actual: Implementado localmente y listo para review.
+- PR: https://github.com/dignacioconde/culturApp/pull/104
+- Estado actual: cerrada en la rama de release.
 
 ## Notas de progreso
 
@@ -83,6 +83,7 @@ Implementado en `release/0.1.0-beta.18`. Pendiente de review, PR y cierre de rel
 - `/calendar/events` vuelve a ser el calendario operativo de eventos.
 - `/calendar/projects` se mantiene como planificación anual y la navegación usa `Agenda` / `Plan anual`.
 - La vista de eventos evita mantener `week` cuando el viewport pasa a móvil.
+- PR #104 abierta hacia `main`.
 
 ## Cambios de alcance y decisiones
 
@@ -99,6 +100,7 @@ Sin bloqueos.
 - `npm run build`
 - `npm run test:e2e -- e2e/beta18.spec.ts`
 - Smoke visual de `/calendar`, `/calendar/events` y `/calendar/projects` en 320, 390, 768 y desktop.
+- `npm run verify:pr -- --base origin/main`
 
 ## Memoria
 

--- a/docs/project/plans/CURRENT_PLAN.md
+++ b/docs/project/plans/CURRENT_PLAN.md
@@ -5,7 +5,7 @@ id: PB-CURRENT-PLAN
 title: Current Plan
 lifecycle: active
 created: '2026-05-05'
-updated: '2026-05-11'
+updated: '2026-05-13'
 aliases:
   - Current Plan
 tags:
@@ -18,11 +18,11 @@ generated: false
 
 ## Foco actual
 
-Beta 17 queda cerrada con feedback cualitativo simple propio en Supabase. No hay release activa.
+Beta 18 activa: cerrar P1 visible de UX core con notas contextuales, pulido financiero movil y calendarios separados más claros, sin tocar `CACH-B0004` ni modelo financiero.
 
 ## Release activa
 
-No hay release activa.
+[[../releases/RELEASE-0.1.0-beta.18|RELEASE-0.1.0-beta.18]] — Cierre P1 UX core.
 
 Últimos cortes:
 
@@ -44,12 +44,14 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 - Beta 15 cierra `CACH-0051`: dominio publico canonico `app.caches.es`, Vercel, Supabase Auth redirects y Edge Function `APP_URL`.
 - Beta 16 cierra `CACH-0042`: racionalizar navegacion inferior movil.
 - Beta 17 cierra `CACH-0052`: feedback simple propio en Supabase y PostHog diferido.
+- Beta 18 queda activa para `CACH-0054`, `CACH-0055` y `CACH-0056`.
 
 ## Prioridades
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
 2. Mantener el feedback beta simple antes de introducir analitica de producto.
 3. No introducir PostHog, Plausible ni analitica de eventos sin issue/ADR posterior.
+4. No mezclar beta 18 con contratantes, facturacion, liquidacion neta, migraciones, RLS ni cambios de formulas financieras.
 
 ## Plan operativo
 
@@ -62,8 +64,8 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 
 ## Próximo checkpoint
 
-Aplicar la migracion remota de Supabase de beta 17 solo con confirmacion humana explicita, y elegir el siguiente corte cuando haga falta.
+Completar beta 18 y verificar visualmente dashboard, detalles y calendarios en mobile/desktop.
 
 ## Siguiente release candidata
 
-Tras beta 17, evaluar si basta el feedback propio o si conviene abrir una ADR/issue especifica para PostHog con region UE y consentimiento explicito.
+Tras beta 18, evaluar `CACH-B0004` como release de datos separada para contratantes, facturacion y liquidacion neta.

--- a/docs/project/plans/CURRENT_PLAN.md
+++ b/docs/project/plans/CURRENT_PLAN.md
@@ -18,11 +18,11 @@ generated: false
 
 ## Foco actual
 
-Beta 18 activa: cerrar P1 visible de UX core con notas contextuales, pulido financiero movil y calendarios separados más claros, sin tocar `CACH-B0004` ni modelo financiero.
+Beta 18 queda cerrada con notas contextuales, pulido financiero movil y calendarios separados más claros. No hay release activa.
 
 ## Release activa
 
-[[../releases/RELEASE-0.1.0-beta.18|RELEASE-0.1.0-beta.18]] — Cierre P1 UX core.
+No hay release activa.
 
 Últimos cortes:
 
@@ -44,14 +44,14 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 - Beta 15 cierra `CACH-0051`: dominio publico canonico `app.caches.es`, Vercel, Supabase Auth redirects y Edge Function `APP_URL`.
 - Beta 16 cierra `CACH-0042`: racionalizar navegacion inferior movil.
 - Beta 17 cierra `CACH-0052`: feedback simple propio en Supabase y PostHog diferido.
-- Beta 18 queda activa para `CACH-0054`, `CACH-0055` y `CACH-0056`.
+- Beta 18 cierra `CACH-0054`, `CACH-0055` y `CACH-0056`: notas contextuales, quick forms financieros y calendario de eventos separado del plan anual.
 
 ## Prioridades
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
 2. Mantener el feedback beta simple antes de introducir analitica de producto.
 3. No introducir PostHog, Plausible ni analitica de eventos sin issue/ADR posterior.
-4. No mezclar beta 18 con contratantes, facturacion, liquidacion neta, migraciones, RLS ni cambios de formulas financieras.
+4. No abrir contratantes, facturacion, liquidacion neta, migraciones, RLS ni cambios de formulas financieras sin release nueva.
 
 ## Plan operativo
 
@@ -64,7 +64,7 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 
 ## Próximo checkpoint
 
-Completar beta 18 y verificar visualmente dashboard, detalles y calendarios en mobile/desktop.
+Elegir siguiente corte. Candidato principal: `CACH-B0004` como release de datos separada para contratantes, facturacion y liquidacion neta.
 
 ## Siguiente release candidata
 

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -5,7 +5,7 @@ id: PB-CURRENT-RELEASE
 title: Current Release
 lifecycle: active
 created: '2026-05-05'
-updated: '2026-05-11'
+updated: '2026-05-13'
 aliases:
   - Current Release
 tags:
@@ -13,17 +13,17 @@ tags:
   - release
   - current
 generated: false
-release_current: false
+release_current: true
 ---
 # Current Release
 
 ## Release activa
 
-No hay release activa.
+[[RELEASE-0.1.0-beta.18|RELEASE-0.1.0-beta.18]] — Cierre P1 UX core.
 
 ## Rama activa
 
-No aplica.
+`release/0.1.0-beta.18`
 
 ## Últimos cortes
 
@@ -43,16 +43,18 @@ No aplica.
 
 ## Scope actual
 
-Beta 17 queda cerrada. La app incorpora un formulario global de feedback propio en Supabase, sin PostHog, Plausible ni analitica de eventos.
+Beta 18 cierra P1 visible de UX core sin abrir modelo financiero nuevo.
 
 Issues incluidas:
 
-- [[../issues/CACH-0052|CACH-0052]] — Formulario simple de feedback beta.
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento.
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas.
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados.
 
 ## Regla de trabajo para esta release
 
-No iniciar trabajo nuevo desde una release activa hasta activar explicitamente el siguiente corte.
+Solo entra trabajo vinculado al scope de beta 18. `CACH-B0004`, contratantes, facturacion, gastos repercutibles, liquidacion neta, migraciones, RLS y cambios de formulas financieras quedan fuera.
 
 ## Como cerrar esta release
 
-Cerrada mediante PR #99. Tag `v0.1.0-beta.17` y smoke de produccion sobre `https://app.caches.es` tras merge a `main`. La migracion remota de Supabase queda pendiente de confirmacion humana explicita.
+Pendiente: validar issues incluidas, abrir PR `release/0.1.0-beta.18` -> `main`, esperar CI verde, mergear, etiquetar y verificar produccion si aplica.

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -13,17 +13,17 @@ tags:
   - release
   - current
 generated: false
-release_current: true
+release_current: false
 ---
 # Current Release
 
 ## Release activa
 
-[[RELEASE-0.1.0-beta.18|RELEASE-0.1.0-beta.18]] — Cierre P1 UX core.
+No hay release activa.
 
 ## Rama activa
 
-`release/0.1.0-beta.18`
+No aplica.
 
 ## Últimos cortes
 
@@ -41,9 +41,11 @@ release_current: true
 
 `RELEASE-0.1.0-beta.17` — feedback simple beta. Ver [[RELEASE-0.1.0-beta.17]].
 
+`RELEASE-0.1.0-beta.18` — cierre P1 UX core. Ver [[RELEASE-0.1.0-beta.18]].
+
 ## Scope actual
 
-Beta 18 cierra P1 visible de UX core sin abrir modelo financiero nuevo.
+Beta 18 queda cerrada. La app incorpora notas contextuales editables, quick forms financieros más ergonómicos y mantiene calendario de eventos separado del plan anual de proyectos.
 
 Issues incluidas:
 
@@ -53,8 +55,8 @@ Issues incluidas:
 
 ## Regla de trabajo para esta release
 
-Solo entra trabajo vinculado al scope de beta 18. `CACH-B0004`, contratantes, facturacion, gastos repercutibles, liquidacion neta, migraciones, RLS y cambios de formulas financieras quedan fuera.
+No iniciar trabajo nuevo desde una release activa hasta activar explicitamente el siguiente corte.
 
 ## Como cerrar esta release
 
-Pendiente: validar issues incluidas, abrir PR `release/0.1.0-beta.18` -> `main`, esperar CI verde, mergear, etiquetar y verificar produccion si aplica.
+Cerrada mediante PR #104. Tag `v0.1.0-beta.18` y smoke de produccion sobre `https://app.caches.es` tras merge a `main`.

--- a/docs/project/releases/RELEASE-0.1.0-beta.18.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.18.md
@@ -1,0 +1,153 @@
+---
+schema_version: 2
+kind: release
+id: RELEASE-0.1.0-beta.18
+title: Cierre P1 UX core
+lifecycle: active
+created: '2026-05-12'
+updated: '2026-05-13'
+aliases:
+  - RELEASE-0.1.0-beta.18
+tags:
+  - product-brain
+  - release
+  - beta
+  - ux
+generated: false
+release_phase: active
+release_current: true
+release_branch: release/0.1.0-beta.18
+release_tag: null
+release_pr: null
+---
+# RELEASE-0.1.0-beta.18 — Cierre P1 UX core
+
+## Estado
+
+Active.
+
+## Rama de release
+
+`release/0.1.0-beta.18`
+
+## Ciclo
+
+`0.1` es el ciclo organizativo. `0.1.0-beta.18` es un corte mergeable para cerrar P1 visible sin abrir modelo financiero nuevo.
+
+## Objetivo de la release
+
+Cerrar el P1 de UX core que falta: notas contextuales, pulido financiero móvil y calendarios separados más claros, manteniendo fuera los cambios de datos de contratantes y liquidación neta.
+
+## Alcance funcional
+
+- Edición contextual de notas en detalles de proyecto y evento usando el campo `notes` existente.
+- Pulido/regresión móvil financiera sin cambiar fórmulas, hooks públicos, RLS ni schema.
+- Calendario de eventos y plan anual de proyectos separados.
+- Compatibilidad de rutas: `/calendar` redirige a `/calendar/events` y `/calendar/projects` conserva la planificación anual.
+
+## Scope
+
+- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento.
+- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero móvil sin cambiar fórmulas.
+- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados.
+
+## Issues incluidas
+
+| Issue | Titulo | Workflow | Rama |
+|---|---|---|---|
+| [[../issues/CACH-0054|CACH-0054]] | Editar notas desde detalles de proyecto y evento | review | `release/0.1.0-beta.18` |
+| [[../issues/CACH-0055|CACH-0055]] | Pulido financiero movil sin cambiar formulas | review | `release/0.1.0-beta.18` |
+| [[../issues/CACH-0056|CACH-0056]] | Calendario de eventos y plan anual separados | review | `release/0.1.0-beta.18` |
+
+## Fuera de alcance
+
+- `CACH-B0004`.
+- Contratantes estructurados, `contractor_id`, facturación, gastos repercutibles y liquidación neta.
+- Migraciones Supabase, cambios de RLS o cambios de schema financiero.
+- Cambios de fórmulas financieras, KPIs o reglas de `cobro bruto/hora`.
+- PWA, notificaciones, offline, features Pro, perfil público o documentos.
+
+## Riesgos
+
+- Las rutas de calendario tocan navegación móvil; deben conservar `Agenda` para eventos y `Plan` como planificación anual.
+- React Big Calendar requiere altura real calculable; el cierre exige verificación visual.
+- El pulido financiero móvil puede parecer cambio de producto si reintroduce métricas o fórmulas; esta release solo cambia presentación y ergonomía.
+- Las notas contextuales no deben convertirse en adjuntos, CRM, privacidad avanzada ni gestión documental.
+
+## Decisiones relacionadas
+
+- [[../issues/CACH-B0001|CACH-B0001]] — Trabajos y jerarquía proyecto-evento.
+- [[../issues/CACH-B0002|CACH-B0002]] — Experiencia mobile financiera.
+- [[../issues/CACH-B0007|CACH-B0007]] — Calendario e interacción rápida.
+- [[../issues/CACH-B0004|CACH-B0004]] queda fuera de este corte.
+
+## Checklist de entrada
+
+- [x] Release creada
+- [x] Rama de release creada
+- [x] Issues asociadas
+- [x] Alcance definido
+- [x] Criterios de validacion definidos
+
+## Checklist de desarrollo
+
+- [x] Todas las issues estan en progreso o cerradas
+- [ ] Commits integrados en rama release
+- [ ] No hay cambios sueltos fuera de release
+- [x] No hay issues sin `issue_workflow`
+- [x] No hay decisiones importantes sin documentar
+
+## Checklist de estabilizacion
+
+- [x] `npm run lint`
+- [x] `npm run test`
+- [x] `npm run build`
+- [x] `npm run pb:guard`
+- [x] `npm run release:status`
+- [x] Revision visual responsive en 320, 390, 768 y desktop
+- [x] Calendario verificado con toolbar, cabeceras, filas/celdas y eventos/proyectos visibles
+- [x] Formulas financieras confirmadas sin cambios
+
+## Checklist de salida
+
+- [ ] PR `release/0.1.0-beta.18` -> `main` abierta
+- [ ] CI en verde
+- [ ] PR mergeada en `main`
+- [ ] Tag creado desde `main` si aplica
+- [ ] Produccion verificada o marcada no aplica
+- [ ] Rama remota `release/0.1.0-beta.18` eliminada si aplica
+- [ ] Release notes actualizadas
+- [ ] Issues marcadas como `done`
+- [ ] Estado actual actualizado
+- [ ] Current Release actualizado
+- [ ] Backlog actualizado
+- [ ] Proximos pasos documentados
+
+## Release notes
+
+### Aniadido
+
+- Edición contextual de notas en detalles de proyecto y evento.
+
+### Cambiado
+
+- Navegación `Agenda` apunta al calendario de eventos; `Plan` mantiene la planificación anual de proyectos.
+- Flujos financieros móviles quedan más directos sin cambiar fórmulas ni modelo de datos.
+
+### Corregido
+
+- Las notas ya no dependen de abrir el formulario completo para una edición rápida desde el detalle.
+
+### Eliminado
+
+- No aplica.
+
+### Tecnico
+
+- `/calendar` queda como redirect compatible hacia `/calendar/events`.
+- La vista unificada se descarta para beta 18: eventos y plan anual quedan separados.
+- No se añaden migraciones ni cambios de RLS.
+
+## Resultado final
+
+Implementación local completa en `release/0.1.0-beta.18`. Pendiente de commits, PR, CI, merge y verificación de producción si aplica.

--- a/docs/project/releases/RELEASE-0.1.0-beta.18.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.18.md
@@ -14,17 +14,17 @@ tags:
   - beta
   - ux
 generated: false
-release_phase: active
-release_current: true
+release_phase: released
+release_current: false
 release_branch: release/0.1.0-beta.18
-release_tag: null
-release_pr: null
+release_tag: v0.1.0-beta.18
+release_pr: https://github.com/dignacioconde/culturApp/pull/104
 ---
 # RELEASE-0.1.0-beta.18 — Cierre P1 UX core
 
 ## Estado
 
-Active.
+Released.
 
 ## Rama de release
 
@@ -55,9 +55,9 @@ Cerrar el P1 de UX core que falta: notas contextuales, pulido financiero móvil 
 
 | Issue | Titulo | Workflow | Rama |
 |---|---|---|---|
-| [[../issues/CACH-0054|CACH-0054]] | Editar notas desde detalles de proyecto y evento | review | `release/0.1.0-beta.18` |
-| [[../issues/CACH-0055|CACH-0055]] | Pulido financiero movil sin cambiar formulas | review | `release/0.1.0-beta.18` |
-| [[../issues/CACH-0056|CACH-0056]] | Calendario de eventos y plan anual separados | review | `release/0.1.0-beta.18` |
+| [[../issues/CACH-0054|CACH-0054]] | Editar notas desde detalles de proyecto y evento | done | `release/0.1.0-beta.18` |
+| [[../issues/CACH-0055|CACH-0055]] | Pulido financiero movil sin cambiar formulas | done | `release/0.1.0-beta.18` |
+| [[../issues/CACH-0056|CACH-0056]] | Calendario de eventos y plan anual separados | done | `release/0.1.0-beta.18` |
 
 ## Fuera de alcance
 
@@ -91,9 +91,9 @@ Cerrar el P1 de UX core que falta: notas contextuales, pulido financiero móvil 
 
 ## Checklist de desarrollo
 
-- [x] Todas las issues estan en progreso o cerradas
-- [ ] Commits integrados en rama release
-- [ ] No hay cambios sueltos fuera de release
+- [x] Todas las issues estan cerradas o listas para release
+- [x] Commits integrados en rama release
+- [x] No hay cambios sueltos fuera de release
 - [x] No hay issues sin `issue_workflow`
 - [x] No hay decisiones importantes sin documentar
 
@@ -110,18 +110,18 @@ Cerrar el P1 de UX core que falta: notas contextuales, pulido financiero móvil 
 
 ## Checklist de salida
 
-- [ ] PR `release/0.1.0-beta.18` -> `main` abierta
-- [ ] CI en verde
-- [ ] PR mergeada en `main`
-- [ ] Tag creado desde `main` si aplica
-- [ ] Produccion verificada o marcada no aplica
-- [ ] Rama remota `release/0.1.0-beta.18` eliminada si aplica
-- [ ] Release notes actualizadas
-- [ ] Issues marcadas como `done`
-- [ ] Estado actual actualizado
-- [ ] Current Release actualizado
-- [ ] Backlog actualizado
-- [ ] Proximos pasos documentados
+- [x] PR `release/0.1.0-beta.18` -> `main` abierta
+- [x] CI en verde
+- [x] PR mergeada en `main`
+- [x] Tag creado desde `main` si aplica
+- [x] Produccion verificada
+- [x] Rama remota `release/0.1.0-beta.18` conservada para trazabilidad
+- [x] Release notes actualizadas
+- [x] Issues marcadas como `done`
+- [x] Estado actual actualizado
+- [x] Current Release actualizado
+- [x] Backlog actualizado
+- [x] Proximos pasos documentados
 
 ## Release notes
 
@@ -147,7 +147,9 @@ Cerrar el P1 de UX core que falta: notas contextuales, pulido financiero móvil 
 - `/calendar` queda como redirect compatible hacia `/calendar/events`.
 - La vista unificada se descarta para beta 18: eventos y plan anual quedan separados.
 - No se añaden migraciones ni cambios de RLS.
+- Validacion local completada: lint, tests, build, Product Brain, release status, `verify:pr`, React Doctor diff y smoke E2E beta 18.
+- PR #104 abierta hacia `main`.
 
 ## Resultado final
 
-Implementación local completa en `release/0.1.0-beta.18`. Pendiente de commits, PR, CI, merge y verificación de producción si aplica.
+Release cerrada mediante PR #104. Tag `v0.1.0-beta.18` creado desde `main`; produccion verificada en `https://app.caches.es` con smoke de rutas SPA.

--- a/e2e/beta18.spec.ts
+++ b/e2e/beta18.spec.ts
@@ -1,0 +1,263 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const userId = '00000000-0000-4000-8000-000000000018'
+const supabaseUrl = process.env.VITE_SUPABASE_URL ?? 'https://mkidexrkhjhrsjnjmugw.supabase.co'
+const projectRef = new URL(supabaseUrl).hostname.split('.')[0]
+const authStorageKey = `sb-${projectRef}-auth-token`
+const currentYear = new Date().getFullYear()
+const currentMonth = String(new Date().getMonth() + 1).padStart(2, '0')
+const projectId = 'project-beta-18'
+const eventId = 'event-beta-18'
+
+const authSession = {
+  access_token: 'local-beta18-e2e-token',
+  refresh_token: 'local-beta18-e2e-refresh',
+  expires_at: Math.floor(Date.now() / 1000) + 3600,
+  expires_in: 3600,
+  token_type: 'bearer',
+  user: {
+    id: userId,
+    aud: 'authenticated',
+    role: 'authenticated',
+    email: 'beta18@example.com',
+    app_metadata: { provider: 'email', providers: ['email'] },
+    user_metadata: {},
+    created_at: new Date().toISOString(),
+  },
+}
+
+const profile = {
+  id: userId,
+  full_name: 'Beta 18',
+  profession: 'Gestora cultural',
+  tax_rate: 15,
+  onboarding_completed: true,
+  usage_consent: true,
+  role: 'user',
+}
+
+const project = {
+  id: projectId,
+  user_id: userId,
+  name: 'Gira Norte',
+  client: 'Auditorio Central',
+  category: 'musica',
+  status: 'confirmed',
+  start_date: `${currentYear}-${currentMonth}-01`,
+  end_date: `${currentYear}-${currentMonth}-28`,
+  color: '#4f98a3',
+  notes: 'Necesidades tecnicas confirmadas.',
+}
+
+const event = {
+  id: eventId,
+  user_id: userId,
+  project_id: projectId,
+  name: 'Ensayo general',
+  client: 'Auditorio Central',
+  category: 'musica',
+  status: 'confirmed',
+  start_datetime: `${currentYear}-${currentMonth}-15T10:00:00+01:00`,
+  end_datetime: `${currentYear}-${currentMonth}-15T12:00:00+01:00`,
+  color: '#C94035',
+  notes: 'Llegar 30 minutos antes.',
+}
+
+const incomes = [
+  {
+    id: 'income-beta-18',
+    user_id: userId,
+    project_id: null,
+    event_id: eventId,
+    concept: 'Cache ensayo',
+    amount: 240,
+    tax_rate: 15,
+    expected_date: `${currentYear}-${currentMonth}-15`,
+    paid_date: `${currentYear}-${currentMonth}-16`,
+    is_paid: true,
+  },
+]
+
+const expenses = [
+  {
+    id: 'expense-beta-18',
+    user_id: userId,
+    project_id: projectId,
+    event_id: null,
+    concept: 'Transporte',
+    amount: 25,
+    category: 'transporte',
+    expense_date: `${currentYear}-${currentMonth}-14`,
+    is_deductible: true,
+  },
+]
+
+const viewports = [
+  { label: '320', width: 320, height: 740 },
+  { label: '390', width: 390, height: 844 },
+  { label: '768', width: 768, height: 1024 },
+  { label: 'desktop', width: 1366, height: 900 },
+]
+
+function jsonResponse(body: unknown) {
+  return {
+    status: 200,
+    contentType: 'application/json',
+    headers: { 'cache-control': 'no-store' },
+    body: JSON.stringify(body),
+  }
+}
+
+async function setupBeta18(page: Page) {
+  let projects = [{ ...project }]
+  let events = [{ ...event }]
+
+  await page.addInitScript(({ key, value }) => {
+    window.localStorage.setItem(key, JSON.stringify(value))
+  }, { key: authStorageKey, value: authSession })
+
+  await page.route('**/auth/v1/**', async (route) => {
+    await route.fulfill(jsonResponse(authSession))
+  })
+
+  await page.route('**/rest/v1/**', async (route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+    const table = url.pathname.split('/').pop()
+    const method = request.method()
+
+    if (table === 'profiles') {
+      await route.fulfill(jsonResponse(profile))
+      return
+    }
+
+    if (table === 'projects') {
+      if (method === 'PATCH') {
+        const patch = request.postDataJSON()
+        projects = projects.map((item, index) => (index === 0 ? { ...item, ...patch } : item))
+        await route.fulfill(jsonResponse(projects[0]))
+        return
+      }
+      await route.fulfill(jsonResponse(projects))
+      return
+    }
+
+    if (table === 'events') {
+      if (method === 'PATCH') {
+        const patch = request.postDataJSON()
+        events = events.map((item, index) => (index === 0 ? { ...item, ...patch } : item))
+        await route.fulfill(jsonResponse(events[0]))
+        return
+      }
+      await route.fulfill(jsonResponse(events))
+      return
+    }
+
+    if (table === 'incomes') {
+      await route.fulfill(jsonResponse(incomes))
+      return
+    }
+
+    if (table === 'expenses') {
+      await route.fulfill(jsonResponse(expenses))
+      return
+    }
+
+    await route.fulfill(jsonResponse([]))
+  })
+}
+
+async function expectCalendarChrome(page: Page) {
+  await expect(page.locator('.rbc-toolbar')).toBeVisible()
+  await expect(page.locator('.rbc-header').first()).toBeVisible()
+  await expect(page.locator('.rbc-day-bg, .rbc-date-cell').first()).toBeVisible()
+  await expect(page.locator('.rbc-event').first()).toBeVisible()
+}
+
+async function expectQuickIncomeDialog(page: Page, isMobile: boolean) {
+  await page.getByRole('button', { name: isMobile ? 'Cobro' : 'Ingreso' }).first().click()
+  const dialog = page.getByRole('dialog', { name: 'Cobro rápido' })
+  await expect(dialog).toBeVisible()
+  await dialog.getByLabel('Concepto').fill('Cache personalizado')
+  await dialog.getByLabel(/Importe/).fill('123,45')
+  await expect(dialog.getByLabel('Marcar como cobrado')).toBeChecked()
+  await dialog.getByRole('button', { name: 'Cerrar' }).click()
+}
+
+function contextNotesCard(page: Page) {
+  return page
+    .getByRole('heading', { name: 'Notas' })
+    .locator('xpath=ancestor::div[contains(@class, "rounded-lg") and contains(@class, "border")][1]')
+}
+
+async function editAndClearContextNote(page: Page, nextNote: string) {
+  const card = contextNotesCard(page)
+  await card.getByRole('button', { name: 'Editar' }).click()
+  await card.getByLabel('Nota').fill(nextNote)
+  const patchResponsePromise = page.waitForResponse((response) =>
+    response.url().includes('/rest/v1/') && response.request().method() === 'PATCH'
+  )
+  await card.getByRole('button', { name: 'Guardar nota' }).click()
+  const patchResponse = await patchResponsePromise
+  expect((await patchResponse.json()).notes).toBe(nextNote)
+  await expect(card.getByText(nextNote)).toBeVisible()
+  await page.reload()
+  const reloadedCard = contextNotesCard(page)
+  await expect(reloadedCard.getByText(nextNote)).toBeVisible()
+  await reloadedCard.getByRole('button', { name: 'Editar' }).click()
+  await reloadedCard.getByRole('button', { name: 'Limpiar nota' }).click()
+  await expect(reloadedCard.getByText(/no hay notas/)).toBeVisible()
+}
+
+for (const viewport of viewports) {
+  test(`beta 18 smoke visual en ${viewport.label}`, async ({ page }) => {
+    const isMobile = viewport.width < 640
+    await page.setViewportSize({ width: viewport.width, height: viewport.height })
+    await setupBeta18(page)
+
+    await page.goto('/dashboard')
+    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible()
+
+    await page.goto(`/projects/${projectId}`)
+    await expect(page.getByRole('heading', { name: 'Gira Norte' }).first()).toBeVisible()
+    await expect(page.getByText('Apuntes privados para preparar y recordar detalles.')).toBeVisible()
+    await expect(page.getByText('Necesidades tecnicas confirmadas.')).toBeVisible()
+    await expectQuickIncomeDialog(page, isMobile)
+
+    await page.goto(`/events/${eventId}`)
+    await expect(page.getByRole('heading', { name: 'Ensayo general' }).first()).toBeVisible()
+    await expect(page.getByText('Apuntes privados para preparar y recordar detalles.')).toBeVisible()
+    await expect(page.getByText('Llegar 30 minutos antes.')).toBeVisible()
+    await expectQuickIncomeDialog(page, isMobile)
+
+    await page.goto('/calendar')
+    await expect(page).toHaveURL(/\/calendar\/events$/)
+    await expect(page.getByRole('heading', { name: 'Calendario de eventos' })).toBeVisible()
+    await expect(page.getByText('1 eventos')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Nuevo evento' })).toBeVisible()
+    await expectCalendarChrome(page)
+    await page.getByText('Ensayo general').first().click()
+    await expect(page.getByRole('heading', { name: 'Ensayo general' })).toBeVisible()
+
+    await page.goto('/calendar/events')
+    await expect(page.getByRole('heading', { name: 'Calendario de eventos' })).toBeVisible()
+    await expect(page.getByText('1 eventos')).toBeVisible()
+    await expectCalendarChrome(page)
+
+    await page.goto('/calendar/projects')
+    await expect(page.getByRole('heading', { name: 'Calendario de proyectos' })).toBeVisible()
+    await expect(page.getByText('Resumen')).toBeVisible()
+    await expect(page.getByRole('button', { name: /Gira Norte/ }).first()).toBeVisible()
+  })
+}
+
+test('beta 18 permite editar y limpiar notas contextuales', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await setupBeta18(page)
+
+  await page.goto(`/projects/${projectId}`)
+  await editAndClearContextNote(page, 'Nota actualizada de proyecto')
+
+  await page.goto(`/events/${eventId}`)
+  await editAndClearContextNote(page, 'Nota actualizada de evento')
+})

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -95,6 +95,7 @@ export default function App() {
         <Route path="/register" element={<PublicRoute><Register /></PublicRoute>} />
         <Route path="/onboarding" element={<PrivateRoute><Onboarding /></PrivateRoute>} />
         <Route path="/dashboard" element={<PrivateRoute><Dashboard /></PrivateRoute>} />
+        <Route path="/calendar" element={<Navigate to="/calendar/events" replace />} />
         <Route path="/calendar/events" element={<PrivateRoute><CalendarEvents /></PrivateRoute>} />
         <Route path="/calendar/projects" element={<PrivateRoute><CalendarProjects /></PrivateRoute>} />
         <Route path="/events" element={<PrivateRoute><EventList /></PrivateRoute>} />
@@ -105,7 +106,6 @@ export default function App() {
         <Route path="/settings" element={<PrivateRoute><Settings /></PrivateRoute>} />
         <Route path="/data" element={<PrivateRoute><Data /></PrivateRoute>} />
         <Route path="/admin/invitaciones" element={<PrivateRoute requireAdmin><AdminInvites /></PrivateRoute>} />
-        <Route path="/calendar" element={<Navigate to="/calendar/events" replace />} />
         <Route path="*" element={<Navigate to="/dashboard" replace />} />
       </Routes>
     </BrowserRouter>

--- a/src/components/layout/navigation.js
+++ b/src/components/layout/navigation.js
@@ -3,8 +3,8 @@ import { Database, LayoutDashboard, CalendarDays, CalendarRange, Briefcase, Sett
 export const navItems = [
   { to: '/work', icon: Briefcase, label: 'Trabajos', mobileLabel: 'Trabajos', activePaths: ['/work', '/projects', '/events'] },
   { to: '/dashboard', icon: LayoutDashboard, label: 'Dashboard', mobileLabel: 'Inicio' },
-  { to: '/calendar/events', icon: CalendarDays, label: 'Cal. eventos', mobileLabel: 'Agenda' },
-  { to: '/calendar/projects', icon: CalendarRange, label: 'Cal. proyectos', mobileLabel: 'Plan' },
+  { to: '/calendar/events', icon: CalendarDays, label: 'Agenda', mobileLabel: 'Agenda', activePaths: ['/calendar', '/calendar/events'] },
+  { to: '/calendar/projects', icon: CalendarRange, label: 'Plan anual', mobileLabel: 'Plan' },
   { to: '/data', icon: Database, label: 'Tus datos', mobileLabel: 'Datos' },
   { to: '/settings', icon: Settings, label: 'Ajustes', mobileLabel: 'Ajustes' },
 ]
@@ -12,6 +12,7 @@ export const navItems = [
 const detailRoutePattern = /^\/(?:events|projects)\/[^/]+/
 
 export function isNavigationItemActive(item, pathname, navLinkActive = false) {
+  if (item.to === '/calendar/events') return pathname === '/calendar' || pathname === '/calendar/events'
   if (navLinkActive) return true
   return item.activePaths?.some((path) => {
     if (pathname === path) return true

--- a/src/components/layout/navigation.test.js
+++ b/src/components/layout/navigation.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { isNavigationItemActive, navItems } from './navigation'
+
+const byLabel = (label) => navItems.find((item) => item.mobileLabel === label)
+
+describe('navigation active states', () => {
+  it('keeps Agenda active for the event calendar and /calendar redirect only', () => {
+    const agenda = byLabel('Agenda')
+
+    expect(isNavigationItemActive(agenda, '/calendar')).toBe(true)
+    expect(isNavigationItemActive(agenda, '/calendar/events')).toBe(true)
+    expect(isNavigationItemActive(agenda, '/calendar/projects', true)).toBe(false)
+  })
+
+  it('keeps Plan active for the annual project calendar', () => {
+    const plan = byLabel('Plan')
+
+    expect(isNavigationItemActive(plan, '/calendar/projects', true)).toBe(true)
+    expect(isNavigationItemActive(plan, '/calendar')).toBe(false)
+    expect(isNavigationItemActive(plan, '/calendar/events')).toBe(false)
+  })
+})

--- a/src/components/ui/ContextNotesCard.jsx
+++ b/src/components/ui/ContextNotesCard.jsx
@@ -1,0 +1,108 @@
+import { useState } from 'react'
+import { Edit } from 'lucide-react'
+import { Button } from './Button'
+import { Card } from './Card'
+import { Textarea } from './Input'
+
+export function ContextNotesCard({
+  title = 'Notas',
+  notes = '',
+  emptyText = 'Aún no hay notas.',
+  placeholder = 'Añade detalles útiles para este trabajo...',
+  onSave,
+  savingLabel = 'Guardando...',
+}) {
+  const currentNotes = notes ?? ''
+  const hasNotes = currentNotes.trim().length > 0
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(currentNotes)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  const startEditing = () => {
+    setDraft(currentNotes)
+    setError('')
+    setEditing(true)
+  }
+
+  const cancelEditing = () => {
+    setDraft(currentNotes)
+    setError('')
+    setEditing(false)
+  }
+
+  const saveNotes = async (nextNotes = draft) => {
+    setSaving(true)
+    setError('')
+    try {
+      const { error: saveError } = await onSave(nextNotes.trim())
+      if (saveError) {
+        setError('No hemos podido guardar la nota. Revisa la conexión y vuelve a intentarlo.')
+        return
+      }
+      setEditing(false)
+    } catch {
+      setError('No hemos podido guardar la nota. Revisa la conexión y vuelve a intentarlo.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Card className="p-4 sm:p-5">
+      <div className="flex flex-col gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold text-[var(--color-ink)]">{title}</h3>
+            <p className="mt-1 text-xs text-[var(--color-ink-muted)]">Apuntes privados para preparar y recordar detalles.</p>
+          </div>
+          {!editing && (
+            <button
+              type="button"
+              onClick={startEditing}
+              className="inline-flex min-h-9 shrink-0 items-center gap-1 rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-paper)] px-3 py-1.5 text-xs font-medium text-[var(--color-ink)] transition-colors hover:bg-[var(--color-paper-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-red)] focus-visible:ring-offset-2"
+            >
+              <Edit size={14} />
+              {hasNotes ? 'Editar' : 'Añadir'}
+            </button>
+          )}
+        </div>
+
+        {editing ? (
+          <div className="flex flex-col gap-3">
+            <Textarea
+              label="Nota"
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              placeholder={placeholder}
+              className="min-h-32"
+              disabled={saving}
+            />
+            {error && <p className="rounded-lg bg-[var(--color-red-light)] px-3 py-2 text-sm text-[var(--color-red)]">{error}</p>}
+            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <Button type="button" variant="ghost" onClick={() => saveNotes('')} disabled={saving || !hasNotes} className="justify-center">
+                Limpiar nota
+              </Button>
+              <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                <Button type="button" variant="secondary" onClick={cancelEditing} disabled={saving} className="justify-center">
+                  Cancelar
+                </Button>
+                <Button type="button" onClick={() => saveNotes()} disabled={saving} className="justify-center">
+                  {saving ? savingLabel : 'Guardar nota'}
+                </Button>
+              </div>
+            </div>
+          </div>
+        ) : hasNotes ? (
+          <div className="rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-surface-alt)] px-3 py-3">
+            <p className="whitespace-pre-wrap break-words text-sm leading-6 text-[var(--color-ink)]">{currentNotes}</p>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed border-[var(--color-paper-mid)] bg-[var(--color-surface-alt)] px-3 py-4 text-sm text-[var(--color-ink-muted)]">
+            {emptyText}
+          </div>
+        )}
+      </div>
+    </Card>
+  )
+}

--- a/src/pages/Calendar/CalendarEvents.jsx
+++ b/src/pages/Calendar/CalendarEvents.jsx
@@ -69,8 +69,8 @@ export default function CalendarEvents() {
   
   // En móvil solo mostrar month y day, no week
   const availableViews = isMobile ? ['month', 'day'] : ['month', 'week', 'day']
-  
-  const timeGridMinWidth = calendarView === 'week' ? 'min-w-[46rem]' : calendarView === 'day' ? 'min-w-[22rem]' : 'min-w-full'
+  const activeCalendarView = isMobile && calendarView === 'week' ? 'month' : calendarView
+  const timeGridMinWidth = activeCalendarView === 'week' ? 'min-w-[46rem]' : activeCalendarView === 'day' ? 'min-w-[22rem]' : 'min-w-full'
 
   const calendarEvents = useMemo(() =>
     events.map((e) => ({
@@ -115,10 +115,10 @@ export default function CalendarEvents() {
   const handleSelectSlot = ({ start, end }) => {
     const slotStart = dayjs(start)
     const startsAtMidnight = slotStart.hour() === 0 && slotStart.minute() === 0
-    const eventStart = startsAtMidnight && calendarView === 'month'
+    const eventStart = startsAtMidnight && activeCalendarView === 'month'
       ? slotStart.hour(8)
       : slotStart
-    const eventEnd = calendarView === 'month'
+    const eventEnd = activeCalendarView === 'month'
       ? eventStart.add(1, 'hour')
       : dayjs(end).isAfter(eventStart)
       ? dayjs(end)
@@ -162,7 +162,7 @@ export default function CalendarEvents() {
                     localizer={localizer}
                     events={calendarEvents}
                     date={calendarDate}
-                    view={calendarView}
+                    view={activeCalendarView}
                     views={availableViews}
                     messages={messages}
                     formats={calendarFormats}

--- a/src/pages/Events/EventDetail.jsx
+++ b/src/pages/Events/EventDetail.jsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Plus, Trash2, CheckCircle, Circle, Edit, ChevronDown, Extern
 import { PageWrapper } from '../../components/layout/PageWrapper'
 import { Card } from '../../components/ui/Card'
 import { Button } from '../../components/ui/Button'
+import { ContextNotesCard } from '../../components/ui/ContextNotesCard'
 import { StatusBadge } from '../../components/ui/Badge'
 import { Modal } from '../../components/ui/Modal'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
@@ -16,7 +17,7 @@ import { useEvents } from '../../hooks/useEvents'
 import { useProjects } from '../../hooks/useProjects'
 import { useIncomes } from '../../hooks/useIncomes'
 import { useExpenses } from '../../hooks/useExpenses'
-import { formatCurrency, formatCurrencyPerHour, formatDate, formatDatetime, formatHours, parseDecimal } from '../../lib/formatters'
+import { formatCurrency, formatCurrencyPerHour, formatDate, formatDatetime, formatHours } from '../../lib/formatters'
 import { normalizeExpenseForm, normalizeIncomeForm } from '../../lib/financeForms'
 import { formatDueDescription, formatDueText, getDueDays } from '../../lib/dueDates'
 import { isPaid, markPaid, markUnpaid, needsQuickPaidConfirmation, paymentDate } from '../../lib/payment'
@@ -77,16 +78,16 @@ export default function EventDetail() {
   const [savingIncomeId, setSavingIncomeId] = useState(null)
   const [pendingPaymentConfirmationIncome, setPendingPaymentConfirmationIncome] = useState(null)
   const [quickIncomeModal, setQuickIncomeModal] = useState(false)
-  const quickIncomeDefault = () => ({ amount: '', is_paid: true })
-  const [quickIncomeForm, setQuickIncomeForm] = useState(() => ({ amount: '', is_paid: true }))
+  const quickIncomeDefault = () => ({ concept: event?.name || 'Ingreso', amount: '', is_paid: true })
+  const [quickIncomeForm, setQuickIncomeForm] = useState(() => quickIncomeDefault())
 
   const [expenseModal, setExpenseModal] = useState(false)
   const [editingExpense, setEditingExpense] = useState(null)
   const [expenseForm, setExpenseForm] = useState(() => createExpenseForm())
   const [savingExpense, setSavingExpense] = useState(false)
   const [quickExpenseModal, setQuickExpenseModal] = useState(false)
-  const quickExpenseDefault = () => ({ amount: '', category: 'otros' })
-  const [quickExpenseForm, setQuickExpenseForm] = useState(() => ({ amount: '', category: 'otros' }))
+  const quickExpenseDefault = () => ({ concept: event?.name || 'Gasto', amount: '', category: 'otros' })
+  const [quickExpenseForm, setQuickExpenseForm] = useState(() => quickExpenseDefault())
   const [financialSummaryExpanded, setFinancialSummaryExpanded] = useState(false)
 
   if (eventsLoading) {
@@ -125,31 +126,36 @@ export default function EventDetail() {
   const grossHourlyRate = eventHours > 0 ? totalPaid / eventHours : 0
   const netProfit = totalPaid - totalRetentions - totalExpenses
   const openQuickIncome = () => {
+    setQuickIncomeForm(quickIncomeDefault())
     setQuickIncomeModal(true)
   }
 
   const handleQuickSubmitIncome = async (e) => {
     e.preventDefault()
-    const amount = parseDecimal(quickIncomeForm.amount)
-    if (amount === null || amount <= 0) {
-      addToast('Pon un importe mayor que 0.', 'error')
-      return
-    }
-    const payload = {
-      concept: event?.name || 'Ingreso',
-      amount,
+    const { payload, error: validationError } = normalizeIncomeForm({
+      concept: quickIncomeForm.concept.trim() || event?.name || 'Ingreso',
+      amount: quickIncomeForm.amount,
       tax_rate: defaultTaxRate,
       expected_date: eventDate,
       paid_date: quickIncomeForm.is_paid ? paymentDate(new Date()) : null,
       is_paid: quickIncomeForm.is_paid,
+    }, { defaultTaxRate })
+    if (validationError) {
+      addToast(validationError === 'amount' ? 'Pon un importe mayor que 0.' : 'Revisa el IRPF.', 'error')
+      return
     }
     setSavingIncome(true)
-    const { error } = await createIncome({ ...payload, event_id: id })
-    setSavingIncome(false)
-    if (error) { addToast('Error al guardar.', 'error'); return }
-    addToast('Ingreso añadido.')
-    setQuickIncomeForm(quickIncomeDefault())
-    setQuickIncomeModal(false)
+    try {
+      const { error } = await createIncome({ ...payload, event_id: id })
+      if (error) { addToast('Error al guardar.', 'error'); return }
+      addToast('Ingreso añadido.')
+      setQuickIncomeForm(quickIncomeDefault())
+      setQuickIncomeModal(false)
+    } catch {
+      addToast('Error al guardar.', 'error')
+    } finally {
+      setSavingIncome(false)
+    }
   }
 
   const openEditIncome = (income) => {
@@ -166,30 +172,35 @@ export default function EventDetail() {
   }
 
   const openQuickExpense = () => {
+    setQuickExpenseForm(quickExpenseDefault())
     setQuickExpenseModal(true)
   }
 
   const handleQuickSubmitExpense = async (e) => {
     e.preventDefault()
-    const amount = parseDecimal(quickExpenseForm.amount)
-    if (amount === null || amount <= 0) {
-      addToast('Pon un importe mayor que 0.', 'error')
-      return
-    }
-    const payload = {
-      concept: event?.name || 'Gasto',
-      amount,
+    const { payload, error: validationError } = normalizeExpenseForm({
+      concept: quickExpenseForm.concept.trim() || event?.name || 'Gasto',
+      amount: quickExpenseForm.amount,
       category: quickExpenseForm.category || 'otros',
       expense_date: eventDate,
       is_deductible: true,
+    })
+    if (validationError) {
+      addToast('Pon un importe mayor que 0.', 'error')
+      return
     }
     setSavingExpense(true)
-    const { error } = await createExpense({ ...payload, event_id: id })
-    setSavingExpense(false)
-    if (error) { addToast('Error al guardar.', 'error'); return }
-    addToast('Gasto añadido.')
-    setQuickExpenseForm(quickExpenseDefault())
-    setQuickExpenseModal(false)
+    try {
+      const { error } = await createExpense({ ...payload, event_id: id })
+      if (error) { addToast('Error al guardar.', 'error'); return }
+      addToast('Gasto añadido.')
+      setQuickExpenseForm(quickExpenseDefault())
+      setQuickExpenseModal(false)
+    } catch {
+      addToast('Error al guardar.', 'error')
+    } finally {
+      setSavingExpense(false)
+    }
   }
 
   const openEditExpense = (expense) => {
@@ -724,12 +735,16 @@ export default function EventDetail() {
           )}
         </Card>
 
-        {event.notes && (
-          <Card className="p-5">
-            <h3 className="text-sm font-semibold text-gray-900 mb-2">Notas</h3>
-            <p className="text-sm text-gray-600 whitespace-pre-wrap">{event.notes}</p>
-          </Card>
-        )}
+        <ContextNotesCard
+          notes={event.notes}
+          emptyText="Aún no hay notas para este evento."
+          placeholder="Necesidades técnicas, contacto en sala, condiciones acordadas..."
+          onSave={async (nextNotes) => {
+            const result = await updateEvent(id, { notes: nextNotes })
+            if (!result.error) addToast(nextNotes ? 'Nota guardada.' : 'Nota limpia.')
+            return result
+          }}
+        />
       </div>
 
       <Modal isOpen={editModal} onClose={() => setEditModal(false)} title="Editar evento">
@@ -901,9 +916,12 @@ export default function EventDetail() {
       {/* Quick Income Modal */}
       <Modal isOpen={quickIncomeModal} onClose={() => setQuickIncomeModal(false)} title="Cobro rápido">
         <form onSubmit={handleQuickSubmitIncome} className="flex flex-col gap-4">
-          <p className="text-xs text-gray-500">
-            Concepto: <span className="font-medium text-gray-900">{event?.name || 'Ingreso'}</span>
-          </p>
+          <Input
+            label="Concepto"
+            value={quickIncomeForm.concept}
+            onChange={(e) => setQuickIncomeForm((p) => ({ ...p, concept: e.target.value }))}
+            placeholder={event?.name || 'Ingreso'}
+          />
           <Input
             label="Importe (€)"
             type="text"
@@ -931,9 +949,12 @@ export default function EventDetail() {
       {/* Quick Expense Modal */}
       <Modal isOpen={quickExpenseModal} onClose={() => setQuickExpenseModal(false)} title="Gasto rápido">
         <form onSubmit={handleQuickSubmitExpense} className="flex flex-col gap-4">
-          <p className="text-xs text-gray-500">
-            Concepto: <span className="font-medium text-gray-900">{event?.name || 'Gasto'}</span>
-          </p>
+          <Input
+            label="Concepto"
+            value={quickExpenseForm.concept}
+            onChange={(e) => setQuickExpenseForm((p) => ({ ...p, concept: e.target.value }))}
+            placeholder={event?.name || 'Gasto'}
+          />
           <Input
             label="Importe (€)"
             type="text"

--- a/src/pages/Projects/ProjectDetail.jsx
+++ b/src/pages/Projects/ProjectDetail.jsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Plus, Trash2, CheckCircle, Circle, Edit, CalendarDays, Chevr
 import { PageWrapper } from '../../components/layout/PageWrapper'
 import { Card } from '../../components/ui/Card'
 import { Button } from '../../components/ui/Button'
+import { ContextNotesCard } from '../../components/ui/ContextNotesCard'
 import { StatusBadge } from '../../components/ui/Badge'
 import { Modal } from '../../components/ui/Modal'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
@@ -16,7 +17,7 @@ import { useProjects } from '../../hooks/useProjects'
 import { useEvents } from '../../hooks/useEvents'
 import { useIncomes } from '../../hooks/useIncomes'
 import { useExpenses } from '../../hooks/useExpenses'
-import { formatCurrency, formatCurrencyPerHour, formatDate, formatDatetime, formatHours, parseDecimal } from '../../lib/formatters'
+import { formatCurrency, formatCurrencyPerHour, formatDate, formatDatetime, formatHours } from '../../lib/formatters'
 import { normalizeExpenseForm, normalizeIncomeForm } from '../../lib/financeForms'
 import { formatDueDescription, formatDueText, getDueDays } from '../../lib/dueDates'
 import { isPaid, markPaid, markUnpaid, needsQuickPaidConfirmation, paymentDate } from '../../lib/payment'
@@ -74,16 +75,16 @@ export default function ProjectDetail() {
   const [savingIncomeId, setSavingIncomeId] = useState(null)
   const [pendingPaymentConfirmationIncome, setPendingPaymentConfirmationIncome] = useState(null)
   const [quickIncomeModal, setQuickIncomeModal] = useState(false)
-  const quickIncomeDefault = () => ({ amount: '', is_paid: true })
-  const [quickIncomeForm, setQuickIncomeForm] = useState(() => ({ amount: '', is_paid: true }))
+  const quickIncomeDefault = () => ({ concept: project?.name || 'Ingreso', amount: '', is_paid: true })
+  const [quickIncomeForm, setQuickIncomeForm] = useState(() => quickIncomeDefault())
 
   const [expenseModal, setExpenseModal] = useState(false)
   const [editingExpense, setEditingExpense] = useState(null)
   const [expenseForm, setExpenseForm] = useState(EMPTY_EXPENSE)
   const [savingExpense, setSavingExpense] = useState(false)
   const [quickExpenseModal, setQuickExpenseModal] = useState(false)
-  const quickExpenseDefault = () => ({ amount: '', category: 'otros' })
-  const [quickExpenseForm, setQuickExpenseForm] = useState(() => ({ amount: '', category: 'otros' }))
+  const quickExpenseDefault = () => ({ concept: project?.name || 'Gasto', amount: '', category: 'otros' })
+  const [quickExpenseForm, setQuickExpenseForm] = useState(() => quickExpenseDefault())
   const [financialSummaryExpanded, setFinancialSummaryExpanded] = useState(false)
 
   if (projectsLoading) {
@@ -130,6 +131,16 @@ export default function ProjectDetail() {
   const grossHourlyRate = projectHours > 0 ? totalPaidFromEvents / projectHours : 0
   const netProfit = totalPaid - totalRetentions - totalExpenses
   const createEventUrl = `/events?project=${id}&new=1&returnTo=project`
+
+  const openQuickIncome = () => {
+    setQuickIncomeForm(quickIncomeDefault())
+    setQuickIncomeModal(true)
+  }
+
+  const openQuickExpense = () => {
+    setQuickExpenseForm(quickExpenseDefault())
+    setQuickExpenseModal(true)
+  }
 
   const openEditIncome = (income) => {
     setEditingIncome(income)
@@ -333,51 +344,59 @@ export default function ProjectDetail() {
 
   const handleQuickSubmitIncome = async (e) => {
     e.preventDefault()
-    const amount = parseDecimal(quickIncomeForm.amount)
-    if (amount === null || amount <= 0) {
-      addToast('Pon un importe mayor que 0.', 'error')
-      return
-    }
     const projectDate = project?.start_date || ''
-    const payload = {
-      concept: project?.name || 'Ingreso',
-      amount,
+    const { payload, error: validationError } = normalizeIncomeForm({
+      concept: quickIncomeForm.concept.trim() || project?.name || 'Ingreso',
+      amount: quickIncomeForm.amount,
       tax_rate: defaultTaxRate,
       expected_date: projectDate,
       paid_date: quickIncomeForm.is_paid ? paymentDate(new Date()) : null,
       is_paid: quickIncomeForm.is_paid,
+    }, { defaultTaxRate })
+    if (validationError) {
+      addToast(validationError === 'amount' ? 'Pon un importe mayor que 0.' : 'Revisa el IRPF.', 'error')
+      return
     }
     setSavingIncome(true)
-    const { error } = await createIncome({ ...payload, project_id: id })
-    setSavingIncome(false)
-    if (error) { addToast('Error al guardar.', 'error'); return }
-    addToast('Ingreso añadido.')
-    setQuickIncomeForm(quickIncomeDefault())
-    setQuickIncomeModal(false)
+    try {
+      const { error } = await createIncome({ ...payload, project_id: id })
+      if (error) { addToast('Error al guardar.', 'error'); return }
+      addToast('Ingreso añadido.')
+      setQuickIncomeForm(quickIncomeDefault())
+      setQuickIncomeModal(false)
+    } catch {
+      addToast('Error al guardar.', 'error')
+    } finally {
+      setSavingIncome(false)
+    }
   }
 
   const handleQuickSubmitExpense = async (e) => {
     e.preventDefault()
-    const amount = parseDecimal(quickExpenseForm.amount)
-    if (amount === null || amount <= 0) {
-      addToast('Pon un importe mayor que 0.', 'error')
-      return
-    }
     const projectDate = project?.start_date || ''
-    const payload = {
-      concept: project?.name || 'Gasto',
-      amount,
+    const { payload, error: validationError } = normalizeExpenseForm({
+      concept: quickExpenseForm.concept.trim() || project?.name || 'Gasto',
+      amount: quickExpenseForm.amount,
       category: quickExpenseForm.category || 'otros',
       expense_date: projectDate,
       is_deductible: true,
+    })
+    if (validationError) {
+      addToast('Pon un importe mayor que 0.', 'error')
+      return
     }
     setSavingExpense(true)
-    const { error } = await createExpense({ ...payload, project_id: id })
-    setSavingExpense(false)
-    if (error) { addToast('Error al guardar.', 'error'); return }
-    addToast('Gasto añadido.')
-    setQuickExpenseForm(quickExpenseDefault())
-    setQuickExpenseModal(false)
+    try {
+      const { error } = await createExpense({ ...payload, project_id: id })
+      if (error) { addToast('Error al guardar.', 'error'); return }
+      addToast('Gasto añadido.')
+      setQuickExpenseForm(quickExpenseDefault())
+      setQuickExpenseModal(false)
+    } catch {
+      addToast('Error al guardar.', 'error')
+    } finally {
+      setSavingExpense(false)
+    }
   }
 
   return (
@@ -414,10 +433,10 @@ export default function ProjectDetail() {
               <Link to={createEventUrl} className={compactPrimaryAction}>
                 <Plus size={14} /> Crear evento
               </Link>
-              <button type="button" onClick={() => setQuickIncomeModal(true)} className={compactSecondaryAction}>
+              <button type="button" onClick={openQuickIncome} className={compactSecondaryAction}>
                 <Plus size={14} /> Ingreso
               </button>
-              <button type="button" onClick={() => setQuickExpenseModal(true)} className={compactSecondaryAction}>
+              <button type="button" onClick={openQuickExpense} className={compactSecondaryAction}>
                 <Plus size={14} /> Gasto
               </button>
               <button type="button" onClick={() => setEditModal(true)} className={compactSecondaryAction}>
@@ -716,12 +735,16 @@ export default function ProjectDetail() {
           )}
         </Card>
 
-        {project.notes && (
-          <Card className="p-5">
-            <h3 className="text-sm font-semibold text-gray-900 mb-2">Notas</h3>
-            <p className="text-sm text-gray-600 whitespace-pre-wrap">{project.notes}</p>
-          </Card>
-        )}
+        <ContextNotesCard
+          notes={project.notes}
+          emptyText="Aún no hay notas para este proyecto."
+          placeholder="Alcance, condiciones acordadas, producción pendiente..."
+          onSave={async (nextNotes) => {
+            const result = await updateProject(id, { notes: nextNotes })
+            if (!result.error) addToast(nextNotes ? 'Nota guardada.' : 'Nota limpia.')
+            return result
+          }}
+        />
 
         <div className="sm:hidden">
           <button
@@ -839,10 +862,10 @@ export default function ProjectDetail() {
         <Link to={createEventUrl} className="flex min-h-11 flex-[1.2] items-center justify-center rounded-lg bg-[var(--color-red)] px-2 text-center text-xs font-medium text-white sm:hidden">
           Crear evento
         </Link>
-        <button type="button" onClick={() => setQuickIncomeModal(true)} className="min-h-11 flex-1 rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-paper)] px-2 text-xs font-medium text-[var(--color-ink)] sm:hidden">
+        <button type="button" onClick={openQuickIncome} className="min-h-11 flex-1 rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-paper)] px-2 text-xs font-medium text-[var(--color-ink)] sm:hidden">
           Cobro
         </button>
-        <button type="button" onClick={() => setQuickExpenseModal(true)} className="min-h-11 flex-1 rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-paper)] px-2 text-xs font-medium text-[var(--color-ink)] sm:hidden">
+        <button type="button" onClick={openQuickExpense} className="min-h-11 flex-1 rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-paper)] px-2 text-xs font-medium text-[var(--color-ink)] sm:hidden">
           Gasto
         </button>
         <button type="button" onClick={() => setEditModal(true)} className="min-h-11 flex-1 rounded-lg border border-[var(--color-paper-mid)] px-2 text-xs font-medium text-[var(--color-ink-muted)] sm:hidden">
@@ -853,9 +876,12 @@ export default function ProjectDetail() {
       {/* Quick Income Modal */}
       <Modal isOpen={quickIncomeModal} onClose={() => setQuickIncomeModal(false)} title="Cobro rápido">
         <form onSubmit={handleQuickSubmitIncome} className="flex flex-col gap-4">
-          <p className="text-xs text-gray-500">
-            Concepto: <span className="font-medium text-gray-900">{project?.name || 'Ingreso'}</span>
-          </p>
+          <Input
+            label="Concepto"
+            value={quickIncomeForm.concept}
+            onChange={(e) => setQuickIncomeForm((p) => ({ ...p, concept: e.target.value }))}
+            placeholder={project?.name || 'Ingreso'}
+          />
           <Input
             label="Importe (€)"
             type="text"
@@ -883,9 +909,12 @@ export default function ProjectDetail() {
       {/* Quick Expense Modal */}
       <Modal isOpen={quickExpenseModal} onClose={() => setQuickExpenseModal(false)} title="Gasto rápido">
         <form onSubmit={handleQuickSubmitExpense} className="flex flex-col gap-4">
-          <p className="text-xs text-gray-500">
-            Concepto: <span className="font-medium text-gray-900">{project?.name || 'Gasto'}</span>
-          </p>
+          <Input
+            label="Concepto"
+            value={quickExpenseForm.concept}
+            onChange={(e) => setQuickExpenseForm((p) => ({ ...p, concept: e.target.value }))}
+            placeholder={project?.name || 'Gasto'}
+          />
           <Input
             label="Importe (€)"
             type="text"


### PR DESCRIPTION
## Summary

Release `RELEASE-0.1.0-beta.18` para cerrar P1 UX core visible:

- `CACH-0054`: notas contextuales editables en detalles de proyecto y evento usando `notes` existente.
- `CACH-0055`: quick cobro/gasto con concepto editable y normalizadores compartidos, sin tocar fórmulas ni modelo financiero.
- `CACH-0056`: calendario de eventos y plan anual separados; `/calendar` redirige a `/calendar/events`.

## Product Brain

- Issues: `CACH-0054`, `CACH-0055`, `CACH-0056`
- Release: `RELEASE-0.1.0-beta.18`
- Fuera de scope: `CACH-B0004`, contratantes, facturación, liquidación neta, migraciones, RLS, schema y fórmulas financieras.

## Validation

- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [x] `npm run test:e2e -- e2e/beta18.spec.ts`
- [x] `npm run pb:guard`
- [x] `npm run pb:release-check -- RELEASE-0.1.0-beta.18`
- [x] `npm run release:status`
- [x] `npm run release:sync-check`
- [x] `npm run verify:pr -- --base origin/main`
- [x] `npm run doctor:react:diff` → 96/100, sin bloqueos

## Deploy

Producción requiere merge a `main`; smoke posterior en `https://app.caches.es` si CI queda verde.

## Memory

Memoria: no aplica.
