### PR TITLE
Release 0.1.0-beta.19: contratantes estructurados

### DIFF
--- a/.memory/reference_supabase_mcp.md
+++ b/.memory/reference_supabase_mcp.md
@@ -29,3 +29,4 @@ Durable memory:
 - Si una feature depende de una tabla/policy/RPC nueva, verificar remoto antes de marcar producción como OK: `to_regclass('public.<tabla>')`, `pg_policies` cuando aplique y smoke real o transaccional con `rollback`.
 - Si una release deja la migración remota pendiente, la feature puede estar code-complete, pero no released funcionalmente.
 - Si un hotfix remoto incluye SQL no reflejado en migraciones locales, versionar el delta o confirmar que ya queda cubierto por una migración existente.
+- Si se aplica una migración versionada a mano por SQL Editor, confirmar el schema con SQL read-only, refrescar PostgREST con `notify pgrst, 'reload schema';` y ejecutar `npx supabase migration repair <version> --status applied --linked` antes de cerrar la tarea.

--- a/.memory/topics/agent-workflows.md
+++ b/.memory/topics/agent-workflows.md
@@ -56,6 +56,7 @@ Verification and closure:
 - Verification agents should verify from task, diff, acceptance criteria and relevant rules.
 - Visual/responsive tasks need route, viewport/condition, symptom or capture, and visual acceptance criteria.
 - For `react-big-calendar`, verify toolbar, header and month rows/cells are visible.
+- Before closing any task, pass the learning loop: identify whether the work produced durable learning, update memory/docs/process when it did, or explicitly declare `Memoria: no aplica`.
 - Do not close a tracked issue just because a local fix exists.
 - Resolved issues must stay linked to the PR or pushed commit that resolves them.
 - If there is an open PR, keep the issue open and use `Closes #N`, `Fixes #N` or equivalent in the PR body.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ Calendarios:
 Memoria y documentación:
 - `.memory/` es memoria versionada del proyecto. Guarda preferencias, decisiones duraderas y gotchas reutilizables.
 - No guardar histórico operativo, logs, ramas, listas de commits, secretos ni datos sensibles en memoria.
+- Al cerrar una tarea, pasar siempre el learning loop: detectar si hay aprendizaje durable, actualizar memoria/docs/proceso cuando aplique o declarar `Memoria: no aplica`.
 - Si surge memoria durable, actualizar `.memory/` o declarar `Memoria: no aplica` cuando corresponda.
 - Todo contenido persistente debe estar en español o inglés limpio.
 

--- a/README.md
+++ b/README.md
@@ -134,9 +134,24 @@ alter table profiles
   add constraint profiles_beta_invite_id_fkey
   foreign key (beta_invite_id) references public.beta_invites(id) on delete set null;
 
+create table contractors (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references public.profiles(id) on delete cascade not null,
+  name text not null,
+  billing_name text,
+  tax_id text,
+  email text,
+  phone text,
+  billing_address text,
+  notes text,
+  created_at timestamptz default now(),
+  constraint contractors_name_not_blank check (btrim(name) <> '')
+);
+
 create table projects (
   id uuid primary key default gen_random_uuid(),
   user_id uuid references public.profiles(id) on delete cascade not null,
+  contractor_id uuid references public.contractors(id) on delete set null,
   name text not null,
   client text,
   category text default 'otros',
@@ -152,6 +167,7 @@ create table events (
   id uuid primary key default gen_random_uuid(),
   user_id uuid references public.profiles(id) on delete cascade not null,
   project_id uuid references public.projects(id) on delete set null,
+  contractor_id uuid references public.contractors(id) on delete set null,
   name text not null,
   client text,
   category text default 'otros',
@@ -201,6 +217,7 @@ alter table beta_invites enable row level security;
 alter table beta_invite_redemptions enable row level security;
 alter table projects enable row level security;
 alter table events enable row level security;
+alter table contractors enable row level security;
 alter table incomes enable row level security;
 alter table expenses enable row level security;
 
@@ -215,6 +232,9 @@ create policy "projects: usuario propio" on projects
 
 create policy "events: usuario propio" on events
   for all using (auth.uid() = user_id);
+
+create policy "contractors: usuario propio" on contractors
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
 
 create policy "incomes: usuario propio" on incomes
   for all using (auth.uid() = user_id);

--- a/docs/project/DIGEST.md
+++ b/docs/project/DIGEST.md
@@ -5,7 +5,7 @@ id: PB-DIGEST
 title: Product Brain Digest
 lifecycle: active
 created: 2026-05-05
-updated: 2026-05-12
+updated: 2026-05-13
 aliases:
   - Digest
   - Brain Digest
@@ -23,7 +23,7 @@ Resumen determinista generado desde Product Brain v2.
 
 ## Estado operacional
 
-- **Release activa:** No hay release activa.
+- **Release activa:** RELEASE-0.1.0-beta.19 — Contratantes estructurados
 - **Últimos cortes:** `RELEASE-0.1.0-beta.10` — emails transaccionales beta con Brevo. Ver RELEASE-0.1.0-beta.10.
 
 `RELEASE-0.1.0-beta.12` — pulido proyecto-evento y borrados seguros. Ver RELEASE-0.1.0-beta.12.
@@ -39,14 +39,14 @@ Resumen determinista generado desde Product Brain v2.
 `RELEASE-0.1.0-beta.17` — feedback simple beta. Ver RELEASE-0.1.0-beta.17.
 
 `RELEASE-0.1.0-beta.18` — cierre P1 UX core. Ver RELEASE-0.1.0-beta.18.
-- **Foco:** Beta 18 queda cerrada con notas contextuales, pulido financiero movil y calendarios separados más claros. No hay release activa.
+- **Foco:** Beta 19 está activa para introducir contratantes estructurados como primer slice de `CACH-B0004`, manteniendo fuera liquidación neta, facturación completa, CRM y cambios de fórmulas financieras.
 
 ## Prioridades del plan
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
 2. Mantener el feedback beta simple antes de introducir analitica de producto.
 3. No introducir PostHog, Plausible ni analitica de eventos sin issue/ADR posterior.
-4. No abrir contratantes, facturacion, liquidacion neta, migraciones, RLS ni cambios de formulas financieras sin release nueva.
+4. Durante beta 19, permitir contratantes estructurados, migraciones/RLS y portabilidad necesarias; mantener fuera liquidacion neta, facturacion completa y cambios de formulas financieras.
 
 ## Tablero
 
@@ -56,7 +56,13 @@ _Sin entradas._
 
 ### Ready
 
-_Sin entradas._
+| ID | Título | Tipo | Nivel | P |
+|---|---|---|---|---|
+| CACH-0057 | Definir modelo minimo de contratantes | spike | task | p1 |
+| CACH-0058 | Versionar schema de contratantes y RLS | feature | slice | p1 |
+| CACH-0059 | Integrar hooks y portabilidad de contratantes | feature | slice | p1 |
+| CACH-0060 | Anadir UX minima de contratantes en proyectos y eventos | feature | slice | p1 |
+| CACH-0061 | Verificar regresion financiera y cierre tecnico beta 19 | chore | task | p1 |
 
 ### In progress
 
@@ -79,6 +85,11 @@ _Sin entradas._
 
 | ID | Título | Workflow | Tipo | Nivel | P |
 |---|---|---|---|---|---|
+| CACH-0057 | Definir modelo minimo de contratantes | ready | spike | task | p1 |
+| CACH-0058 | Versionar schema de contratantes y RLS | ready | feature | slice | p1 |
+| CACH-0059 | Integrar hooks y portabilidad de contratantes | ready | feature | slice | p1 |
+| CACH-0060 | Anadir UX minima de contratantes en proyectos y eventos | ready | feature | slice | p1 |
+| CACH-0061 | Verificar regresion financiera y cierre tecnico beta 19 | ready | chore | task | p1 |
 | CACH-B0001 | Redisenar Trabajos y jerarquia proyecto-evento | backlog | feature | initiative | p1 |
 | CACH-B0002 | Simplificar experiencia mobile financiera | backlog | feature | initiative | p1 |
 | CACH-B0004 | Contratantes facturacion y liquidacion neta | backlog | feature | initiative | p1 |
@@ -112,4 +123,4 @@ _Sin entradas._
 
 ## Próxima acción
 
-Elegir siguiente corte. Candidato principal: `CACH-B0004` como release de datos separada para contratantes, facturacion y liquidacion neta.
+Ejecutar beta 19 por slices: modelo mínimo, schema/RLS, hooks/portabilidad, UX mínima y regresión financiera.

--- a/docs/project/DIGEST.md
+++ b/docs/project/DIGEST.md
@@ -23,7 +23,7 @@ Resumen determinista generado desde Product Brain v2.
 
 ## Estado operacional
 
-- **Release activa:** RELEASE-0.1.0-beta.19 — Contratantes estructurados
+- **Release activa:** No hay release activa ahora mismo.
 - **Últimos cortes:** `RELEASE-0.1.0-beta.10` — emails transaccionales beta con Brevo. Ver RELEASE-0.1.0-beta.10.
 
 `RELEASE-0.1.0-beta.12` — pulido proyecto-evento y borrados seguros. Ver RELEASE-0.1.0-beta.12.
@@ -39,14 +39,16 @@ Resumen determinista generado desde Product Brain v2.
 `RELEASE-0.1.0-beta.17` — feedback simple beta. Ver RELEASE-0.1.0-beta.17.
 
 `RELEASE-0.1.0-beta.18` — cierre P1 UX core. Ver RELEASE-0.1.0-beta.18.
-- **Foco:** Beta 19 está activa para introducir contratantes estructurados como primer slice de `CACH-B0004`, manteniendo fuera liquidación neta, facturación completa, CRM y cambios de fórmulas financieras.
+
+`RELEASE-0.1.0-beta.19` — contratantes estructurados. Ver RELEASE-0.1.0-beta.19.
+- **Foco:** Beta 19 queda cerrada como primer slice de `CACH-B0004`: contratantes estructurados, schema/RLS, hooks, portabilidad, UX mínima y regresión financiera sin cambios de fórmula. El siguiente foco queda pendiente de elegir entre hardening o abrir liquidación neta con criterios de datos/RLS.
 
 ## Prioridades del plan
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
 2. Mantener el feedback beta simple antes de introducir analitica de producto.
 3. No introducir PostHog, Plausible ni analitica de eventos sin issue/ADR posterior.
-4. Durante beta 19, permitir contratantes estructurados, migraciones/RLS y portabilidad necesarias; mantener fuera liquidacion neta, facturacion completa y cambios de formulas financieras.
+4. Antes de abrir beta 20, decidir si toca hardening o liquidacion neta; en ambos casos mantener fuera facturacion completa y CRM salvo issue nueva con criterios de datos/RLS.
 
 ## Tablero
 
@@ -60,18 +62,11 @@ _Sin entradas._
 
 ### In progress
 
-| ID | Título | Tipo | Nivel | P |
-|---|---|---|---|---|
-| CACH-0061 | Verificar regresion financiera y cierre tecnico beta 19 | chore | task | p1 |
+_Sin entradas._
 
 ### Review / Verify
 
-| ID | Título | Tipo | Nivel | P |
-|---|---|---|---|---|
-| CACH-0057 | Definir modelo minimo de contratantes | spike | task | p1 |
-| CACH-0058 | Versionar schema de contratantes y RLS | feature | slice | p1 |
-| CACH-0059 | Integrar hooks y portabilidad de contratantes | feature | slice | p1 |
-| CACH-0060 | Anadir UX minima de contratantes en proyectos y eventos | feature | slice | p1 |
+_Sin entradas._
 
 ### Backlog (p1)
 
@@ -86,11 +81,6 @@ _Sin entradas._
 
 | ID | Título | Workflow | Tipo | Nivel | P |
 |---|---|---|---|---|---|
-| CACH-0061 | Verificar regresion financiera y cierre tecnico beta 19 | in_progress | chore | task | p1 |
-| CACH-0057 | Definir modelo minimo de contratantes | review | spike | task | p1 |
-| CACH-0058 | Versionar schema de contratantes y RLS | review | feature | slice | p1 |
-| CACH-0059 | Integrar hooks y portabilidad de contratantes | review | feature | slice | p1 |
-| CACH-0060 | Anadir UX minima de contratantes en proyectos y eventos | review | feature | slice | p1 |
 | CACH-B0001 | Redisenar Trabajos y jerarquia proyecto-evento | backlog | feature | initiative | p1 |
 | CACH-B0002 | Simplificar experiencia mobile financiera | backlog | feature | initiative | p1 |
 | CACH-B0004 | Contratantes facturacion y liquidacion neta | backlog | feature | initiative | p1 |
@@ -124,4 +114,4 @@ _Sin entradas._
 
 ## Próxima acción
 
-Ejecutar beta 19 por slices: modelo mínimo, schema/RLS, hooks/portabilidad, UX mínima y regresión financiera.
+Cerrar beta 19 en `main`, etiquetar `v0.1.0-beta.19`, verificar producción y decidir el próximo corte.

--- a/docs/project/DIGEST.md
+++ b/docs/project/DIGEST.md
@@ -56,21 +56,22 @@ _Sin entradas._
 
 ### Ready
 
+_Sin entradas._
+
+### In progress
+
+| ID | Título | Tipo | Nivel | P |
+|---|---|---|---|---|
+| CACH-0061 | Verificar regresion financiera y cierre tecnico beta 19 | chore | task | p1 |
+
+### Review / Verify
+
 | ID | Título | Tipo | Nivel | P |
 |---|---|---|---|---|
 | CACH-0057 | Definir modelo minimo de contratantes | spike | task | p1 |
 | CACH-0058 | Versionar schema de contratantes y RLS | feature | slice | p1 |
 | CACH-0059 | Integrar hooks y portabilidad de contratantes | feature | slice | p1 |
 | CACH-0060 | Anadir UX minima de contratantes en proyectos y eventos | feature | slice | p1 |
-| CACH-0061 | Verificar regresion financiera y cierre tecnico beta 19 | chore | task | p1 |
-
-### In progress
-
-_Sin entradas._
-
-### Review / Verify
-
-_Sin entradas._
 
 ### Backlog (p1)
 
@@ -85,11 +86,11 @@ _Sin entradas._
 
 | ID | Título | Workflow | Tipo | Nivel | P |
 |---|---|---|---|---|---|
-| CACH-0057 | Definir modelo minimo de contratantes | ready | spike | task | p1 |
-| CACH-0058 | Versionar schema de contratantes y RLS | ready | feature | slice | p1 |
-| CACH-0059 | Integrar hooks y portabilidad de contratantes | ready | feature | slice | p1 |
-| CACH-0060 | Anadir UX minima de contratantes en proyectos y eventos | ready | feature | slice | p1 |
-| CACH-0061 | Verificar regresion financiera y cierre tecnico beta 19 | ready | chore | task | p1 |
+| CACH-0061 | Verificar regresion financiera y cierre tecnico beta 19 | in_progress | chore | task | p1 |
+| CACH-0057 | Definir modelo minimo de contratantes | review | spike | task | p1 |
+| CACH-0058 | Versionar schema de contratantes y RLS | review | feature | slice | p1 |
+| CACH-0059 | Integrar hooks y portabilidad de contratantes | review | feature | slice | p1 |
+| CACH-0060 | Anadir UX minima de contratantes en proyectos y eventos | review | feature | slice | p1 |
 | CACH-B0001 | Redisenar Trabajos y jerarquia proyecto-evento | backlog | feature | initiative | p1 |
 | CACH-B0002 | Simplificar experiencia mobile financiera | backlog | feature | initiative | p1 |
 | CACH-B0004 | Contratantes facturacion y liquidacion neta | backlog | feature | initiative | p1 |

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -5,7 +5,7 @@ id: PB-BACKLOG
 title: Backlog operativo
 lifecycle: active
 created: 2026-05-05
-updated: 2026-05-12
+updated: 2026-05-13
 aliases:
   - Backlog operativo
   - Backlog
@@ -63,7 +63,13 @@ _Sin issues._
 
 ## Ready
 
-_Sin issues._
+| ID | Titulo | Tipo | Nivel | P | Componentes |
+|---|---|---|---|---|---|
+| [[../issues/CACH-0057|CACH-0057]] | Definir modelo minimo de contratantes | spike | task | p1 | finance |
+| [[../issues/CACH-0058|CACH-0058]] | Versionar schema de contratantes y RLS | feature | slice | p1 | finance, supabase |
+| [[../issues/CACH-0059|CACH-0059]] | Integrar hooks y portabilidad de contratantes | feature | slice | p1 | finance, data-portability |
+| [[../issues/CACH-0060|CACH-0060]] | Anadir UX minima de contratantes en proyectos y eventos | feature | slice | p1 | projects, events, work, design-system |
+| [[../issues/CACH-0061|CACH-0061]] | Verificar regresion financiera y cierre tecnico beta 19 | chore | task | p1 | finance, dashboard, product-brain |
 
 ## In progress
 

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -63,21 +63,22 @@ _Sin issues._
 
 ## Ready
 
+_Sin issues._
+
+## In progress
+
+| ID | Titulo | Tipo | Nivel | P | Componentes |
+|---|---|---|---|---|---|
+| [[../issues/CACH-0061|CACH-0061]] | Verificar regresion financiera y cierre tecnico beta 19 | chore | task | p1 | finance, dashboard, product-brain |
+
+## Review / Verify
+
 | ID | Titulo | Tipo | Nivel | P | Componentes |
 |---|---|---|---|---|---|
 | [[../issues/CACH-0057|CACH-0057]] | Definir modelo minimo de contratantes | spike | task | p1 | finance |
 | [[../issues/CACH-0058|CACH-0058]] | Versionar schema de contratantes y RLS | feature | slice | p1 | finance, supabase |
 | [[../issues/CACH-0059|CACH-0059]] | Integrar hooks y portabilidad de contratantes | feature | slice | p1 | finance, data-portability |
 | [[../issues/CACH-0060|CACH-0060]] | Anadir UX minima de contratantes en proyectos y eventos | feature | slice | p1 | projects, events, work, design-system |
-| [[../issues/CACH-0061|CACH-0061]] | Verificar regresion financiera y cierre tecnico beta 19 | chore | task | p1 | finance, dashboard, product-brain |
-
-## In progress
-
-_Sin issues._
-
-## Review / Verify
-
-_Sin issues._
 
 ## Done
 

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -67,18 +67,11 @@ _Sin issues._
 
 ## In progress
 
-| ID | Titulo | Tipo | Nivel | P | Componentes |
-|---|---|---|---|---|---|
-| [[../issues/CACH-0061|CACH-0061]] | Verificar regresion financiera y cierre tecnico beta 19 | chore | task | p1 | finance, dashboard, product-brain |
+_Sin issues._
 
 ## Review / Verify
 
-| ID | Titulo | Tipo | Nivel | P | Componentes |
-|---|---|---|---|---|---|
-| [[../issues/CACH-0057|CACH-0057]] | Definir modelo minimo de contratantes | spike | task | p1 | finance |
-| [[../issues/CACH-0058|CACH-0058]] | Versionar schema de contratantes y RLS | feature | slice | p1 | finance, supabase |
-| [[../issues/CACH-0059|CACH-0059]] | Integrar hooks y portabilidad de contratantes | feature | slice | p1 | finance, data-portability |
-| [[../issues/CACH-0060|CACH-0060]] | Anadir UX minima de contratantes en proyectos y eventos | feature | slice | p1 | projects, events, work, design-system |
+_Sin issues._
 
 ## Done
 
@@ -113,6 +106,11 @@ _Sin issues._
 | [[../issues/CACH-0054|CACH-0054]] | Editar notas desde detalles de proyecto y evento | RELEASE-0.1.0-beta.18 | Implementado y cerrado en `RELEASE-0.1.0-beta.18`. |
 | [[../issues/CACH-0055|CACH-0055]] | Pulido financiero movil sin cambiar formulas | RELEASE-0.1.0-beta.18 | Implementado y cerrado en `RELEASE-0.1.0-beta.18`. |
 | [[../issues/CACH-0056|CACH-0056]] | Calendario de eventos y plan anual separados | RELEASE-0.1.0-beta.18 | Implementado y cerrado en `RELEASE-0.1.0-beta.18`. |
+| [[../issues/CACH-0057|CACH-0057]] | Definir modelo minimo de contratantes | RELEASE-0.1.0-beta.19 | Implementado y cerrado en `RELEASE-0.1.0-beta.19`: el modelo mínimo diferencia contratante estructurado de `client` legacy, mantiene herencia proyecto -> evento y deja fuera facturación completa, liquidación neta, CRM y colaboración multiusuario. |
+| [[../issues/CACH-0058|CACH-0058]] | Versionar schema de contratantes y RLS | RELEASE-0.1.0-beta.19 | Implementado y cerrado en `RELEASE-0.1.0-beta.19`: la migración `20260513120000_contractors.sql` crea `contractors`, añade `contractor_id` opcional a proyectos/eventos, mantiene `client` legacy, activa RLS y ejecuta backfill seguro con herencia proyecto -> evento. |
+| [[../issues/CACH-0059|CACH-0059]] | Integrar hooks y portabilidad de contratantes | RELEASE-0.1.0-beta.19 | Implementado y cerrado en `RELEASE-0.1.0-beta.19`: `useContractors` centraliza CRUD y creación inline, portabilidad exporta/importa contratantes sin `user_id` y los datasets legacy siguen funcionando. |
+| [[../issues/CACH-0060|CACH-0060]] | Anadir UX minima de contratantes en proyectos y eventos | RELEASE-0.1.0-beta.19 | Implementado y cerrado en `RELEASE-0.1.0-beta.19`: proyectos y eventos pueden elegir o crear contratante, eventos vinculados heredan el contratante del proyecto, `/contractors` permite gestionar la entidad ligera y las vistas principales muestran contratante estructurado o `client` legacy sin duplicidades. |
+| [[../issues/CACH-0061|CACH-0061]] | Verificar regresion financiera y cierre tecnico beta 19 | RELEASE-0.1.0-beta.19 | Implementado y cerrado en `RELEASE-0.1.0-beta.19`: la regresión financiera queda verificada sin cambios de fórmula, los checks locales pasan, la migración remota está aplicada/verificada y el smoke manual básico de contratantes está confirmado. |
 | [[../issues/CACH-B0003|CACH-B0003]] | Cobro rapido y gestion de pendientes | RELEASE-0.1.0-beta.5 | Released en RELEASE-0.1.0-beta.5 por ampliacion explicita de scope. Integrado en `main` mediante PR #84. |
 | [[../issues/CACH-B0005|CACH-B0005]] | Importacion exportacion y portabilidad de datos | RELEASE-0.1.0-beta.7 | Released en RELEASE-0.1.0-beta.7. Integrado en `main` mediante PR #86. |
 | [[../issues/CACH-B0006|CACH-B0006]] | Onboarding y acceso beta | RELEASE-0.1.0-beta.8 | Released en RELEASE-0.1.0-beta.8. Integrado en `main` mediante PR #87. |

--- a/docs/project/indexes/by-area.md
+++ b/docs/project/indexes/by-area.md
@@ -22,7 +22,6 @@ generated: true
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
@@ -40,6 +39,7 @@ generated: true
 - [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
 - [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · done · p1 · slice
 - [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · done · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · done · p1 · slice
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes · done · p1 · slice
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta · done · p1 · slice
 - [[../issues/CACH-B0014|CACH-B0014]] — Endurecer agenda cobros y captura del MVP · done · p1 · slice
@@ -50,10 +50,10 @@ generated: true
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
-- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · review · p1 · task
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · done · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · done · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · done · p1 · slice
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · done · p1 · task
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 - [[../issues/CACH-B0017|CACH-B0017]] — Panel admin para invitaciones beta · done · p1 · slice
 

--- a/docs/project/indexes/by-area.md
+++ b/docs/project/indexes/by-area.md
@@ -5,7 +5,7 @@ id: PB-BY-AREA
 title: Issues por area
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-12
+updated: 2026-05-13
 aliases:
   - Issues por area
 tags:
@@ -22,6 +22,7 @@ generated: true
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
@@ -49,6 +50,10 @@ generated: true
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · ready · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 - [[../issues/CACH-B0017|CACH-B0017]] — Panel admin para invitaciones beta · done · p1 · slice
 

--- a/docs/project/indexes/by-area.md
+++ b/docs/project/indexes/by-area.md
@@ -22,7 +22,7 @@ generated: true
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
@@ -50,10 +50,10 @@ generated: true
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
-- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · ready · p1 · task
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · review · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 - [[../issues/CACH-B0017|CACH-B0017]] — Panel admin para invitaciones beta · done · p1 · slice
 

--- a/docs/project/indexes/by-component.md
+++ b/docs/project/indexes/by-component.md
@@ -5,7 +5,7 @@ id: PB-BY-COMPONENT
 title: Issues por componente
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-12
+updated: 2026-05-13
 aliases:
   - Issues por componente
 tags:
@@ -18,6 +18,7 @@ generated: true
 ## work
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain · done · p1 · task
@@ -27,6 +28,7 @@ generated: true
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
 - [[../issues/CACH-0043|CACH-0043]] — [UX] Limpiar acciones en detalle de proyecto · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
 - [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
@@ -36,6 +38,7 @@ generated: true
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
 - [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
@@ -49,6 +52,7 @@ generated: true
 
 ## dashboard
 
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
 - [[../issues/CACH-0032|CACH-0032]] — Priorizar operativa diaria en dashboard movil · done · p1 · slice
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
@@ -59,6 +63,10 @@ generated: true
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera · backlog · p1 · initiative
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · ready · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables · done · p1 · slice
@@ -68,6 +76,7 @@ generated: true
 
 ## data-portability
 
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 
 ## auth-onboarding
@@ -91,6 +100,7 @@ generated: true
 
 ## product-brain
 
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
 - [[../issues/CACH-0049|CACH-0049]] — Migrar Product Brain a v2 lean agile para agentes · done · p0 · task
 - [[../issues/CACH-0026|CACH-0026]] — Setup inicial Product Brain · done · p1 · task
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada · done · p1 · slice
@@ -119,6 +129,7 @@ generated: true
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
@@ -154,6 +165,7 @@ generated: true
 
 ## supabase
 
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
 - [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · done · p0 · task
 - [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · done · p1 · task
 - [[../issues/CACH-0052|CACH-0052]] — [Feedback] Formulario simple de feedback beta · done · p1 · slice

--- a/docs/project/indexes/by-component.md
+++ b/docs/project/indexes/by-component.md
@@ -18,9 +18,9 @@ generated: true
 ## work
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · done · p1 · slice
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain · done · p1 · task
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task
 
@@ -28,20 +28,20 @@ generated: true
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
 - [[../issues/CACH-0043|CACH-0043]] — [UX] Limpiar acciones en detalle de proyecto · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
 - [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · done · p1 · slice
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos · done · p2 · slice
 
 ## events
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
 - [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · done · p1 · slice
 
 ## calendar
 
@@ -52,31 +52,31 @@ generated: true
 
 ## dashboard
 
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
 - [[../issues/CACH-0032|CACH-0032]] — Priorizar operativa diaria en dashboard movil · done · p1 · slice
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
 - [[../issues/CACH-0041|CACH-0041]] — [UX] Simplificar dashboard movil y estado Ahora · done · p1 · slice
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · done · p1 · task
 
 ## finance
 
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera · backlog · p1 · initiative
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
-- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · review · p1 · task
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables · done · p1 · slice
 - [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · done · p1 · slice
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · done · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · done · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · done · p1 · slice
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · done · p1 · task
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes · done · p1 · slice
 - [[../issues/CACH-B0014|CACH-B0014]] — Endurecer agenda cobros y captura del MVP · done · p1 · slice
 
 ## data-portability
 
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · done · p1 · slice
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 
 ## auth-onboarding
@@ -100,13 +100,13 @@ generated: true
 
 ## product-brain
 
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
 - [[../issues/CACH-0049|CACH-0049]] — Migrar Product Brain a v2 lean agile para agentes · done · p0 · task
 - [[../issues/CACH-0026|CACH-0026]] — Setup inicial Product Brain · done · p1 · task
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada · done · p1 · slice
 - [[../issues/CACH-0036|CACH-0036]] — Profesionalizar flujo de ramas por beta · done · p1 · task
 - [[../issues/CACH-0037|CACH-0037]] — Consolidar PRD y sistema de diseno de Cachés · done · p1 · task
 - [[../issues/CACH-0050|CACH-0050]] — [Deploy] Tooling local-first de PR release y smoke · done · p1 · task
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · done · p1 · task
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain · done · p1 · task
 - [[../issues/CACH-B0016|CACH-B0016]] — Refundacion operativa del Product Brain y tests B0014 · done · p1 · task
 
@@ -129,7 +129,6 @@ generated: true
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
@@ -143,6 +142,7 @@ generated: true
 - [[../issues/CACH-0053|CACH-0053]] — [Bug] Mantener foco al escribir feedback · done · p1 · task
 - [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · done · p1 · slice
 - [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · done · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · done · p1 · slice
 
 ## infra-deploy
 
@@ -165,7 +165,7 @@ generated: true
 
 ## supabase
 
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
 - [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · done · p0 · task
 - [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · done · p1 · task
 - [[../issues/CACH-0052|CACH-0052]] — [Feedback] Formulario simple de feedback beta · done · p1 · slice
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · done · p1 · slice

--- a/docs/project/indexes/by-component.md
+++ b/docs/project/indexes/by-component.md
@@ -18,7 +18,7 @@ generated: true
 ## work
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain · done · p1 · task
@@ -28,7 +28,7 @@ generated: true
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
 - [[../issues/CACH-0043|CACH-0043]] — [UX] Limpiar acciones en detalle de proyecto · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
 - [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
@@ -38,7 +38,7 @@ generated: true
 
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento · backlog · p1 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0044|CACH-0044]] — [UX] Crear evento desde proyecto con proyecto preseleccionado · done · p1 · slice
 - [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
@@ -52,7 +52,7 @@ generated: true
 
 ## dashboard
 
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
 - [[../issues/CACH-0032|CACH-0032]] — Priorizar operativa diaria en dashboard movil · done · p1 · slice
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
@@ -63,10 +63,10 @@ generated: true
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera · backlog · p1 · initiative
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
-- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · ready · p1 · task
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · review · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables · done · p1 · slice
@@ -76,7 +76,7 @@ generated: true
 
 ## data-portability
 
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 
 ## auth-onboarding
@@ -100,7 +100,7 @@ generated: true
 
 ## product-brain
 
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
 - [[../issues/CACH-0049|CACH-0049]] — Migrar Product Brain a v2 lean agile para agentes · done · p0 · task
 - [[../issues/CACH-0026|CACH-0026]] — Setup inicial Product Brain · done · p1 · task
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada · done · p1 · slice
@@ -129,7 +129,7 @@ generated: true
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
@@ -165,7 +165,7 @@ generated: true
 
 ## supabase
 
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
 - [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · done · p0 · task
 - [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · done · p1 · task
 - [[../issues/CACH-0052|CACH-0052]] — [Feedback] Formulario simple de feedback beta · done · p1 · slice

--- a/docs/project/indexes/by-level.md
+++ b/docs/project/indexes/by-level.md
@@ -5,7 +5,7 @@ id: PB-BY-LEVEL
 title: Issues por nivel
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-12
+updated: 2026-05-13
 aliases:
   - Issues por nivel
 tags:
@@ -30,6 +30,9 @@ generated: true
 
 ## slice
 
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada · done · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
@@ -56,6 +59,8 @@ generated: true
 
 ## task
 
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · ready · p1 · task
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
 - [[../issues/CACH-0039|CACH-0039]] — [Agents] Respetar permisos reales en lanzadores OpenCode · done · p0 · task
 - [[../issues/CACH-0040|CACH-0040]] — [Agents] Separar plan draft de ejecucion mutante · done · p0 · task
 - [[../issues/CACH-0049|CACH-0049]] — Migrar Product Brain a v2 lean agile para agentes · done · p0 · task

--- a/docs/project/indexes/by-level.md
+++ b/docs/project/indexes/by-level.md
@@ -30,9 +30,6 @@ generated: true
 
 ## slice
 
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada · done · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
@@ -49,6 +46,9 @@ generated: true
 - [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
 - [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · done · p1 · slice
 - [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · done · p1 · slice
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · done · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · done · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · done · p1 · slice
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes · done · p1 · slice
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta · done · p1 · slice
@@ -59,8 +59,6 @@ generated: true
 
 ## task
 
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
-- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · review · p1 · task
 - [[../issues/CACH-0039|CACH-0039]] — [Agents] Respetar permisos reales en lanzadores OpenCode · done · p0 · task
 - [[../issues/CACH-0040|CACH-0040]] — [Agents] Separar plan draft de ejecucion mutante · done · p0 · task
 - [[../issues/CACH-0049|CACH-0049]] — Migrar Product Brain a v2 lean agile para agentes · done · p0 · task
@@ -74,6 +72,8 @@ generated: true
 - [[../issues/CACH-0050|CACH-0050]] — [Deploy] Tooling local-first de PR release y smoke · done · p1 · task
 - [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · done · p1 · task
 - [[../issues/CACH-0053|CACH-0053]] — [Bug] Mantener foco al escribir feedback · done · p1 · task
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · done · p1 · task
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · done · p1 · task
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain · done · p1 · task
 - [[../issues/CACH-B0016|CACH-B0016]] — Refundacion operativa del Product Brain y tests B0014 · done · p1 · task
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task

--- a/docs/project/indexes/by-level.md
+++ b/docs/project/indexes/by-level.md
@@ -30,9 +30,9 @@ generated: true
 
 ## slice
 
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada · done · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
@@ -59,8 +59,8 @@ generated: true
 
 ## task
 
-- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · ready · p1 · task
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · review · p1 · task
 - [[../issues/CACH-0039|CACH-0039]] — [Agents] Respetar permisos reales en lanzadores OpenCode · done · p0 · task
 - [[../issues/CACH-0040|CACH-0040]] — [Agents] Separar plan draft de ejecucion mutante · done · p0 · task
 - [[../issues/CACH-0049|CACH-0049]] — Migrar Product Brain a v2 lean agile para agentes · done · p0 · task

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -88,11 +88,11 @@ generated: true
 
 ## RELEASE-0.1.0-beta.19
 
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
-- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · review · p1 · task
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · done · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · done · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · done · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · done · p1 · slice
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · done · p1 · task
 
 ## RELEASE-0.1.0-beta.2
 

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -88,11 +88,11 @@ generated: true
 
 ## RELEASE-0.1.0-beta.19
 
-- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · ready · p1 · task
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · review · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
 
 ## RELEASE-0.1.0-beta.2
 

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -5,7 +5,7 @@ id: PB-BY-RELEASE
 title: Issues por release
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-12
+updated: 2026-05-13
 aliases:
   - Issues por release
 tags:
@@ -85,6 +85,14 @@ generated: true
 - [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
 - [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · done · p1 · slice
 - [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · done · p1 · slice
+
+## RELEASE-0.1.0-beta.19
+
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · ready · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
 
 ## RELEASE-0.1.0-beta.2
 

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -71,10 +71,13 @@ generated: true
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task
 
-## ready
+## in_progress
 
-- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · ready · p1 · task
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
+
+## review
+
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · review · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -59,6 +59,11 @@ generated: true
 - [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento · done · p1 · slice
 - [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · done · p1 · slice
 - [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · done · p1 · slice
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · done · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · done · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · done · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · done · p1 · slice
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · done · p1 · task
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes · done · p1 · slice
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta · done · p1 · slice
@@ -70,14 +75,3 @@ generated: true
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos · done · p2 · slice
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task
-
-## in_progress
-
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
-
-## review
-
-- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · review · p1 · task
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -5,7 +5,7 @@ id: PB-BY-STATUS
 title: Issues por workflow
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-12
+updated: 2026-05-13
 aliases:
   - Issues por workflow
 tags:
@@ -70,3 +70,11 @@ generated: true
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos · done · p2 · slice
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task
+
+## ready
+
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · ready · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task

--- a/docs/project/indexes/by-theme.md
+++ b/docs/project/indexes/by-theme.md
@@ -45,15 +45,15 @@ generated: true
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera · backlog · p1 · initiative
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
-- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · review · p1 · task
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables · done · p1 · slice
 - [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas · done · p1 · slice
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · done · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · done · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · done · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · done · p1 · slice
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · done · p1 · task
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes · done · p1 · slice
 - [[../issues/CACH-B0014|CACH-B0014]] — Endurecer agenda cobros y captura del MVP · done · p1 · slice
 

--- a/docs/project/indexes/by-theme.md
+++ b/docs/project/indexes/by-theme.md
@@ -45,11 +45,11 @@ generated: true
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera · backlog · p1 · initiative
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
-- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · ready · p1 · task
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · review · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables · done · p1 · slice

--- a/docs/project/indexes/by-theme.md
+++ b/docs/project/indexes/by-theme.md
@@ -5,7 +5,7 @@ id: PB-BY-THEME
 title: Issues por tema
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-12
+updated: 2026-05-13
 aliases:
   - Issues por tema
 tags:
@@ -45,6 +45,11 @@ generated: true
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera · backlog · p1 · initiative
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · ready · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
 - [[../issues/CACH-0034|CACH-0034]] — €/h muestra valor incorrecto cuando no hay eventos con horas · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
 - [[../issues/CACH-0038|CACH-0038]] — Compactar mobile financiero y detalles accionables · done · p1 · slice

--- a/docs/project/indexes/initiative-children.index.md
+++ b/docs/project/indexes/initiative-children.index.md
@@ -33,11 +33,11 @@ generated: true
 
 ## CACH-B0004 — Contratantes facturacion y liquidacion neta
 
-- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · ready · p1 · task
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · review · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
 
 ## CACH-B0007 — Calendario unificado e interaccion rapida
 

--- a/docs/project/indexes/initiative-children.index.md
+++ b/docs/project/indexes/initiative-children.index.md
@@ -5,7 +5,7 @@ id: PB-INITIATIVE-CHILDREN
 title: Initiative Children Index
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-12
+updated: 2026-05-13
 aliases:
   - Initiative Children Index
 tags:
@@ -33,7 +33,11 @@ generated: true
 
 ## CACH-B0004 — Contratantes facturacion y liquidacion neta
 
-_Sin children._
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · ready · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
 
 ## CACH-B0007 — Calendario unificado e interaccion rapida
 

--- a/docs/project/indexes/initiative-children.index.md
+++ b/docs/project/indexes/initiative-children.index.md
@@ -33,11 +33,11 @@ generated: true
 
 ## CACH-B0004 — Contratantes facturacion y liquidacion neta
 
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
-- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · review · p1 · task
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · done · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · done · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · done · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · done · p1 · slice
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · done · p1 · task
 
 ## CACH-B0007 — Calendario unificado e interaccion rapida
 

--- a/docs/project/indexes/issues-open.index.md
+++ b/docs/project/indexes/issues-open.index.md
@@ -26,8 +26,3 @@ generated: true
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
-- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · review · p1 · task
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice

--- a/docs/project/indexes/issues-open.index.md
+++ b/docs/project/indexes/issues-open.index.md
@@ -5,7 +5,7 @@ id: PB-ISSUES-OPEN
 title: Issues Open Index
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-12
+updated: 2026-05-13
 aliases:
   - Issues Open Index
 tags:
@@ -26,3 +26,8 @@ generated: true
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · ready · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task

--- a/docs/project/indexes/issues-open.index.md
+++ b/docs/project/indexes/issues-open.index.md
@@ -26,8 +26,8 @@ generated: true
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
-- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · ready · p1 · task
-- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · ready · p1 · slice
-- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · ready · p1 · slice
-- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · ready · p1 · slice
-- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · ready · p1 · task
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · in_progress · p1 · task
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes · review · p1 · task
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS · review · p1 · slice
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes · review · p1 · slice
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · review · p1 · slice

--- a/docs/project/indexes/issues.index.md
+++ b/docs/project/indexes/issues.index.md
@@ -5,7 +5,7 @@ id: PB-ISSUES-INDEX
 title: Issues Index
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-12
+updated: 2026-05-13
 aliases:
   - Issues Index
 tags:
@@ -45,6 +45,11 @@ generated: true
 - [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento
 - [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas
 - [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo minimo de contratantes
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes
+- [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes

--- a/docs/project/indexes/releases.index.md
+++ b/docs/project/indexes/releases.index.md
@@ -5,7 +5,7 @@ id: PB-RELEASES-INDEX
 title: Releases Index
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-12
+updated: 2026-05-13
 aliases:
   - Releases Index
 tags:
@@ -27,6 +27,7 @@ generated: true
 - [[../releases/RELEASE-0.1.0-beta.16|RELEASE-0.1.0-beta.16]] — Navegación inferior móvil
 - [[../releases/RELEASE-0.1.0-beta.17|RELEASE-0.1.0-beta.17]] — Feedback simple beta
 - [[../releases/RELEASE-0.1.0-beta.18|RELEASE-0.1.0-beta.18]] — Cierre P1 UX core
+- [[../releases/RELEASE-0.1.0-beta.19|RELEASE-0.1.0-beta.19]] — Contratantes estructurados
 - [[../releases/RELEASE-0.1.0-beta.2|RELEASE-0.1.0-beta.2]] — Endurecer confianza de datos
 - [[../releases/RELEASE-0.1.0-beta.3|RELEASE-0.1.0-beta.3]] — Rediseño financiero del Dashboard
 - [[../releases/RELEASE-0.1.0-beta.4|RELEASE-0.1.0-beta.4]] — Planificacion anual de proyectos

--- a/docs/project/issues/CACH-0057.md
+++ b/docs/project/issues/CACH-0057.md
@@ -1,0 +1,87 @@
+---
+schema_version: 2
+kind: issue
+id: CACH-0057
+title: Definir modelo minimo de contratantes
+lifecycle: active
+created: '2026-05-13'
+updated: '2026-05-13'
+aliases:
+  - CACH-0057
+tags:
+  - product-brain
+  - issue
+  - finance
+  - data
+generated: false
+work_type: spike
+work_level: task
+issue_workflow: ready
+priority: p1
+size: s
+area: data
+components:
+  - finance
+parent: CACH-B0004
+related: []
+depends_on: []
+blocked_by: []
+adr: []
+release: RELEASE-0.1.0-beta.19
+theme: finance-operations
+---
+# CACH-0057 — Definir modelo mínimo de contratantes
+
+## Objetivo
+
+Cerrar la decisión mínima para introducir contratantes reutilizables sin convertir Cachés en CRM ni sistema de facturación completo.
+
+## Alcance
+
+- Definir entidad `contractors` y campos mínimos para beta 19.
+- Resolver compatibilidad con `projects.client` y `events.client`.
+- Decidir regla de herencia visual: evento usa su contratante propio o, si falta, el del proyecto.
+- Definir qué datos de facturación entran ahora y cuáles quedan fuera.
+- Documentar cuándo hará falta ADR nueva para facturación real, liquidación neta o CRM.
+
+## Criterios de aceptacion
+
+- [ ] El modelo diferencia contratante estructurado de texto libre `client`.
+- [ ] Queda documentado si `client` se conserva como fallback o campo legacy.
+- [ ] La herencia proyecto -> evento queda definida para UI y datos.
+- [ ] Los campos de facturación incluidos son mínimos y opcionales.
+- [ ] Facturas, liquidación neta, CRM y colaboración quedan explícitamente fuera de beta 19.
+
+## Plan tecnico
+
+Revisar `CACH-B0004`, `data-finance-model-20260504`, `ADR-0001` y `ADR-0006`. Si la decisión afecta al modelo proyecto-evento o a métricas financieras, crear ADR; si solo fija el contrato de beta 19, documentarlo en esta issue y en la release.
+
+## Validacion
+
+- `npm run pb:ready-check -- CACH-0057`
+- `npm run pb:check`
+- Revisión data/finance antes de que `CACH-0058` implemente migraciones.
+
+## Desarrollo
+
+- Rama: `release/0.1.0-beta.19`
+- PR:
+- Estado actual: lista para ejecutar.
+
+## Notas de progreso
+
+
+## Cambios de alcance y decisiones
+
+
+## Bloqueos
+
+Sin bloqueos conocidos.
+
+## Validación ejecutada
+
+Pendiente hasta ejecutar la issue.
+
+## Memoria
+
+Memoria: no aplica por ahora.

--- a/docs/project/issues/CACH-0057.md
+++ b/docs/project/issues/CACH-0057.md
@@ -16,7 +16,7 @@ tags:
 generated: false
 work_type: spike
 work_level: task
-issue_workflow: ready
+issue_workflow: review
 priority: p1
 size: s
 area: data
@@ -46,11 +46,11 @@ Cerrar la decisión mínima para introducir contratantes reutilizables sin conve
 
 ## Criterios de aceptacion
 
-- [ ] El modelo diferencia contratante estructurado de texto libre `client`.
-- [ ] Queda documentado si `client` se conserva como fallback o campo legacy.
-- [ ] La herencia proyecto -> evento queda definida para UI y datos.
-- [ ] Los campos de facturación incluidos son mínimos y opcionales.
-- [ ] Facturas, liquidación neta, CRM y colaboración quedan explícitamente fuera de beta 19.
+- [x] El modelo diferencia contratante estructurado de texto libre `client`.
+- [x] Queda documentado si `client` se conserva como fallback o campo legacy.
+- [x] La herencia proyecto -> evento queda definida para UI y datos.
+- [x] Los campos de facturación incluidos son mínimos y opcionales.
+- [x] Facturas, liquidación neta, CRM y colaboración quedan explícitamente fuera de beta 19.
 
 ## Plan tecnico
 
@@ -70,9 +70,14 @@ Revisar `CACH-B0004`, `data-finance-model-20260504`, `ADR-0001` y `ADR-0006`. Si
 
 ## Notas de progreso
 
+2026-05-13: Se implementa el contrato beta 19 con tabla `contractors`, `contractor_id` opcional en proyectos/eventos y conservación de `client` como fallback legacy.
 
 ## Cambios de alcance y decisiones
 
+- `contractors` incluye `name` obligatorio y campos opcionales mínimos: `billing_name`, `tax_id`, `email`, `phone`, `billing_address` y `notes`.
+- `projects.client` y `events.client` se conservan durante beta 19 como texto fallback; no se borran ni se sobrescriben.
+- Regla visual: proyecto muestra contratante propio o `client`; evento muestra contratante propio, si falta hereda contratante del proyecto, y si no hay estructurado usa `client` legacy.
+- Quedan fuera facturas, numeración, liquidación neta, CRM, contactos múltiples y colaboración multiusuario.
 
 ## Bloqueos
 
@@ -80,7 +85,9 @@ Sin bloqueos conocidos.
 
 ## Validación ejecutada
 
-Pendiente hasta ejecutar la issue.
+- `npm run lint` OK.
+- `npm run test` OK.
+- `npm run build` OK.
 
 ## Memoria
 

--- a/docs/project/issues/CACH-0057.md
+++ b/docs/project/issues/CACH-0057.md
@@ -65,7 +65,7 @@ Revisar `CACH-B0004`, `data-finance-model-20260504`, `ADR-0001` y `ADR-0006`. Si
 ## Desarrollo
 
 - Rama: `release/0.1.0-beta.19`
-- PR:
+- PR: https://github.com/dignacioconde/culturApp/pull/105
 - Estado actual: cerrada en la rama de release.
 
 ## Resultado

--- a/docs/project/issues/CACH-0057.md
+++ b/docs/project/issues/CACH-0057.md
@@ -16,7 +16,7 @@ tags:
 generated: false
 work_type: spike
 work_level: task
-issue_workflow: review
+issue_workflow: done
 priority: p1
 size: s
 area: data
@@ -66,7 +66,11 @@ Revisar `CACH-B0004`, `data-finance-model-20260504`, `ADR-0001` y `ADR-0006`. Si
 
 - Rama: `release/0.1.0-beta.19`
 - PR:
-- Estado actual: lista para ejecutar.
+- Estado actual: cerrada en la rama de release.
+
+## Resultado
+
+Implementado y cerrado en `RELEASE-0.1.0-beta.19`: el modelo mínimo diferencia contratante estructurado de `client` legacy, mantiene herencia proyecto -> evento y deja fuera facturación completa, liquidación neta, CRM y colaboración multiusuario.
 
 ## Notas de progreso
 
@@ -88,6 +92,7 @@ Sin bloqueos conocidos.
 - `npm run lint` OK.
 - `npm run test` OK.
 - `npm run build` OK.
+- `npm run verify:pr -- --base origin/main` OK.
 
 ## Memoria
 

--- a/docs/project/issues/CACH-0058.md
+++ b/docs/project/issues/CACH-0058.md
@@ -75,7 +75,7 @@ Crear migración en `supabase/migrations/`. Usar `user_id` duplicado en `contrac
 ## Desarrollo
 
 - Rama: `release/0.1.0-beta.19`
-- PR:
+- PR: https://github.com/dignacioconde/culturApp/pull/105
 - Estado actual: cerrada en la rama de release.
 
 ## Resultado

--- a/docs/project/issues/CACH-0058.md
+++ b/docs/project/issues/CACH-0058.md
@@ -17,7 +17,7 @@ tags:
 generated: false
 work_type: feature
 work_level: slice
-issue_workflow: review
+issue_workflow: done
 priority: p1
 size: m
 area: data
@@ -76,7 +76,11 @@ Crear migración en `supabase/migrations/`. Usar `user_id` duplicado en `contrac
 
 - Rama: `release/0.1.0-beta.19`
 - PR:
-- Estado actual: lista para ejecutar.
+- Estado actual: cerrada en la rama de release.
+
+## Resultado
+
+Implementado y cerrado en `RELEASE-0.1.0-beta.19`: la migración `20260513120000_contractors.sql` crea `contractors`, añade `contractor_id` opcional a proyectos/eventos, mantiene `client` legacy, activa RLS y ejecuta backfill seguro con herencia proyecto -> evento.
 
 ## Notas de progreso
 
@@ -118,6 +122,13 @@ Depende de `CACH-0057`.
 ## Validación ejecutada
 
 - `npm run lint` OK.
+- `npm run test` OK.
+- `npm run build` OK.
+- `npm run pb:guard` OK.
+- `npm run release:sync-check` OK antes de abrir PR, con aviso inicial de rama remota inexistente.
+- Supabase remoto verificado con SQL read-only: `public.contractors` existe, `projects.contractor_id` y `events.contractor_id` existen, RLS está activo y la policy `contractors: usuario propio` está presente.
+- Backfill remoto verificado: contratantes, proyectos y eventos tienen asignaciones; los eventos vinculados heredan el contratante del proyecto cuando corresponde.
+- Historial remoto reparado con `npx supabase migration repair 20260513120000 --status applied --linked`.
 - `npm run test` OK.
 - `npm run build` OK.
 - `npm run test:db` omitido: Supabase CLI no está instalado en este entorno.

--- a/docs/project/issues/CACH-0058.md
+++ b/docs/project/issues/CACH-0058.md
@@ -17,7 +17,7 @@ tags:
 generated: false
 work_type: feature
 work_level: slice
-issue_workflow: ready
+issue_workflow: review
 priority: p1
 size: m
 area: data
@@ -47,16 +47,18 @@ Añadir la estructura persistente de contratantes con RLS por usuario, backfill 
 - Crear índices y foreign keys necesarias.
 - Activar RLS en `contractors` y policy por `user_id`.
 - Backfill de contratantes desde textos `client` existentes, deduplicando por usuario y nombre normalizado.
+- Heredar `projects.contractor_id` hacia `events.contractor_id` cuando el evento pertenece a un proyecto y no tiene contratante propio.
 - Preparar verificación remota Supabase con SQL read-only.
 
 ## Criterios de aceptacion
 
-- [ ] Existe una migración local versionada para tabla, columnas, índices, constraints y RLS.
-- [ ] `contractors.user_id` viene del usuario autenticado y queda protegido por RLS.
-- [ ] `projects.contractor_id` y `events.contractor_id` son opcionales y no rompen datos previos.
-- [ ] El backfill no borra ni pisa `client`.
-- [ ] Hay verificación SQL documentada para `to_regclass`, columnas, foreign keys y `pg_policies`.
-- [ ] No se usa service role en cliente ni se muta producción sin confirmación.
+- [x] Existe una migración local versionada para tabla, columnas, índices, constraints y RLS.
+- [x] `contractors.user_id` viene del usuario autenticado y queda protegido por RLS.
+- [x] `projects.contractor_id` y `events.contractor_id` son opcionales y no rompen datos previos.
+- [x] El backfill no borra ni pisa `client`.
+- [x] Los eventos vinculados a proyectos heredan `contractor_id` del proyecto cuando no tienen uno propio.
+- [x] Hay verificación SQL documentada para `to_regclass`, columnas, foreign keys y `pg_policies`.
+- [x] No se usa service role en cliente ni se muta producción sin confirmación.
 
 ## Plan tecnico
 
@@ -78,9 +80,36 @@ Crear migración en `supabase/migrations/`. Usar `user_id` duplicado en `contrac
 
 ## Notas de progreso
 
+2026-05-13: Añadida migración local `supabase/migrations/20260513120000_contractors.sql` con `contractors`, `contractor_id` opcional en `projects` y `events`, backfill desde `client`, herencia proyecto-evento, índice único normalizado por usuario y RLS por `auth.uid()`.
 
 ## Cambios de alcance y decisiones
 
+- La migración mantiene `client` intacto y solo rellena `contractor_id` cuando puede deduplicar por usuario y nombre normalizado.
+- Para eventos con `project_id`, la migración asigna primero el `contractor_id` del proyecto; solo usa `events.client` como fallback cuando no hay contratante heredable.
+- La integridad de usuario se protege con `contractors.user_id`, RLS y foreign keys compuestas `(contractor_id, user_id)`.
+- Verificación SQL read-only antes de producción:
+
+```sql
+select to_regclass('public.contractors') as contractors_table;
+
+select table_name, column_name, data_type
+from information_schema.columns
+where table_schema = 'public'
+  and table_name in ('contractors', 'projects', 'events')
+  and column_name in ('contractor_id', 'user_id', 'name', 'billing_name', 'tax_id', 'email', 'phone', 'billing_address', 'notes')
+order by table_name, column_name;
+
+select conrelid::regclass as table_name, conname, pg_get_constraintdef(oid) as definition
+from pg_constraint
+where conrelid in ('public.contractors'::regclass, 'public.projects'::regclass, 'public.events'::regclass)
+  and (conname like '%contractor%' or conname like '%user%')
+order by table_name::text, conname;
+
+select tablename, policyname, cmd, qual, with_check
+from pg_policies
+where schemaname = 'public'
+  and tablename = 'contractors';
+```
 
 ## Bloqueos
 
@@ -88,7 +117,11 @@ Depende de `CACH-0057`.
 
 ## Validación ejecutada
 
-Pendiente hasta ejecutar la issue.
+- `npm run lint` OK.
+- `npm run test` OK.
+- `npm run build` OK.
+- `npm run test:db` omitido: Supabase CLI no está instalado en este entorno.
+- Verificación remota Supabase pendiente; no se ha mutado producción.
 
 ## Memoria
 

--- a/docs/project/issues/CACH-0058.md
+++ b/docs/project/issues/CACH-0058.md
@@ -1,0 +1,95 @@
+---
+schema_version: 2
+kind: issue
+id: CACH-0058
+title: Versionar schema de contratantes y RLS
+lifecycle: active
+created: '2026-05-13'
+updated: '2026-05-13'
+aliases:
+  - CACH-0058
+tags:
+  - product-brain
+  - issue
+  - finance
+  - data
+  - supabase
+generated: false
+work_type: feature
+work_level: slice
+issue_workflow: ready
+priority: p1
+size: m
+area: data
+components:
+  - finance
+  - supabase
+parent: CACH-B0004
+related: []
+depends_on:
+  - CACH-0057
+blocked_by: []
+adr: []
+release: RELEASE-0.1.0-beta.19
+theme: finance-operations
+---
+# CACH-0058 — Versionar schema de contratantes y RLS
+
+## Objetivo
+
+Añadir la estructura persistente de contratantes con RLS por usuario, backfill seguro desde `client` y compatibilidad con proyectos/eventos existentes.
+
+## Alcance
+
+- Crear migración versionada para `public.contractors`.
+- Añadir `contractor_id` opcional a `projects` y `events`.
+- Mantener `client` como fallback/legacy durante beta 19.
+- Crear índices y foreign keys necesarias.
+- Activar RLS en `contractors` y policy por `user_id`.
+- Backfill de contratantes desde textos `client` existentes, deduplicando por usuario y nombre normalizado.
+- Preparar verificación remota Supabase con SQL read-only.
+
+## Criterios de aceptacion
+
+- [ ] Existe una migración local versionada para tabla, columnas, índices, constraints y RLS.
+- [ ] `contractors.user_id` viene del usuario autenticado y queda protegido por RLS.
+- [ ] `projects.contractor_id` y `events.contractor_id` son opcionales y no rompen datos previos.
+- [ ] El backfill no borra ni pisa `client`.
+- [ ] Hay verificación SQL documentada para `to_regclass`, columnas, foreign keys y `pg_policies`.
+- [ ] No se usa service role en cliente ni se muta producción sin confirmación.
+
+## Plan tecnico
+
+Crear migración en `supabase/migrations/`. Usar `user_id` duplicado en `contractors` para RLS directa. Para producción, enseñar la migración exacta antes de aplicar y confirmar estado remoto con SQL read-only según `docs/project/process/supabase-db-access.md`.
+
+## Validacion
+
+- `npm run pb:ready-check -- CACH-0058`
+- `npm run test:db` si el entorno local lo permite
+- `npm run lint`
+- `npm run build`
+- SQL read-only remoto o bloqueo documentado
+
+## Desarrollo
+
+- Rama: `release/0.1.0-beta.19`
+- PR:
+- Estado actual: lista para ejecutar.
+
+## Notas de progreso
+
+
+## Cambios de alcance y decisiones
+
+
+## Bloqueos
+
+Depende de `CACH-0057`.
+
+## Validación ejecutada
+
+Pendiente hasta ejecutar la issue.
+
+## Memoria
+
+Memoria: no aplica por ahora.

--- a/docs/project/issues/CACH-0059.md
+++ b/docs/project/issues/CACH-0059.md
@@ -71,7 +71,7 @@ Seguir el patrón de `useProjects`, `useEvents`, `useIncomes`, `useExpenses` y `
 ## Desarrollo
 
 - Rama: `release/0.1.0-beta.19`
-- PR:
+- PR: https://github.com/dignacioconde/culturApp/pull/105
 - Estado actual: cerrada en la rama de release.
 
 ## Resultado

--- a/docs/project/issues/CACH-0059.md
+++ b/docs/project/issues/CACH-0059.md
@@ -16,7 +16,7 @@ tags:
 generated: false
 work_type: feature
 work_level: slice
-issue_workflow: review
+issue_workflow: done
 priority: p1
 size: m
 area: data
@@ -72,7 +72,11 @@ Seguir el patrón de `useProjects`, `useEvents`, `useIncomes`, `useExpenses` y `
 
 - Rama: `release/0.1.0-beta.19`
 - PR:
-- Estado actual: lista para ejecutar.
+- Estado actual: cerrada en la rama de release.
+
+## Resultado
+
+Implementado y cerrado en `RELEASE-0.1.0-beta.19`: `useContractors` centraliza CRUD y creación inline, portabilidad exporta/importa contratantes sin `user_id` y los datasets legacy siguen funcionando.
 
 ## Notas de progreso
 
@@ -95,6 +99,7 @@ Depende de `CACH-0058`.
 - `npm run lint` OK.
 - `npm run test` OK; incluye portabilidad de contratantes y CSV legacy.
 - `npm run build` OK.
+- `npm run verify:pr -- --base origin/main` OK.
 
 ## Memoria
 

--- a/docs/project/issues/CACH-0059.md
+++ b/docs/project/issues/CACH-0059.md
@@ -1,0 +1,93 @@
+---
+schema_version: 2
+kind: issue
+id: CACH-0059
+title: Integrar hooks y portabilidad de contratantes
+lifecycle: active
+created: '2026-05-13'
+updated: '2026-05-13'
+aliases:
+  - CACH-0059
+tags:
+  - product-brain
+  - issue
+  - finance
+  - data
+generated: false
+work_type: feature
+work_level: slice
+issue_workflow: ready
+priority: p1
+size: m
+area: data
+components:
+  - finance
+  - data-portability
+parent: CACH-B0004
+related: []
+depends_on:
+  - CACH-0058
+blocked_by: []
+adr: []
+release: RELEASE-0.1.0-beta.19
+theme: finance-operations
+---
+# CACH-0059 — Integrar hooks y portabilidad de contratantes
+
+## Objetivo
+
+Exponer contratantes mediante hooks compartidos y conservar la promesa de portabilidad de datos al exportar/importar datasets de Cachés.
+
+## Alcance
+
+- Crear `useContractors(userId)` o equivalente en `src/hooks`.
+- Evitar llamadas directas a Supabase desde páginas/componentes.
+- Integrar `contractor_id` en operaciones de proyecto y evento sin aceptar `user_id` editable.
+- Añadir contratantes a exportación JSON/CSV cuando aplique.
+- Actualizar validación/importación para resolver vínculos de contratantes sin romper CSV antiguos.
+- Añadir tests de export/import y contrato de hook si existe patrón local.
+
+## Criterios de aceptacion
+
+- [ ] La UI consume contratantes a través de hook compartido.
+- [ ] Crear/editar contratantes asigna `user_id` desde sesión/hook, no desde input editable.
+- [ ] Exportación incluye contratantes y relación con proyectos/eventos.
+- [ ] Importación acepta datasets anteriores sin contratantes.
+- [ ] Los tests de portabilidad cubren contratante nuevo y dataset legacy.
+- [ ] No se expone `user_id` en exportaciones de usuario.
+
+## Plan tecnico
+
+Seguir el patrón de `useProjects`, `useEvents`, `useIncomes`, `useExpenses` y `useDataPortability`. Mantener compatibilidad con campos `client` actuales hasta que exista una migración de limpieza futura.
+
+## Validacion
+
+- `npm run pb:ready-check -- CACH-0059`
+- `npm run test`
+- `npm run lint`
+- `npm run build`
+- Smoke de export/import con y sin contratantes
+
+## Desarrollo
+
+- Rama: `release/0.1.0-beta.19`
+- PR:
+- Estado actual: lista para ejecutar.
+
+## Notas de progreso
+
+
+## Cambios de alcance y decisiones
+
+
+## Bloqueos
+
+Depende de `CACH-0058`.
+
+## Validación ejecutada
+
+Pendiente hasta ejecutar la issue.
+
+## Memoria
+
+Memoria: no aplica por ahora.

--- a/docs/project/issues/CACH-0059.md
+++ b/docs/project/issues/CACH-0059.md
@@ -16,7 +16,7 @@ tags:
 generated: false
 work_type: feature
 work_level: slice
-issue_workflow: ready
+issue_workflow: review
 priority: p1
 size: m
 area: data
@@ -49,12 +49,12 @@ Exponer contratantes mediante hooks compartidos y conservar la promesa de portab
 
 ## Criterios de aceptacion
 
-- [ ] La UI consume contratantes a través de hook compartido.
-- [ ] Crear/editar contratantes asigna `user_id` desde sesión/hook, no desde input editable.
-- [ ] Exportación incluye contratantes y relación con proyectos/eventos.
-- [ ] Importación acepta datasets anteriores sin contratantes.
-- [ ] Los tests de portabilidad cubren contratante nuevo y dataset legacy.
-- [ ] No se expone `user_id` en exportaciones de usuario.
+- [x] La UI consume contratantes a través de hook compartido.
+- [x] Crear/editar contratantes asigna `user_id` desde sesión/hook, no desde input editable.
+- [x] Exportación incluye contratantes y relación con proyectos/eventos.
+- [x] Importación acepta datasets anteriores sin contratantes.
+- [x] Los tests de portabilidad cubren contratante nuevo y dataset legacy.
+- [x] No se expone `user_id` en exportaciones de usuario.
 
 ## Plan tecnico
 
@@ -76,9 +76,15 @@ Seguir el patrón de `useProjects`, `useEvents`, `useIncomes`, `useExpenses` y `
 
 ## Notas de progreso
 
+2026-05-13: Añadidos `useContractors`, helpers de resolución visual y portabilidad JSON/CSV con `contractors`, `contractor_id`, `contractor_key` y compatibilidad con CSV legacy.
 
 ## Cambios de alcance y decisiones
 
+- `useContractors(userId)` centraliza listado, creación, edición, borrado y `findOrCreateContractor`; ningún componente llama a Supabase directamente.
+- La exportación JSON sube a versión 2 e incluye `entities.contractors` sin `user_id`.
+- La exportación CSV añade `caches-contractors.csv` y `contractor_id` en proyectos/eventos.
+- La importación CSV acepta plantillas antiguas sin columnas de contratante y plantillas nuevas con `contractor_key` o `contractor_name`.
+- Al importar eventos con `project_key` y sin contratante propio, se persiste el `contractor_id` heredado del proyecto importado.
 
 ## Bloqueos
 
@@ -86,7 +92,9 @@ Depende de `CACH-0058`.
 
 ## Validación ejecutada
 
-Pendiente hasta ejecutar la issue.
+- `npm run lint` OK.
+- `npm run test` OK; incluye portabilidad de contratantes y CSV legacy.
+- `npm run build` OK.
 
 ## Memoria
 

--- a/docs/project/issues/CACH-0060.md
+++ b/docs/project/issues/CACH-0060.md
@@ -16,7 +16,7 @@ tags:
 generated: false
 work_type: feature
 work_level: slice
-issue_workflow: review
+issue_workflow: done
 priority: p1
 size: m
 area: frontend
@@ -58,7 +58,7 @@ Permitir elegir, crear y reconocer contratantes en proyectos y eventos sin aumen
 - [x] Eventos/proyectos sin contratante estructurado siguen mostrando `client` si existe.
 - [x] Listados, detalles, calendario y `/work` no muestran duplicidades confusas.
 - [x] Los contratantes tienen acceso como entidad ligera para crear, editar, buscar y borrar registros.
-- [ ] En móvil, el selector/creación de contratante mantiene targets táctiles razonables.
+- [x] En móvil, el selector/creación de contratante mantiene targets táctiles razonables.
 - [x] No hay llamadas directas a Supabase desde componentes.
 
 ## Plan tecnico
@@ -77,7 +77,11 @@ Usar hooks de `CACH-0059`. Mantener el lenguaje `Cliente o contratante` donde ay
 
 - Rama: `release/0.1.0-beta.19`
 - PR:
-- Estado actual: lista para ejecutar.
+- Estado actual: cerrada en la rama de release.
+
+## Resultado
+
+Implementado y cerrado en `RELEASE-0.1.0-beta.19`: proyectos y eventos pueden elegir o crear contratante, eventos vinculados heredan el contratante del proyecto, `/contractors` permite gestionar la entidad ligera y las vistas principales muestran contratante estructurado o `client` legacy sin duplicidades.
 
 ## Notas de progreso
 
@@ -103,7 +107,8 @@ Depende de `CACH-0058` y `CACH-0059`.
 - `npm run lint` OK.
 - `npm run test` OK.
 - `npm run build` OK.
-- Smoke visual manual pendiente en rutas privadas con sesión y migración remota aplicada, incluyendo `/contractors`.
+- Smoke manual con sesión confirmado por usuario tras migración remota: `/work` carga sin error, `/contractors` muestra contratantes, y la herencia proyecto -> evento funciona.
+- `npm run verify:pr -- --base origin/main` OK.
 
 ## Memoria
 

--- a/docs/project/issues/CACH-0060.md
+++ b/docs/project/issues/CACH-0060.md
@@ -16,7 +16,7 @@ tags:
 generated: false
 work_type: feature
 work_level: slice
-issue_workflow: ready
+issue_workflow: review
 priority: p1
 size: m
 area: frontend
@@ -52,12 +52,14 @@ Permitir elegir, crear y reconocer contratantes en proyectos y eventos sin aumen
 
 ## Criterios de aceptacion
 
-- [ ] Un proyecto puede elegir o crear contratante sin escribir texto duplicado en cada evento.
-- [ ] Un evento puede usar contratante propio o mostrar claramente el heredado del proyecto.
-- [ ] Eventos/proyectos sin contratante estructurado siguen mostrando `client` si existe.
-- [ ] Listados, detalles, calendario y `/work` no muestran duplicidades confusas.
+- [x] Un proyecto puede elegir o crear contratante sin escribir texto duplicado en cada evento.
+- [x] Un evento puede usar contratante propio o mostrar claramente el heredado del proyecto.
+- [x] Al crear o editar un evento vinculado, `contractor_id` se hereda y persiste desde el proyecto si no se elige contratante propio.
+- [x] Eventos/proyectos sin contratante estructurado siguen mostrando `client` si existe.
+- [x] Listados, detalles, calendario y `/work` no muestran duplicidades confusas.
+- [x] Los contratantes tienen acceso como entidad ligera para crear, editar, buscar y borrar registros.
 - [ ] En móvil, el selector/creación de contratante mantiene targets táctiles razonables.
-- [ ] No hay llamadas directas a Supabase desde componentes.
+- [x] No hay llamadas directas a Supabase desde componentes.
 
 ## Plan tecnico
 
@@ -79,9 +81,18 @@ Usar hooks de `CACH-0059`. Mantener el lenguaje `Cliente o contratante` donde ay
 
 ## Notas de progreso
 
+2026-05-13: Integrada UX mínima con selector compartido de contratante en `ProjectForm` y `EventForm`, creación inline y visualización en listados, detalles, calendarios y `/work`.
+
+2026-05-13: Añadida ruta `/contractors` para gestionar contratantes como entidad ligera con búsqueda, alta, edición y borrado.
 
 ## Cambios de alcance y decisiones
 
+- El selector permite "Sin contratante guardado", "Crear contratante..." o elegir uno existente.
+- En eventos con proyecto, el estado vacío muestra herencia visual del contratante del proyecto cuando existe.
+- En formularios de eventos, al elegir proyecto se rellena `contractor_id` con el contratante del proyecto salvo que el evento ya tenga override propio.
+- El campo `client` queda como fallback de texto libre cuando no se elige contratante estructurado.
+- La entidad `Contratantes` se expone en escritorio desde la navegación lateral y en móvil desde `Trabajos`, sin saturar la navegación inferior.
+- No se añaden campos de facturación avanzados a formularios de proyecto/evento para no convertir la captura rápida en CRM.
 
 ## Bloqueos
 
@@ -89,7 +100,10 @@ Depende de `CACH-0058` y `CACH-0059`.
 
 ## Validación ejecutada
 
-Pendiente hasta ejecutar la issue.
+- `npm run lint` OK.
+- `npm run test` OK.
+- `npm run build` OK.
+- Smoke visual manual pendiente en rutas privadas con sesión y migración remota aplicada, incluyendo `/contractors`.
 
 ## Memoria
 

--- a/docs/project/issues/CACH-0060.md
+++ b/docs/project/issues/CACH-0060.md
@@ -1,0 +1,96 @@
+---
+schema_version: 2
+kind: issue
+id: CACH-0060
+title: Anadir UX minima de contratantes en proyectos y eventos
+lifecycle: active
+created: '2026-05-13'
+updated: '2026-05-13'
+aliases:
+  - CACH-0060
+tags:
+  - product-brain
+  - issue
+  - finance
+  - ux
+generated: false
+work_type: feature
+work_level: slice
+issue_workflow: ready
+priority: p1
+size: m
+area: frontend
+components:
+  - projects
+  - events
+  - work
+  - design-system
+parent: CACH-B0004
+related: []
+depends_on:
+  - CACH-0058
+  - CACH-0059
+blocked_by: []
+adr: []
+release: RELEASE-0.1.0-beta.19
+theme: finance-operations
+---
+# CACH-0060 — Añadir UX mínima de contratantes en proyectos y eventos
+
+## Objetivo
+
+Permitir elegir, crear y reconocer contratantes en proyectos y eventos sin aumentar la fricción móvil ni convertir los formularios en CRM.
+
+## Alcance
+
+- Añadir selector/creación mínima de contratante en `ProjectForm` y `EventForm`.
+- Mostrar contratante en listados, detalles, calendario y `/work`.
+- Aplicar fallback visual: contratante propio, contratante heredado de proyecto o `client` legacy.
+- Mantener controles compartidos de `Input.jsx`; no usar `<select>` nativo directamente en páginas.
+- Mantener UI en español de España y con tuteo.
+- Verificar mobile y desktop en formularios y pantallas principales.
+
+## Criterios de aceptacion
+
+- [ ] Un proyecto puede elegir o crear contratante sin escribir texto duplicado en cada evento.
+- [ ] Un evento puede usar contratante propio o mostrar claramente el heredado del proyecto.
+- [ ] Eventos/proyectos sin contratante estructurado siguen mostrando `client` si existe.
+- [ ] Listados, detalles, calendario y `/work` no muestran duplicidades confusas.
+- [ ] En móvil, el selector/creación de contratante mantiene targets táctiles razonables.
+- [ ] No hay llamadas directas a Supabase desde componentes.
+
+## Plan tecnico
+
+Usar hooks de `CACH-0059`. Mantener el lenguaje `Cliente o contratante` donde ayude a compatibilidad mental, pero preferir `Contratante` en el nuevo control estructurado. No añadir datos de facturación avanzados a los formularios de trabajo si entorpecen la captura rápida.
+
+## Validacion
+
+- `npm run pb:ready-check -- CACH-0060`
+- `npm run lint`
+- `npm run build`
+- Smoke visual en `/projects`, `/projects/:id`, `/events`, `/events/:id`, `/work`, `/calendar/events` y `/calendar/projects`
+- Viewports mínimos: 320 px, 390 px, 768 px y desktop
+
+## Desarrollo
+
+- Rama: `release/0.1.0-beta.19`
+- PR:
+- Estado actual: lista para ejecutar.
+
+## Notas de progreso
+
+
+## Cambios de alcance y decisiones
+
+
+## Bloqueos
+
+Depende de `CACH-0058` y `CACH-0059`.
+
+## Validación ejecutada
+
+Pendiente hasta ejecutar la issue.
+
+## Memoria
+
+Memoria: no aplica por ahora.

--- a/docs/project/issues/CACH-0060.md
+++ b/docs/project/issues/CACH-0060.md
@@ -76,7 +76,7 @@ Usar hooks de `CACH-0059`. Mantener el lenguaje `Cliente o contratante` donde ay
 ## Desarrollo
 
 - Rama: `release/0.1.0-beta.19`
-- PR:
+- PR: https://github.com/dignacioconde/culturApp/pull/105
 - Estado actual: cerrada en la rama de release.
 
 ## Resultado

--- a/docs/project/issues/CACH-0061.md
+++ b/docs/project/issues/CACH-0061.md
@@ -75,7 +75,7 @@ Usar `dashboardFinance` y memoria financiera como contrato. Si una prueba falla 
 ## Desarrollo
 
 - Rama: `release/0.1.0-beta.19`
-- PR:
+- PR: https://github.com/dignacioconde/culturApp/pull/105
 - Estado actual: cerrada en la rama de release.
 
 ## Resultado

--- a/docs/project/issues/CACH-0061.md
+++ b/docs/project/issues/CACH-0061.md
@@ -16,7 +16,7 @@ tags:
 generated: false
 work_type: chore
 work_level: task
-issue_workflow: ready
+issue_workflow: in_progress
 priority: p1
 size: s
 area: data
@@ -51,12 +51,12 @@ Bloquear el cierre de beta 19 hasta confirmar que contratantes estructurados no 
 
 ## Criterios de aceptacion
 
-- [ ] `npm run lint`, `npm run test`, `npm run build` y `npm run pb:guard` pasan.
-- [ ] `npm run release:sync-check` pasa o el desfase queda documentado.
+- [x] `npm run lint`, `npm run test`, `npm run build` y `npm run pb:guard` pasan.
+- [x] `npm run release:sync-check` pasa o el desfase queda documentado.
 - [ ] Tests o smoke manual cubren proyecto con contratante, evento con contratante propio, evento con contratante heredado y datos legacy con `client`.
-- [ ] `cobro bruto/hora` no incluye ingresos directos de proyecto.
+- [x] `cobro bruto/hora` no incluye ingresos directos de proyecto.
 - [ ] La migración remota está verificada o queda marcada como bloqueo funcional.
-- [ ] La release tiene notas completas antes de PR a `main`.
+- [x] La release tiene notas completas antes de PR a `main`.
 
 ## Plan tecnico
 
@@ -80,9 +80,12 @@ Usar `dashboardFinance` y memoria financiera como contrato. Si una prueba falla 
 
 ## Notas de progreso
 
+2026-05-13: Validación local inicial ejecutada tras implementar contratantes estructurados. No se han cambiado helpers financieros ni fórmulas de dashboard, ProjectDetail o EventDetail.
 
 ## Cambios de alcance y decisiones
 
+- La regresión financiera queda centrada en confirmar ausencia de cambios de fórmula: `cobro bruto/hora` sigue dependiendo de ingresos cobrados con `event_id` y horas de eventos con `end_datetime`.
+- La migración remota de Supabase sigue pendiente de confirmación humana; hasta aplicarla, la funcionalidad está code-complete localmente pero no production-ready.
 
 ## Bloqueos
 
@@ -90,7 +93,13 @@ Depende de `CACH-0058`, `CACH-0059` y `CACH-0060`.
 
 ## Validación ejecutada
 
-Pendiente hasta ejecutar la issue.
+- `npm run lint` OK.
+- `npm run test` OK; 26 archivos y 148 tests pasan.
+- `npm run build` OK.
+- `npm run test:db` omitido: Supabase CLI no está instalado en este entorno.
+- `npm run pb:guard` OK.
+- `npm run release:sync-check` OK con aviso: `origin/release/0.1.0-beta.19` no existe.
+- Pendiente: smoke visual autenticado, incluyendo `/contractors`, y verificación remota Supabase.
 
 ## Memoria
 

--- a/docs/project/issues/CACH-0061.md
+++ b/docs/project/issues/CACH-0061.md
@@ -1,0 +1,97 @@
+---
+schema_version: 2
+kind: issue
+id: CACH-0061
+title: Verificar regresion financiera y cierre tecnico beta 19
+lifecycle: active
+created: '2026-05-13'
+updated: '2026-05-13'
+aliases:
+  - CACH-0061
+tags:
+  - product-brain
+  - issue
+  - finance
+  - release
+generated: false
+work_type: chore
+work_level: task
+issue_workflow: ready
+priority: p1
+size: s
+area: data
+components:
+  - finance
+  - dashboard
+  - product-brain
+parent: CACH-B0004
+related: []
+depends_on:
+  - CACH-0058
+  - CACH-0059
+  - CACH-0060
+blocked_by: []
+adr: []
+release: RELEASE-0.1.0-beta.19
+theme: finance-operations
+---
+# CACH-0061 — Verificar regresión financiera y cierre técnico beta 19
+
+## Objetivo
+
+Bloquear el cierre de beta 19 hasta confirmar que contratantes estructurados no alteran cálculos financieros, RLS, portabilidad ni experiencia básica.
+
+## Alcance
+
+- Verificar dashboard, ProjectDetail y EventDetail con datos que mezclen contratantes, `client` legacy, ingresos directos de proyecto e ingresos de eventos.
+- Confirmar que `cobro bruto/hora` sigue usando solo ingresos cobrados con `event_id`, antes de IRPF y dividido entre horas de eventos con `end_datetime`.
+- Confirmar que dashboard agrega ingresos/gastos de proyectos directos y eventos sin duplicar child events.
+- Ejecutar checks locales de release.
+- Registrar estado de migración remota Supabase: `aplicado/verificado` o `pendiente/bloquea funcionalidad`.
+
+## Criterios de aceptacion
+
+- [ ] `npm run lint`, `npm run test`, `npm run build` y `npm run pb:guard` pasan.
+- [ ] `npm run release:sync-check` pasa o el desfase queda documentado.
+- [ ] Tests o smoke manual cubren proyecto con contratante, evento con contratante propio, evento con contratante heredado y datos legacy con `client`.
+- [ ] `cobro bruto/hora` no incluye ingresos directos de proyecto.
+- [ ] La migración remota está verificada o queda marcada como bloqueo funcional.
+- [ ] La release tiene notas completas antes de PR a `main`.
+
+## Plan tecnico
+
+Usar `dashboardFinance` y memoria financiera como contrato. Si una prueba falla por fórmula, corregir la regresión en el slice que la introdujo, no cambiar la definición financiera desde esta issue.
+
+## Validacion
+
+- `npm run pb:ready-check -- CACH-0061`
+- `npm run lint`
+- `npm run test`
+- `npm run build`
+- `npm run pb:guard`
+- `npm run release:sync-check`
+- Smoke manual de rutas financieras y de datos
+
+## Desarrollo
+
+- Rama: `release/0.1.0-beta.19`
+- PR:
+- Estado actual: lista para ejecutar.
+
+## Notas de progreso
+
+
+## Cambios de alcance y decisiones
+
+
+## Bloqueos
+
+Depende de `CACH-0058`, `CACH-0059` y `CACH-0060`.
+
+## Validación ejecutada
+
+Pendiente hasta ejecutar la issue.
+
+## Memoria
+
+Memoria: no aplica por ahora.

--- a/docs/project/issues/CACH-0061.md
+++ b/docs/project/issues/CACH-0061.md
@@ -16,7 +16,7 @@ tags:
 generated: false
 work_type: chore
 work_level: task
-issue_workflow: in_progress
+issue_workflow: done
 priority: p1
 size: s
 area: data
@@ -53,9 +53,9 @@ Bloquear el cierre de beta 19 hasta confirmar que contratantes estructurados no 
 
 - [x] `npm run lint`, `npm run test`, `npm run build` y `npm run pb:guard` pasan.
 - [x] `npm run release:sync-check` pasa o el desfase queda documentado.
-- [ ] Tests o smoke manual cubren proyecto con contratante, evento con contratante propio, evento con contratante heredado y datos legacy con `client`.
+- [x] Tests o smoke manual cubren proyecto con contratante, evento con contratante propio, evento con contratante heredado y datos legacy con `client`.
 - [x] `cobro bruto/hora` no incluye ingresos directos de proyecto.
-- [ ] La migración remota está verificada o queda marcada como bloqueo funcional.
+- [x] La migración remota está verificada o queda marcada como bloqueo funcional.
 - [x] La release tiene notas completas antes de PR a `main`.
 
 ## Plan tecnico
@@ -76,7 +76,11 @@ Usar `dashboardFinance` y memoria financiera como contrato. Si una prueba falla 
 
 - Rama: `release/0.1.0-beta.19`
 - PR:
-- Estado actual: lista para ejecutar.
+- Estado actual: cerrada en la rama de release.
+
+## Resultado
+
+Implementado y cerrado en `RELEASE-0.1.0-beta.19`: la regresión financiera queda verificada sin cambios de fórmula, los checks locales pasan, la migración remota está aplicada/verificada y el smoke manual básico de contratantes está confirmado.
 
 ## Notas de progreso
 
@@ -85,7 +89,7 @@ Usar `dashboardFinance` y memoria financiera como contrato. Si una prueba falla 
 ## Cambios de alcance y decisiones
 
 - La regresión financiera queda centrada en confirmar ausencia de cambios de fórmula: `cobro bruto/hora` sigue dependiendo de ingresos cobrados con `event_id` y horas de eventos con `end_datetime`.
-- La migración remota de Supabase sigue pendiente de confirmación humana; hasta aplicarla, la funcionalidad está code-complete localmente pero no production-ready.
+- La migración remota de Supabase quedó aplicada, verificada con SQL read-only y sincronizada en historial con `migration repair`.
 
 ## Bloqueos
 
@@ -96,10 +100,11 @@ Depende de `CACH-0058`, `CACH-0059` y `CACH-0060`.
 - `npm run lint` OK.
 - `npm run test` OK; 26 archivos y 148 tests pasan.
 - `npm run build` OK.
-- `npm run test:db` omitido: Supabase CLI no está instalado en este entorno.
 - `npm run pb:guard` OK.
 - `npm run release:sync-check` OK con aviso: `origin/release/0.1.0-beta.19` no existe.
-- Pendiente: smoke visual autenticado, incluyendo `/contractors`, y verificación remota Supabase.
+- `npm run verify:pr -- --base origin/main` OK.
+- Supabase remoto verificado: tabla, columnas, RLS, policy y backfill.
+- Smoke manual autenticado confirmado por usuario, incluyendo `/contractors`, `/work` y herencia de contratante desde proyecto hacia evento.
 
 ## Memoria
 

--- a/docs/project/issues/CACH-B0004.md
+++ b/docs/project/issues/CACH-B0004.md
@@ -88,6 +88,8 @@ Quedan fuera de beta 19: facturas emitidas, liquidación neta gasto-ingreso, CRM
 
 2026-05-13: Se activa `RELEASE-0.1.0-beta.19` como primer corte de la iniciativa, limitado a contratantes estructurados y compatibilidad con `client` legacy.
 
+2026-05-13: Implementación local de beta 19 preparada: schema/RLS local, hook, portabilidad y UX mínima de contratantes. Quedan pendientes verificación remota Supabase y smoke autenticado antes de considerar la release production-ready.
+
 ## Cambios de alcance y decisiones
 
 Beta 19 no implementa liquidación neta ni facturación completa. Es una base de datos/UX para contratantes reutilizables.
@@ -97,7 +99,10 @@ Beta 19 no implementa liquidación neta ni facturación completa. Es una base de
 
 ## Validación ejecutada
 
-Pendiente hasta ejecutar la issue.
+- `npm run lint` OK.
+- `npm run test` OK.
+- `npm run build` OK.
+- Verificación remota Supabase pendiente.
 
 ## Memoria
 

--- a/docs/project/issues/CACH-B0004.md
+++ b/docs/project/issues/CACH-B0004.md
@@ -5,7 +5,7 @@ id: CACH-B0004
 title: Contratantes facturacion y liquidacion neta
 lifecycle: active
 created: '2026-05-04'
-updated: '2026-05-08'
+updated: '2026-05-13'
 aliases:
   - CACH-B0004
 tags:
@@ -53,6 +53,18 @@ El modelo actual cubre ingresos/gastos por proyecto o evento, pero no expresa bi
 - Asociar gastos a ingresos para calcular cobro neto real.
 - Tratar CRM ligero y cooperativa como spikes estratégicos antes de modelo multiusuario.
 
+## Slicing beta
+
+`RELEASE-0.1.0-beta.19` abre esta iniciativa con el slice seguro de contratantes estructurados:
+
+- [[CACH-0057|CACH-0057]] — Definir modelo mínimo de contratantes.
+- [[CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS.
+- [[CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes.
+- [[CACH-0060|CACH-0060]] — Añadir UX mínima de contratantes en proyectos y eventos.
+- [[CACH-0061|CACH-0061]] — Verificar regresión financiera y cierre técnico beta 19.
+
+Quedan fuera de beta 19: facturas emitidas, liquidación neta gasto-ingreso, CRM ligero, colaboración multiusuario y cambios de fórmulas financieras.
+
 ## Acceptance Criteria
 
 - [ ] El diseño de datos diferencia cliente/contratante de texto libre.
@@ -74,9 +86,11 @@ El modelo actual cubre ingresos/gastos por proyecto o evento, pero no expresa bi
 
 ## Notas de progreso
 
+2026-05-13: Se activa `RELEASE-0.1.0-beta.19` como primer corte de la iniciativa, limitado a contratantes estructurados y compatibilidad con `client` legacy.
 
 ## Cambios de alcance y decisiones
 
+Beta 19 no implementa liquidación neta ni facturación completa. Es una base de datos/UX para contratantes reutilizables.
 
 ## Bloqueos
 

--- a/docs/project/plans/CURRENT_PLAN.md
+++ b/docs/project/plans/CURRENT_PLAN.md
@@ -18,11 +18,11 @@ generated: false
 
 ## Foco actual
 
-Beta 18 queda cerrada con notas contextuales, pulido financiero movil y calendarios separados más claros. No hay release activa.
+Beta 19 está activa para introducir contratantes estructurados como primer slice de `CACH-B0004`, manteniendo fuera liquidación neta, facturación completa, CRM y cambios de fórmulas financieras.
 
 ## Release activa
 
-No hay release activa.
+[[../releases/RELEASE-0.1.0-beta.19|RELEASE-0.1.0-beta.19]] — Contratantes estructurados.
 
 Últimos cortes:
 
@@ -45,13 +45,14 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 - Beta 16 cierra `CACH-0042`: racionalizar navegacion inferior movil.
 - Beta 17 cierra `CACH-0052`: feedback simple propio en Supabase y PostHog diferido.
 - Beta 18 cierra `CACH-0054`, `CACH-0055` y `CACH-0056`: notas contextuales, quick forms financieros y calendario de eventos separado del plan anual.
+- Beta 19 queda activa como primer corte de `CACH-B0004`: contratantes estructurados, schema/RLS, hooks, portabilidad, UX mínima y regresión financiera.
 
 ## Prioridades
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
 2. Mantener el feedback beta simple antes de introducir analitica de producto.
 3. No introducir PostHog, Plausible ni analitica de eventos sin issue/ADR posterior.
-4. No abrir contratantes, facturacion, liquidacion neta, migraciones, RLS ni cambios de formulas financieras sin release nueva.
+4. Durante beta 19, permitir contratantes estructurados, migraciones/RLS y portabilidad necesarias; mantener fuera liquidacion neta, facturacion completa y cambios de formulas financieras.
 
 ## Plan operativo
 
@@ -64,8 +65,8 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 
 ## Próximo checkpoint
 
-Elegir siguiente corte. Candidato principal: `CACH-B0004` como release de datos separada para contratantes, facturacion y liquidacion neta.
+Ejecutar beta 19 por slices: modelo mínimo, schema/RLS, hooks/portabilidad, UX mínima y regresión financiera.
 
 ## Siguiente release candidata
 
-Tras beta 18, evaluar `CACH-B0004` como release de datos separada para contratantes, facturacion y liquidacion neta.
+Tras beta 19, evaluar `CACH-B0004` beta 20 para liquidación neta gasto-ingreso o decidir si conviene una release de hardening antes de abrir facturación completa.

--- a/docs/project/plans/CURRENT_PLAN.md
+++ b/docs/project/plans/CURRENT_PLAN.md
@@ -18,11 +18,11 @@ generated: false
 
 ## Foco actual
 
-Beta 19 está activa para introducir contratantes estructurados como primer slice de `CACH-B0004`, manteniendo fuera liquidación neta, facturación completa, CRM y cambios de fórmulas financieras.
+Beta 19 queda cerrada como primer slice de `CACH-B0004`: contratantes estructurados, schema/RLS, hooks, portabilidad, UX mínima y regresión financiera sin cambios de fórmula. El siguiente foco queda pendiente de elegir entre hardening o abrir liquidación neta con criterios de datos/RLS.
 
 ## Release activa
 
-[[../releases/RELEASE-0.1.0-beta.19|RELEASE-0.1.0-beta.19]] — Contratantes estructurados.
+No hay release activa ahora mismo.
 
 Últimos cortes:
 
@@ -45,14 +45,14 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 - Beta 16 cierra `CACH-0042`: racionalizar navegacion inferior movil.
 - Beta 17 cierra `CACH-0052`: feedback simple propio en Supabase y PostHog diferido.
 - Beta 18 cierra `CACH-0054`, `CACH-0055` y `CACH-0056`: notas contextuales, quick forms financieros y calendario de eventos separado del plan anual.
-- Beta 19 queda activa como primer corte de `CACH-B0004`: contratantes estructurados, schema/RLS, hooks, portabilidad, UX mínima y regresión financiera.
+- Beta 19 cierra el primer corte de `CACH-B0004`: contratantes estructurados, schema/RLS, hooks, portabilidad, UX mínima y regresión financiera.
 
 ## Prioridades
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
 2. Mantener el feedback beta simple antes de introducir analitica de producto.
 3. No introducir PostHog, Plausible ni analitica de eventos sin issue/ADR posterior.
-4. Durante beta 19, permitir contratantes estructurados, migraciones/RLS y portabilidad necesarias; mantener fuera liquidacion neta, facturacion completa y cambios de formulas financieras.
+4. Antes de abrir beta 20, decidir si toca hardening o liquidacion neta; en ambos casos mantener fuera facturacion completa y CRM salvo issue nueva con criterios de datos/RLS.
 
 ## Plan operativo
 
@@ -65,7 +65,7 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 
 ## Próximo checkpoint
 
-Ejecutar beta 19 por slices: modelo mínimo, schema/RLS, hooks/portabilidad, UX mínima y regresión financiera.
+Cerrar beta 19 en `main`, etiquetar `v0.1.0-beta.19`, verificar producción y decidir el próximo corte.
 
 ## Siguiente release candidata
 

--- a/docs/project/process/supabase-db-access.md
+++ b/docs/project/process/supabase-db-access.md
@@ -66,9 +66,16 @@ rollback;
 - Todo cambio de schema, trigger, policy o RPC debe vivir primero en `supabase/migrations/`.
 - Antes de aplicar en producción, el agente debe mostrar el SQL exacto y esperar confirmación explícita.
 - Aplicar con MCP `apply_migration` cuando esté disponible; si no, pegar la migración completa en SQL Editor.
+- Si una migración se aplica a mano en SQL Editor, reparar después el historial remoto para evitar drift futuro con Supabase CLI:
+
+```bash
+npx supabase migration repair <version> --status applied --linked
+npx supabase migration list --linked
+```
+
 - Si una feature o release depende de una tabla, policy, trigger o RPC nueva, no marcarla como verificada en producción hasta confirmar el remoto con SQL read-only y smoke real o transaccional con `rollback`.
 - Si la migración remota queda pendiente, la release puede estar code-complete, pero la funcionalidad afectada no está released funcionalmente; documentarlo como pendiente o bloqueante.
-- Después de cambiar RPCs, ejecutar:
+- Después de cambiar RPCs o schema consumido por PostgREST, ejecutar:
 
 ```sql
 notify pgrst, 'reload schema';

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -13,13 +13,13 @@ tags:
   - release
   - current
 generated: false
-release_current: true
+release_current: false
 ---
 # Current Release
 
 ## Release activa
 
-[[RELEASE-0.1.0-beta.19|RELEASE-0.1.0-beta.19]] — Contratantes estructurados.
+No hay release activa ahora mismo.
 
 ## Rama activa
 
@@ -43,9 +43,11 @@ release_current: true
 
 `RELEASE-0.1.0-beta.18` — cierre P1 UX core. Ver [[RELEASE-0.1.0-beta.18]].
 
+`RELEASE-0.1.0-beta.19` — contratantes estructurados. Ver [[RELEASE-0.1.0-beta.19]].
+
 ## Scope actual
 
-Beta 19 abre `CACH-B0004` por el slice seguro de contratantes estructurados. El objetivo es introducir contratantes reutilizables para proyectos y eventos sin cambiar fórmulas financieras ni implementar facturación completa.
+Pendiente de seleccionar. Beta 19 queda cerrada como primer slice seguro de `CACH-B0004`; el siguiente corte candidato puede ser liquidación neta gasto-ingreso o una release de hardening antes de abrir facturación completa.
 
 Issues incluidas:
 
@@ -55,10 +57,10 @@ Issues incluidas:
 - [[../issues/CACH-0060|CACH-0060]] — Añadir UX mínima de contratantes en proyectos y eventos.
 - [[../issues/CACH-0061|CACH-0061]] — Verificar regresión financiera y cierre técnico beta 19.
 
-## Regla de trabajo para esta release
+## Regla de trabajo para la próxima release
 
-Solo entran cambios necesarios para contratantes estructurados y su verificación. Liquidación neta, facturas, CRM, multiusuario, PWA, notificaciones, features Pro y cambios de fórmulas financieras quedan fuera.
+Definir primero el scope en un documento de release y asociar issues `CACH-*` antes de crear rama. No abrir liquidación neta, facturación completa o CRM sin criterios de aceptación y validación de datos/RLS.
 
 ## Como cerrar esta release
 
-Cerrar mediante PR única `release/0.1.0-beta.19` -> `main`, CI verde, `pb:guard`, `release:sync-check`, verificación remota Supabase cuando aplique, tag `v0.1.0-beta.19` y smoke de producción sobre `https://app.caches.es` tras merge.
+Beta 19 se cierra mediante PR única `release/0.1.0-beta.19` -> `main`, CI verde, `pb:guard`, `release:sync-check`, verificación remota Supabase, tag `v0.1.0-beta.19` y smoke de producción sobre `https://app.caches.es` tras merge.

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -13,17 +13,17 @@ tags:
   - release
   - current
 generated: false
-release_current: false
+release_current: true
 ---
 # Current Release
 
 ## Release activa
 
-No hay release activa.
+[[RELEASE-0.1.0-beta.19|RELEASE-0.1.0-beta.19]] — Contratantes estructurados.
 
 ## Rama activa
 
-No aplica.
+`release/0.1.0-beta.19`
 
 ## Últimos cortes
 
@@ -45,18 +45,20 @@ No aplica.
 
 ## Scope actual
 
-Beta 18 queda cerrada. La app incorpora notas contextuales editables, quick forms financieros más ergonómicos y mantiene calendario de eventos separado del plan anual de proyectos.
+Beta 19 abre `CACH-B0004` por el slice seguro de contratantes estructurados. El objetivo es introducir contratantes reutilizables para proyectos y eventos sin cambiar fórmulas financieras ni implementar facturación completa.
 
 Issues incluidas:
 
-- [[../issues/CACH-0054|CACH-0054]] — Editar notas desde detalles de proyecto y evento.
-- [[../issues/CACH-0055|CACH-0055]] — Pulido financiero movil sin cambiar formulas.
-- [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados.
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo mínimo de contratantes.
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS.
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes.
+- [[../issues/CACH-0060|CACH-0060]] — Añadir UX mínima de contratantes en proyectos y eventos.
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresión financiera y cierre técnico beta 19.
 
 ## Regla de trabajo para esta release
 
-No iniciar trabajo nuevo desde una release activa hasta activar explicitamente el siguiente corte.
+Solo entran cambios necesarios para contratantes estructurados y su verificación. Liquidación neta, facturas, CRM, multiusuario, PWA, notificaciones, features Pro y cambios de fórmulas financieras quedan fuera.
 
 ## Como cerrar esta release
 
-Cerrada mediante PR #104. Tag `v0.1.0-beta.18` y smoke de produccion sobre `https://app.caches.es` tras merge a `main`.
+Cerrar mediante PR única `release/0.1.0-beta.19` -> `main`, CI verde, `pb:guard`, `release:sync-check`, verificación remota Supabase cuando aplique, tag `v0.1.0-beta.19` y smoke de producción sobre `https://app.caches.es` tras merge.

--- a/docs/project/releases/RELEASE-0.1.0-beta.19.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.19.md
@@ -1,0 +1,160 @@
+---
+schema_version: 2
+kind: release
+id: RELEASE-0.1.0-beta.19
+title: Contratantes estructurados
+lifecycle: active
+created: '2026-05-13'
+updated: '2026-05-13'
+aliases:
+  - RELEASE-0.1.0-beta.19
+tags:
+  - product-brain
+  - release
+  - beta
+  - finance
+  - data
+generated: false
+release_phase: active
+release_current: true
+release_branch: release/0.1.0-beta.19
+release_tag: null
+release_pr: null
+---
+# RELEASE-0.1.0-beta.19 — Contratantes estructurados
+
+## Estado
+
+Active.
+
+## Rama de release
+
+`release/0.1.0-beta.19`
+
+## Ciclo
+
+`0.1` es el ciclo organizativo. `0.1.0-beta.19` es un corte mergeable para abrir `CACH-B0004` por el slice seguro de contratantes estructurados.
+
+## Objetivo de la release
+
+Crear la base de datos, contrato técnico y UX mínima para que proyectos y eventos puedan usar un contratante reutilizable, sin romper el campo `client` actual ni cambiar fórmulas financieras.
+
+## Alcance funcional
+
+- Decidir el modelo mínimo de contratante y documentar el límite entre contratante, facturación y CRM.
+- Versionar schema, RLS y backfill para `contractors` con compatibilidad hacia `client`.
+- Añadir hooks y portabilidad para contratantes.
+- Permitir elegir o crear contratante desde formularios de proyecto y evento.
+- Mostrar el contratante de forma limpia en listados, detalles, calendario y trabajos.
+- Verificar que dashboard, detalles, cobros y `cobro bruto/hora` no cambian de fórmula.
+
+## Scope
+
+- [[../issues/CACH-0057|CACH-0057]] — Definir modelo mínimo de contratantes.
+- [[../issues/CACH-0058|CACH-0058]] — Versionar schema de contratantes y RLS.
+- [[../issues/CACH-0059|CACH-0059]] — Integrar hooks y portabilidad de contratantes.
+- [[../issues/CACH-0060|CACH-0060]] — Añadir UX mínima de contratantes en proyectos y eventos.
+- [[../issues/CACH-0061|CACH-0061]] — Verificar regresión financiera y cierre técnico beta 19.
+
+## Issues incluidas
+
+| Issue | Titulo | Workflow | Rama |
+|---|---|---|---|
+| [[../issues/CACH-0057|CACH-0057]] | Definir modelo mínimo de contratantes | ready | `release/0.1.0-beta.19` |
+| [[../issues/CACH-0058|CACH-0058]] | Versionar schema de contratantes y RLS | ready | `release/0.1.0-beta.19` |
+| [[../issues/CACH-0059|CACH-0059]] | Integrar hooks y portabilidad de contratantes | ready | `release/0.1.0-beta.19` |
+| [[../issues/CACH-0060|CACH-0060]] | Añadir UX mínima de contratantes en proyectos y eventos | ready | `release/0.1.0-beta.19` |
+| [[../issues/CACH-0061|CACH-0061]] | Verificar regresión financiera y cierre técnico beta 19 | ready | `release/0.1.0-beta.19` |
+
+## Fuera de alcance
+
+- Facturas emitidas, numeración, PDF, presupuestos, albaranes o fiscalidad completa.
+- Liquidación neta que vincule gasto repercutible con ingreso concreto.
+- CRM ligero, contactos múltiples, pipeline comercial o colaboración multiusuario.
+- Unificar ingresos/gastos a nivel proyecto.
+- Cambiar `cobro bruto/hora`, KPIs, dashboard finance helpers o reglas de IRPF.
+- Mutar Supabase producción sin mostrar SQL exacto y recibir confirmación explícita.
+
+## Riesgos
+
+- La migración remota de Supabase es funcionalmente bloqueante: una release con schema pendiente puede estar code-complete, pero no production-ready.
+- El backfill desde `client` debe deduplicar por usuario y texto normalizado sin perder el texto libre existente.
+- La UX debe evitar convertirse en un CRM pesado; el objetivo es reutilizar contratantes, no gestionar ventas.
+- Portabilidad debe conservar datasets anteriores y no exponer `user_id`.
+- Cualquier cambio accidental en fórmulas financieras debe bloquear el cierre.
+
+## Decisiones relacionadas
+
+- [[../issues/CACH-B0004|CACH-B0004]] — Contratantes, facturación y liquidación neta.
+- [[../context/data-finance-model-20260504|data-finance-model-20260504]]
+- [[../decisions/ADR-0001-project-event-finance-model|ADR-0001]]
+- [[../decisions/ADR-0006-gross-cache-per-hour|ADR-0006]]
+- [[../process/supabase-db-access|Supabase DB Access]]
+
+## Checklist de entrada
+
+- [x] Release creada
+- [x] Rama de release creada localmente
+- [x] Issues asociadas
+- [x] Alcance definido
+- [x] Criterios de validacion definidos
+
+## Checklist de desarrollo
+
+- [ ] Todas las issues estan en progreso o cerradas
+- [ ] Commits integrados en rama release
+- [ ] No hay cambios sueltos fuera de release
+- [ ] No hay issues sin `issue_workflow`
+- [ ] No hay decisiones importantes sin documentar
+
+## Checklist de estabilizacion
+
+- [ ] `npm run lint`
+- [ ] `npm run test`
+- [ ] `npm run build`
+- [ ] `npm run pb:guard`
+- [ ] `npm run release:sync-check`
+- [ ] Smoke proyecto/evento/listados/dashboard/exportacion
+- [ ] Verificacion remota Supabase o bloqueo documentado
+- [ ] Regresion financiera confirmada sin cambios de formulas
+
+## Checklist de salida
+
+- [ ] PR `release/0.1.0-beta.19` -> `main` abierta
+- [ ] CI en verde
+- [ ] PR mergeada en `main`
+- [ ] Tag creado desde `main` si aplica
+- [ ] Produccion verificada o marcada como pendiente por migracion remota
+- [ ] Rama remota `release/0.1.0-beta.19` eliminada si aplica
+- [ ] Release notes actualizadas
+- [ ] Issues marcadas como `done`
+- [ ] Estado actual actualizado
+- [ ] Current Release actualizado
+- [ ] Backlog actualizado
+- [ ] Proximos pasos documentados
+
+## Release notes
+
+### Aniadido
+
+- Pendiente.
+
+### Cambiado
+
+- Pendiente.
+
+### Corregido
+
+- Pendiente.
+
+### Eliminado
+
+- No aplica por ahora.
+
+### Tecnico
+
+- Pendiente.
+
+## Resultado final
+
+Pendiente hasta cerrar la release.

--- a/docs/project/releases/RELEASE-0.1.0-beta.19.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.19.md
@@ -19,7 +19,7 @@ release_phase: released
 release_current: false
 release_branch: release/0.1.0-beta.19
 release_tag: v0.1.0-beta.19
-release_pr: null
+release_pr: https://github.com/dignacioconde/culturApp/pull/105
 ---
 # RELEASE-0.1.0-beta.19 — Contratantes estructurados
 

--- a/docs/project/releases/RELEASE-0.1.0-beta.19.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.19.md
@@ -15,17 +15,17 @@ tags:
   - finance
   - data
 generated: false
-release_phase: active
-release_current: true
+release_phase: released
+release_current: false
 release_branch: release/0.1.0-beta.19
-release_tag: null
+release_tag: v0.1.0-beta.19
 release_pr: null
 ---
 # RELEASE-0.1.0-beta.19 — Contratantes estructurados
 
 ## Estado
 
-Active.
+Released.
 
 ## Rama de release
 
@@ -60,11 +60,11 @@ Crear la base de datos, contrato técnico y UX mínima para que proyectos y even
 
 | Issue | Titulo | Workflow | Rama |
 |---|---|---|---|
-| [[../issues/CACH-0057|CACH-0057]] | Definir modelo mínimo de contratantes | ready | `release/0.1.0-beta.19` |
-| [[../issues/CACH-0058|CACH-0058]] | Versionar schema de contratantes y RLS | ready | `release/0.1.0-beta.19` |
-| [[../issues/CACH-0059|CACH-0059]] | Integrar hooks y portabilidad de contratantes | ready | `release/0.1.0-beta.19` |
-| [[../issues/CACH-0060|CACH-0060]] | Añadir UX mínima de contratantes en proyectos y eventos | ready | `release/0.1.0-beta.19` |
-| [[../issues/CACH-0061|CACH-0061]] | Verificar regresión financiera y cierre técnico beta 19 | ready | `release/0.1.0-beta.19` |
+| [[../issues/CACH-0057|CACH-0057]] | Definir modelo mínimo de contratantes | done | `release/0.1.0-beta.19` |
+| [[../issues/CACH-0058|CACH-0058]] | Versionar schema de contratantes y RLS | done | `release/0.1.0-beta.19` |
+| [[../issues/CACH-0059|CACH-0059]] | Integrar hooks y portabilidad de contratantes | done | `release/0.1.0-beta.19` |
+| [[../issues/CACH-0060|CACH-0060]] | Añadir UX mínima de contratantes en proyectos y eventos | done | `release/0.1.0-beta.19` |
+| [[../issues/CACH-0061|CACH-0061]] | Verificar regresión financiera y cierre técnico beta 19 | done | `release/0.1.0-beta.19` |
 
 ## Fuera de alcance
 
@@ -101,37 +101,37 @@ Crear la base de datos, contrato técnico y UX mínima para que proyectos y even
 
 ## Checklist de desarrollo
 
-- [x] Todas las issues estan en progreso o review
-- [ ] Commits integrados en rama release
-- [ ] No hay cambios sueltos fuera de release
-- [ ] No hay issues sin `issue_workflow`
-- [ ] No hay decisiones importantes sin documentar
+- [x] Todas las issues estan cerradas o listas para release
+- [x] Commits integrados en rama release
+- [x] No hay cambios sueltos fuera de release
+- [x] No hay issues sin `issue_workflow`
+- [x] No hay decisiones importantes sin documentar
 
 ## Checklist de estabilizacion
 
-- [ ] `npm run lint`
-- [ ] `npm run test`
-- [ ] `npm run build`
-- [ ] `npm run pb:guard`
-- [ ] `npm run release:sync-check`
-- [ ] Smoke proyecto/evento/listados/dashboard/exportacion
-- [ ] Verificacion remota Supabase o bloqueo documentado
-- [ ] Regresion financiera confirmada sin cambios de formulas
+- [x] `npm run lint`
+- [x] `npm run test`
+- [x] `npm run build`
+- [x] `npm run pb:guard`
+- [x] `npm run release:sync-check`
+- [x] Smoke proyecto/evento/listados/dashboard/exportacion
+- [x] Verificacion remota Supabase o bloqueo documentado
+- [x] Regresion financiera confirmada sin cambios de formulas
 
 ## Checklist de salida
 
-- [ ] PR `release/0.1.0-beta.19` -> `main` abierta
-- [ ] CI en verde
-- [ ] PR mergeada en `main`
-- [ ] Tag creado desde `main` si aplica
-- [ ] Produccion verificada o marcada como pendiente por migracion remota
-- [ ] Rama remota `release/0.1.0-beta.19` eliminada si aplica
-- [ ] Release notes actualizadas
-- [ ] Issues marcadas como `done`
-- [ ] Estado actual actualizado
-- [ ] Current Release actualizado
-- [ ] Backlog actualizado
-- [ ] Proximos pasos documentados
+- [x] PR `release/0.1.0-beta.19` -> `main` abierta
+- [x] CI en verde
+- [x] PR mergeada en `main`
+- [x] Tag creado desde `main` si aplica
+- [x] Produccion verificada o marcada como pendiente por migracion remota
+- [x] Rama remota `release/0.1.0-beta.19` eliminada si aplica
+- [x] Release notes actualizadas
+- [x] Issues marcadas como `done`
+- [x] Estado actual actualizado
+- [x] Current Release actualizado
+- [x] Backlog actualizado
+- [x] Proximos pasos documentados
 
 ## Release notes
 
@@ -150,7 +150,7 @@ Crear la base de datos, contrato técnico y UX mínima para que proyectos y even
 
 ### Corregido
 
-- Pendiente.
+- La app ya no muestra errores genéricos de carga en trabajos/contratantes cuando el schema de contratantes está pendiente: se informa el estado de migración de forma específica.
 
 ### Eliminado
 
@@ -159,9 +159,10 @@ Crear la base de datos, contrato técnico y UX mínima para que proyectos y even
 ### Tecnico
 
 - Migración local `supabase/migrations/20260513120000_contractors.sql`.
-- Validación local inicial: `npm run lint`, `npm run test`, `npm run build`.
-- Pendiente antes de release funcional: aplicar/verificar migración remota Supabase y smoke autenticado.
+- Validación local completada: `npm run lint`, `npm run test`, `npm run build`, `npm run pb:guard`, `npm run release:sync-check` y `npm run verify:pr -- --base origin/main`.
+- Migración remota Supabase aplicada, verificada con SQL read-only y sincronizada en historial con `migration repair`.
+- Smoke manual autenticado confirmado por usuario: `/work`, `/contractors` y herencia de contratante desde proyecto hacia evento.
 
 ## Resultado final
 
-Pendiente hasta cerrar la release.
+Release cerrada mediante PR final a `main`. Tag `v0.1.0-beta.19` preparado desde `main`; produccion verificada en `https://app.caches.es` con smoke de rutas SPA.

--- a/docs/project/releases/RELEASE-0.1.0-beta.19.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.19.md
@@ -101,7 +101,7 @@ Crear la base de datos, contrato técnico y UX mínima para que proyectos y even
 
 ## Checklist de desarrollo
 
-- [ ] Todas las issues estan en progreso o cerradas
+- [x] Todas las issues estan en progreso o review
 - [ ] Commits integrados en rama release
 - [ ] No hay cambios sueltos fuera de release
 - [ ] No hay issues sin `issue_workflow`
@@ -137,11 +137,16 @@ Crear la base de datos, contrato técnico y UX mínima para que proyectos y even
 
 ### Aniadido
 
-- Pendiente.
+- Tabla `contractors` con RLS por usuario y backfill desde `client`.
+- `contractor_id` opcional en proyectos y eventos.
+- Herencia persistida de `project.contractor_id` hacia eventos vinculados cuando no tienen contratante propio.
+- Hook `useContractors`, selector de contratante y creación inline desde formularios de proyecto/evento.
+- Ruta `/contractors` para gestionar contratantes como entidad ligera.
+- Exportación/importación de contratantes con compatibilidad CSV legacy.
 
 ### Cambiado
 
-- Pendiente.
+- Proyectos, eventos, calendarios y `/work` muestran contratante estructurado, heredado o `client` legacy sin duplicar texto.
 
 ### Corregido
 
@@ -153,7 +158,9 @@ Crear la base de datos, contrato técnico y UX mínima para que proyectos y even
 
 ### Tecnico
 
-- Pendiente.
+- Migración local `supabase/migrations/20260513120000_contractors.sql`.
+- Validación local inicial: `npm run lint`, `npm run test`, `npm run build`.
+- Pendiente antes de release funcional: aplicar/verificar migración remota Supabase y smoke autenticado.
 
 ## Resultado final
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import EventList from './pages/Events/EventList'
 import EventDetail from './pages/Events/EventDetail'
 import ProjectList from './pages/Projects/ProjectList'
 import ProjectDetail from './pages/Projects/ProjectDetail'
+import ContractorList from './pages/Contractors/ContractorList'
 import Work from './pages/Work/Work'
 import Settings from './pages/Settings/Settings'
 import Data from './pages/Data/Data'
@@ -102,6 +103,7 @@ export default function App() {
         <Route path="/events/:id" element={<PrivateRoute><EventDetail /></PrivateRoute>} />
         <Route path="/projects" element={<PrivateRoute><ProjectList /></PrivateRoute>} />
         <Route path="/projects/:id" element={<PrivateRoute><ProjectDetail /></PrivateRoute>} />
+        <Route path="/contractors" element={<PrivateRoute><ContractorList /></PrivateRoute>} />
         <Route path="/work" element={<PrivateRoute><Work /></PrivateRoute>} />
         <Route path="/settings" element={<PrivateRoute><Settings /></PrivateRoute>} />
         <Route path="/data" element={<PrivateRoute><Data /></PrivateRoute>} />

--- a/src/components/contractors/ContractorSelector.jsx
+++ b/src/components/contractors/ContractorSelector.jsx
@@ -1,0 +1,57 @@
+import { Input, Select } from '../ui/Input'
+
+export const NEW_CONTRACTOR_VALUE = '__new_contractor__'
+
+export function ContractorSelector({
+  contractors = [],
+  value = '',
+  newName = '',
+  clientValue = '',
+  inheritedLabel = '',
+  onChange,
+  onNewNameChange,
+  onClientChange,
+  label = 'Contratante',
+}) {
+  const selectedValue = value ?? ''
+  const showNewContractor = selectedValue === NEW_CONTRACTOR_VALUE
+  const showClientFallback = selectedValue === ''
+
+  return (
+    <div className="grid gap-3">
+      <Select
+        label={label}
+        name="contractor_id"
+        value={selectedValue}
+        onChange={onChange}
+      >
+        <option value="">{inheritedLabel || 'Sin contratante guardado'}</option>
+        <option value={NEW_CONTRACTOR_VALUE}>Crear contratante...</option>
+        {contractors.map((contractor) => (
+          <option key={contractor.id} value={contractor.id}>{contractor.name}</option>
+        ))}
+      </Select>
+
+      {showNewContractor && (
+        <Input
+          label="Nombre del contratante *"
+          name="new_contractor_name"
+          value={newName}
+          onChange={onNewNameChange}
+          placeholder="Ayuntamiento de Madrid"
+          required
+        />
+      )}
+
+      {showClientFallback && (
+        <Input
+          label="Cliente o contratante"
+          name="client"
+          value={clientValue}
+          onChange={onClientChange}
+          placeholder="Ayuntamiento de Madrid"
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/layout/BottomNavigation.jsx
+++ b/src/components/layout/BottomNavigation.jsx
@@ -3,6 +3,7 @@ import { isNavigationItemActive, navItems, shouldShowBottomNavigation } from './
 
 export function BottomNavigation() {
   const location = useLocation()
+  const mobileNavItems = navItems.filter((item) => item.showOnMobile !== false)
 
   if (!shouldShowBottomNavigation(location.pathname)) return null
 
@@ -11,8 +12,8 @@ export function BottomNavigation() {
       aria-label="Navegación principal móvil"
       className="fixed inset-x-0 bottom-0 z-40 border-t border-[#E2D9C2] bg-[#FFFCF5]/95 px-1.5 pt-1.5 pb-[calc(0.5rem+env(safe-area-inset-bottom))] shadow-[0_-6px_18px_rgba(33,28,24,0.08)] backdrop-blur lg:hidden"
     >
-      <div className="grid grid-cols-6 gap-0.5">
-        {navItems.map((item) => (
+      <div className="grid gap-0.5" style={{ gridTemplateColumns: `repeat(${mobileNavItems.length}, minmax(0, 1fr))` }}>
+        {mobileNavItems.map((item) => (
           <NavLink
             key={item.to}
             to={item.to}

--- a/src/components/layout/navigation.js
+++ b/src/components/layout/navigation.js
@@ -1,7 +1,8 @@
-import { Database, LayoutDashboard, CalendarDays, CalendarRange, Briefcase, Settings } from 'lucide-react'
+import { Building2, Database, LayoutDashboard, CalendarDays, CalendarRange, Briefcase, Settings } from 'lucide-react'
 
 export const navItems = [
   { to: '/work', icon: Briefcase, label: 'Trabajos', mobileLabel: 'Trabajos', activePaths: ['/work', '/projects', '/events'] },
+  { to: '/contractors', icon: Building2, label: 'Contratantes', mobileLabel: 'Contr.', showOnMobile: false },
   { to: '/dashboard', icon: LayoutDashboard, label: 'Dashboard', mobileLabel: 'Inicio' },
   { to: '/calendar/events', icon: CalendarDays, label: 'Agenda', mobileLabel: 'Agenda', activePaths: ['/calendar', '/calendar/events'] },
   { to: '/calendar/projects', icon: CalendarRange, label: 'Plan anual', mobileLabel: 'Plan' },

--- a/src/hooks/useContractors.js
+++ b/src/hooks/useContractors.js
@@ -1,0 +1,151 @@
+import { useState, useEffect, useCallback } from 'react'
+import { supabase } from '../supabaseClient'
+import { normalizeContractorName } from '../lib/contractors'
+
+const CONTRACTOR_SELECT = 'id,user_id,name,billing_name,tax_id,email,phone,billing_address,notes,created_at'
+
+export function isContractorsSchemaMissing(error) {
+  const message = `${error?.message ?? ''} ${error?.details ?? ''}`.toLowerCase()
+  return error?.code === '42P01' ||
+    error?.code === '42703' ||
+    error?.code === 'PGRST204' ||
+    error?.code === 'PGRST205' ||
+    message.includes('contractors') && (
+      message.includes('does not exist') ||
+      message.includes('schema cache') ||
+      message.includes('could not find')
+    )
+}
+
+function portabilityError(message) {
+  return { message }
+}
+
+function cleanText(value) {
+  const trimmed = String(value ?? '').trim()
+  return trimmed === '' ? null : trimmed
+}
+
+function sanitizeContractorData(contractorData) {
+  const rest = { ...(contractorData ?? {}) }
+  delete rest.user_id
+  delete rest.id
+  delete rest.created_at
+
+  return {
+    name: String(rest.name ?? '').trim(),
+    billing_name: cleanText(rest.billing_name),
+    tax_id: cleanText(rest.tax_id),
+    email: cleanText(rest.email),
+    phone: cleanText(rest.phone),
+    billing_address: cleanText(rest.billing_address),
+    notes: cleanText(rest.notes),
+  }
+}
+
+function sortContractors(rows = []) {
+  return [...rows].sort((a, b) => a.name.localeCompare(b.name, 'es', { sensitivity: 'base' }))
+}
+
+export function useContractors(userId) {
+  const [contractors, setContractors] = useState([])
+  const [loading, setLoading] = useState(Boolean(userId))
+  const [error, setError] = useState(null)
+
+  const fetchContractors = useCallback(async () => {
+    if (!userId) {
+      setContractors([])
+      setLoading(false)
+      return { data: [], error: null }
+    }
+
+    setLoading(true)
+    const { data, error } = await supabase
+      .from('contractors')
+      .select(CONTRACTOR_SELECT)
+      .eq('user_id', userId)
+      .order('name', { ascending: true })
+
+    if (error) {
+      setError(error)
+      setLoading(false)
+      return { data: null, error }
+    }
+
+    const nextContractors = sortContractors(data ?? [])
+    setContractors(nextContractors)
+    setError(null)
+    setLoading(false)
+    return { data: nextContractors, error: null }
+  }, [userId])
+
+  useEffect(() => {
+    queueMicrotask(fetchContractors)
+  }, [fetchContractors])
+
+  const createContractor = async (contractorData) => {
+    if (!userId) return { data: null, error: portabilityError('Necesitas una sesión activa.') }
+
+    const payload = sanitizeContractorData(contractorData)
+    if (!payload.name) return { data: null, error: portabilityError('Pon un nombre para el contratante.') }
+
+    const { data, error } = await supabase
+      .from('contractors')
+      .insert({ ...payload, user_id: userId })
+      .select(CONTRACTOR_SELECT)
+      .single()
+
+    if (!error) setContractors((prev) => sortContractors([...prev, data]))
+    return { data, error }
+  }
+
+  const updateContractor = async (id, contractorData) => {
+    const payload = sanitizeContractorData(contractorData)
+    if (!payload.name) return { data: null, error: portabilityError('Pon un nombre para el contratante.') }
+
+    const { data, error } = await supabase
+      .from('contractors')
+      .update(payload)
+      .eq('id', id)
+      .select(CONTRACTOR_SELECT)
+      .single()
+
+    if (!error) setContractors((prev) => sortContractors(prev.map((contractor) => (contractor.id === id ? data : contractor))))
+    return { data, error }
+  }
+
+  const deleteContractor = async (id) => {
+    const { error } = await supabase.from('contractors').delete().eq('id', id)
+    if (!error) setContractors((prev) => prev.filter((contractor) => contractor.id !== id))
+    return { error }
+  }
+
+  const findOrCreateContractor = async (name) => {
+    const normalized = normalizeContractorName(name)
+    if (!normalized) return { data: null, error: portabilityError('Pon un nombre para el contratante.') }
+
+    const existing = contractors.find((contractor) => normalizeContractorName(contractor.name) === normalized)
+    if (existing) return { data: existing, error: null }
+
+    const created = await createContractor({ name })
+    if (!created.error) return created
+
+    if (created.error?.code !== '23505') return created
+
+    const fresh = await fetchContractors()
+    const duplicate = fresh.data?.find((contractor) => normalizeContractorName(contractor.name) === normalized)
+    return duplicate ? { data: duplicate, error: null } : created
+  }
+
+  return {
+    contractors,
+    loading,
+    error,
+    schemaReady: !isContractorsSchemaMissing(error),
+    createContractor,
+    updateContractor,
+    deleteContractor,
+    findOrCreateContractor,
+    refetch: fetchContractors,
+  }
+}

--- a/src/hooks/useDataPortability.js
+++ b/src/hooks/useDataPortability.js
@@ -7,30 +7,33 @@ import {
   hasImportErrors,
   validateCsvImport,
 } from '../lib/portability/index.ts'
+import { normalizeContractorName } from '../lib/contractors'
 
 function portabilityError(message) {
   return { message }
 }
 
 function emptyInserted() {
-  return { projects: 0, events: 0, incomes: 0, expenses: 0 }
+  return { contractors: 0, projects: 0, events: 0, incomes: 0, expenses: 0 }
 }
 
 export async function exportPortableData(client, userId) {
   if (!userId) return { data: null, error: portabilityError('Necesitas una sesión activa para exportar datos.') }
 
   try {
-    const [projectsResult, eventsResult, incomesResult, expensesResult] = await Promise.all([
+    const [contractorsResult, projectsResult, eventsResult, incomesResult, expensesResult] = await Promise.all([
+      client.from('contractors').select('*').eq('user_id', userId).order('name', { ascending: true }),
       client.from('projects').select('*').eq('user_id', userId).order('start_date', { ascending: true }),
       client.from('events').select('*').eq('user_id', userId).order('start_datetime', { ascending: true }),
       client.from('incomes').select('*').eq('user_id', userId).order('expected_date', { ascending: true }),
       client.from('expenses').select('*').eq('user_id', userId).order('expense_date', { ascending: true }),
     ])
 
-    const firstError = [projectsResult, eventsResult, incomesResult, expensesResult].find((result) => result.error)?.error
+    const firstError = [contractorsResult, projectsResult, eventsResult, incomesResult, expensesResult].find((result) => result.error)?.error
     if (firstError) return { data: null, error: firstError }
 
     const entities = {
+      contractors: contractorsResult.data ?? [],
       projects: projectsResult.data ?? [],
       events: eventsResult.data ?? [],
       incomes: incomesResult.data ?? [],
@@ -58,14 +61,91 @@ export async function commitPortableImport(client, userId, preview) {
 
   const inserted = emptyInserted()
   const failures = []
+  const contractorIds = new Map()
+  const contractorIdsByName = new Map()
   const projectIds = new Map()
+  const projectContractorIds = new Map()
   const eventIds = new Map()
 
   try {
+    const existingContractors = await client
+      .from('contractors')
+      .select('id,name')
+      .eq('user_id', userId)
+
+    if (existingContractors.error) {
+      return { data: { inserted, failures }, error: existingContractors.error }
+    }
+
+    for (const contractor of existingContractors.data ?? []) {
+      contractorIdsByName.set(normalizeContractorName(contractor.name), contractor.id)
+    }
+
+    const resolveContractorByName = async (name, row, entity = 'contractor') => {
+      const normalized = normalizeContractorName(name)
+      if (!normalized) return null
+      const existingId = contractorIdsByName.get(normalized)
+      if (existingId) return existingId
+
+      const { data, error } = await client
+        .from('contractors')
+        .insert({ name: String(name).trim(), user_id: userId })
+        .select('id,name')
+        .single()
+
+      if (error) {
+        failures.push({ row, entity, error })
+        return null
+      }
+
+      inserted.contractors += 1
+      contractorIdsByName.set(normalizeContractorName(data.name), data.id)
+      return data.id
+    }
+
+    const resolveContractorLink = async (link, row, entity) => {
+      if (!link) return null
+      if (link.type === 'key') {
+        const contractorId = contractorIds.get(link.value)
+        if (!contractorId) {
+          failures.push({ row, entity, error: portabilityError('No se ha podido resolver el contratante importado.') })
+          return null
+        }
+        return contractorId
+      }
+
+      return resolveContractorByName(link.value, row, entity)
+    }
+
+    for (const contractor of preview.contractors ?? []) {
+      const existingId = contractorIdsByName.get(normalizeContractorName(contractor.payload.name))
+      if (existingId) {
+        contractorIds.set(contractor.key, existingId)
+        continue
+      }
+
+      const { data, error } = await client
+        .from('contractors')
+        .insert({ ...contractor.payload, user_id: userId })
+        .select('id,name')
+        .single()
+
+      if (error) {
+        failures.push({ row: contractor.row, entity: 'contractor', error })
+      } else {
+        inserted.contractors += 1
+        contractorIds.set(contractor.key, data.id)
+        contractorIdsByName.set(normalizeContractorName(data.name), data.id)
+      }
+    }
+
     for (const project of preview.projects) {
+      const contractorId = await resolveContractorLink(project.contractor, project.row, 'project')
+      if (project.contractor && !contractorId) continue
+
       const { data, error } = await client
         .from('projects')
-        .insert({ ...project.payload, user_id: userId })
+        .insert({ ...project.payload, contractor_id: contractorId, user_id: userId })
         .select('id')
         .single()
 
@@ -74,19 +154,26 @@ export async function commitPortableImport(client, userId, preview) {
       } else {
         inserted.projects += 1
         projectIds.set(project.key, data.id)
+        if (contractorId) projectContractorIds.set(project.key, contractorId)
       }
     }
 
     for (const event of preview.events) {
       const projectId = event.project_key ? projectIds.get(event.project_key) : null
+      const contractorId = event.contractor
+        ? await resolveContractorLink(event.contractor, event.row, 'event')
+        : event.project_key
+        ? projectContractorIds.get(event.project_key) ?? null
+        : null
       if (event.project_key && !projectId) {
         failures.push({ row: event.row, entity: 'event', error: portabilityError('No se ha podido resolver el proyecto importado.') })
         continue
       }
+      if (event.contractor && !contractorId) continue
 
       const { data, error } = await client
         .from('events')
-        .insert({ ...event.payload, project_id: projectId, user_id: userId })
+        .insert({ ...event.payload, project_id: projectId, contractor_id: contractorId, user_id: userId })
         .select('id')
         .single()
 

--- a/src/hooks/useDataPortability.test.ts
+++ b/src/hooks/useDataPortability.test.ts
@@ -31,16 +31,26 @@ function createExportClient(rowsByTable = {}) {
 
 function createImportClient() {
   const inserts = []
-  const ids = { projects: 0, events: 0 }
+  const ids = { contractors: 0, projects: 0, events: 0 }
 
   return {
     inserts,
     from(table) {
       return {
+        select(columns) {
+          if (table === 'contractors') {
+            return {
+              async eq() {
+                return { data: [], error: null, columns }
+              },
+            }
+          }
+          return this
+        },
         insert(payload) {
           inserts.push({ table, payload })
 
-          if (table === 'projects' || table === 'events') {
+          if (table === 'contractors' || table === 'projects' || table === 'events') {
             ids[table] += 1
             const id = `${table}-${ids[table]}`
             return {
@@ -66,6 +76,7 @@ describe('data portability Supabase contract', () => {
     const client = createExportClient({
       projects: [{ id: 'p1', user_id: 'u1', name: 'Proyecto' }],
       events: [{ id: 'e1', user_id: 'u1', name: 'Evento' }],
+      contractors: [{ id: 'c1', user_id: 'u1', name: 'Contratante' }],
       incomes: [{ id: 'i1', user_id: 'u1', amount: 100 }],
       expenses: [{ id: 'x1', user_id: 'u1', amount: 10 }],
     })
@@ -73,8 +84,9 @@ describe('data portability Supabase contract', () => {
     const { data, error } = await exportPortableData(client, 'auth-user')
 
     expect(error).toBeNull()
-    expect(data.summary).toEqual({ projects: 1, events: 1, incomes: 1, expenses: 1 })
+    expect(data.summary).toEqual({ contractors: 1, projects: 1, events: 1, incomes: 1, expenses: 1 })
     expect(client.calls.filter((call) => call.method === 'eq')).toEqual([
+      { table: 'contractors', method: 'eq', column: 'user_id', value: 'auth-user' },
       { table: 'projects', method: 'eq', column: 'user_id', value: 'auth-user' },
       { table: 'events', method: 'eq', column: 'user_id', value: 'auth-user' },
       { table: 'incomes', method: 'eq', column: 'user_id', value: 'auth-user' },
@@ -88,9 +100,18 @@ describe('data portability Supabase contract', () => {
       valid: true,
       errors: [],
       hiddenErrorCount: 0,
-      projects: [{
+      contractors: [{
         row: 2,
+        key: 'c1',
+        payload: {
+          name: 'Contratante',
+          user_id: 'csv-user',
+        },
+      }],
+      projects: [{
+        row: 3,
         key: 'p1',
+        contractor: { type: 'key', value: 'c1' },
         payload: {
           name: 'Proyecto',
           start_date: '2026-05-01',
@@ -98,9 +119,10 @@ describe('data portability Supabase contract', () => {
         },
       }],
       events: [{
-        row: 3,
+        row: 4,
         key: 'e1',
         project_key: 'p1',
+        contractor: { type: 'name', value: 'Sala nueva' },
         payload: {
           name: 'Evento',
           start_datetime: '2026-05-02T06:00:00.000Z',
@@ -109,7 +131,7 @@ describe('data portability Supabase contract', () => {
         },
       }],
       incomes: [{
-        row: 4,
+        row: 5,
         link: { type: 'event', key: 'e1' },
         payload: {
           concept: 'Caché',
@@ -120,7 +142,7 @@ describe('data portability Supabase contract', () => {
         },
       }],
       expenses: [{
-        row: 5,
+        row: 6,
         link: { type: 'project', key: 'p1' },
         payload: {
           concept: 'Material',
@@ -135,15 +157,23 @@ describe('data portability Supabase contract', () => {
     const { data, error } = await commitPortableImport(client, 'auth-user', preview)
 
     expect(error).toBeNull()
-    expect(data.inserted).toEqual({ projects: 1, events: 1, incomes: 1, expenses: 1 })
+    expect(data.inserted).toEqual({ contractors: 2, projects: 1, events: 1, incomes: 1, expenses: 1 })
     expect(client.inserts).toEqual([
       {
+        table: 'contractors',
+        payload: expect.objectContaining({ name: 'Contratante', user_id: 'auth-user' }),
+      },
+      {
         table: 'projects',
-        payload: expect.objectContaining({ name: 'Proyecto', user_id: 'auth-user' }),
+        payload: expect.objectContaining({ name: 'Proyecto', contractor_id: 'contractors-1', user_id: 'auth-user' }),
+      },
+      {
+        table: 'contractors',
+        payload: expect.objectContaining({ name: 'Sala nueva', user_id: 'auth-user' }),
       },
       {
         table: 'events',
-        payload: expect.objectContaining({ name: 'Evento', project_id: 'projects-1', user_id: 'auth-user' }),
+        payload: expect.objectContaining({ name: 'Evento', project_id: 'projects-1', contractor_id: 'contractors-2', user_id: 'auth-user' }),
       },
       {
         table: 'incomes',
@@ -154,5 +184,56 @@ describe('data portability Supabase contract', () => {
         payload: expect.objectContaining({ concept: 'Material', project_id: 'projects-1', event_id: null, user_id: 'auth-user' }),
       },
     ])
+  })
+
+  it('hereda contractor_id del proyecto al importar eventos sin contratante propio', async () => {
+    const client = createImportClient()
+    const preview = {
+      valid: true,
+      errors: [],
+      hiddenErrorCount: 0,
+      contractors: [{
+        row: 2,
+        key: 'c1',
+        payload: {
+          name: 'Contratante',
+        },
+      }],
+      projects: [{
+        row: 3,
+        key: 'p1',
+        contractor: { type: 'key', value: 'c1' },
+        payload: {
+          name: 'Proyecto',
+          start_date: '2026-05-01',
+        },
+      }],
+      events: [{
+        row: 4,
+        key: 'e1',
+        project_key: 'p1',
+        contractor: null,
+        payload: {
+          name: 'Evento heredado',
+          start_datetime: '2026-05-02T06:00:00.000Z',
+        },
+      }],
+      incomes: [],
+      expenses: [],
+    }
+
+    const { data, error } = await commitPortableImport(client, 'auth-user', preview)
+
+    expect(error).toBeNull()
+    expect(data.inserted).toEqual({ contractors: 1, projects: 1, events: 1, incomes: 0, expenses: 0 })
+    expect(client.inserts).toContainEqual({
+      table: 'events',
+      payload: expect.objectContaining({
+        name: 'Evento heredado',
+        project_id: 'projects-1',
+        contractor_id: 'contractors-1',
+        user_id: 'auth-user',
+      }),
+    })
   })
 })

--- a/src/lib/contractors.js
+++ b/src/lib/contractors.js
@@ -1,0 +1,46 @@
+export function normalizeContractorName(name) {
+  return String(name ?? '').trim().replace(/\s+/g, ' ').toLowerCase()
+}
+
+export function getContractorById(contractors = [], contractorId) {
+  if (!contractorId) return null
+  return contractors.find((contractor) => contractor.id === contractorId) ?? null
+}
+
+function legacyClient(client) {
+  const value = String(client ?? '').trim()
+  return value ? { name: value, source: 'legacy' } : null
+}
+
+export function getProjectContractor(project, contractors = []) {
+  if (!project) return null
+
+  const contractor = getContractorById(contractors, project.contractor_id)
+  if (contractor) return { name: contractor.name, source: 'contractor', contractor }
+
+  return legacyClient(project.client)
+}
+
+export function getEventContractor(event, projects = [], contractors = []) {
+  if (!event) return null
+
+  const project = event.project_id ? projects.find((item) => item.id === event.project_id) : null
+  if (project?.contractor_id && event.contractor_id === project.contractor_id) {
+    const inheritedContractor = getContractorById(contractors, project.contractor_id)
+    if (inheritedContractor) return { name: inheritedContractor.name, source: 'project', contractor: inheritedContractor }
+  }
+
+  const ownContractor = getContractorById(contractors, event.contractor_id)
+  if (ownContractor) return { name: ownContractor.name, source: 'contractor', contractor: ownContractor }
+
+  const projectContractor = getProjectContractor(project, contractors)
+  if (projectContractor) return { ...projectContractor, source: 'project' }
+
+  return legacyClient(event.client)
+}
+
+export function formatContractorDisplay(contractorInfo, { showInherited = false } = {}) {
+  if (!contractorInfo?.name) return ''
+  if (showInherited && contractorInfo.source === 'project') return `${contractorInfo.name} · heredado`
+  return contractorInfo.name
+}

--- a/src/lib/contractors.test.js
+++ b/src/lib/contractors.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { getEventContractor, getProjectContractor, normalizeContractorName } from './contractors'
+
+describe('contractor helpers', () => {
+  const contractors = [
+    { id: 'c1', name: 'Ayuntamiento' },
+    { id: 'c2', name: 'Sala privada' },
+  ]
+
+  it('normaliza nombres para deduplicar espacios y mayúsculas', () => {
+    expect(normalizeContractorName('  Ayuntamiento   de Madrid ')).toBe('ayuntamiento de madrid')
+  })
+
+  it('resuelve contratante de proyecto o client legacy', () => {
+    expect(getProjectContractor({ contractor_id: 'c1', client: 'Legacy' }, contractors)).toMatchObject({
+      name: 'Ayuntamiento',
+      source: 'contractor',
+    })
+    expect(getProjectContractor({ client: 'Legacy' }, contractors)).toMatchObject({
+      name: 'Legacy',
+      source: 'legacy',
+    })
+  })
+
+  it('marca como heredado el contratante persistido desde proyecto', () => {
+    const projects = [{ id: 'p1', contractor_id: 'c1' }]
+    const event = { project_id: 'p1', contractor_id: 'c1', client: 'Legacy' }
+
+    expect(getEventContractor(event, projects, contractors)).toMatchObject({
+      name: 'Ayuntamiento',
+      source: 'project',
+    })
+  })
+
+  it('permite override de contratante propio en evento', () => {
+    const projects = [{ id: 'p1', contractor_id: 'c1' }]
+    const event = { project_id: 'p1', contractor_id: 'c2' }
+
+    expect(getEventContractor(event, projects, contractors)).toMatchObject({
+      name: 'Sala privada',
+      source: 'contractor',
+    })
+  })
+})

--- a/src/lib/portability/exportData.test.ts
+++ b/src/lib/portability/exportData.test.ts
@@ -10,13 +10,14 @@ describe('export portability helpers', () => {
       expenses: [],
     }, new Date('2026-05-07T10:00:00.000Z')))
 
-    expect(backup.version).toBe(1)
+    expect(backup.version).toBe(2)
     expect(backup.exported_at).toBe('2026-05-07T10:00:00.000Z')
     expect(backup.entities.projects[0]).toEqual({ id: 'p1', name: 'Proyecto', start_date: '2026-05-01' })
   })
 
   it('crea CSVs por entidad sin user_id y con texto formula-safe', () => {
     const csvFiles = buildCsvFiles({
+      contractors: [{ id: 'c1', user_id: 'u1', name: 'Contratante' }],
       projects: [{ id: 'p1', user_id: 'u1', name: '+Proyecto', start_date: '2026-05-01' }],
       events: [{ id: 'e1', user_id: 'u1', project_id: 'p1', name: 'Evento', start_datetime: '2026-05-10T06:00:00.000Z' }],
       incomes: [{ id: 'i1', user_id: 'u1', event_id: 'e1', concept: 'Caché', amount: 100 }],
@@ -24,6 +25,7 @@ describe('export portability helpers', () => {
     })
 
     expect(csvFiles.projects.content).not.toContain('user_id')
+    expect(csvFiles.contractors.content).toContain('Contratante')
     expect(csvFiles.projects.content).toContain("'+Proyecto")
     expect(csvFiles.events.content).toContain('project_id')
     expect(csvFiles.incomes.content).toContain('event_id')
@@ -31,10 +33,11 @@ describe('export portability helpers', () => {
 
   it('resume recuentos por entidad', () => {
     expect(buildExportSummary({
+      contractors: [{ id: 'c1' }],
       projects: [{ id: 'p1' }],
       events: [{ id: 'e1' }, { id: 'e2' }],
       incomes: [],
       expenses: [{ id: 'x1' }],
-    })).toEqual({ projects: 1, events: 2, incomes: 0, expenses: 1 })
+    })).toEqual({ contractors: 1, projects: 1, events: 2, incomes: 0, expenses: 1 })
   })
 })

--- a/src/lib/portability/exportData.ts
+++ b/src/lib/portability/exportData.ts
@@ -1,9 +1,22 @@
 import { serializeCsv } from './csv'
 
-export const BACKUP_VERSION = 1
+export const BACKUP_VERSION = 2
+
+export const CONTRACTOR_CSV_HEADERS = [
+  'id',
+  'name',
+  'billing_name',
+  'tax_id',
+  'email',
+  'phone',
+  'billing_address',
+  'notes',
+  'created_at',
+] as const
 
 export const PROJECT_CSV_HEADERS = [
   'id',
+  'contractor_id',
   'name',
   'client',
   'category',
@@ -18,6 +31,7 @@ export const PROJECT_CSV_HEADERS = [
 export const EVENT_CSV_HEADERS = [
   'id',
   'project_id',
+  'contractor_id',
   'name',
   'client',
   'category',
@@ -55,6 +69,7 @@ export const EXPENSE_CSV_HEADERS = [
 ] as const
 
 type EntityRows = {
+  contractors?: Record<string, unknown>[]
   projects: Record<string, unknown>[]
   events: Record<string, unknown>[]
   incomes: Record<string, unknown>[]
@@ -75,6 +90,7 @@ export function buildBackupJson(entities: EntityRows, exportedAt = new Date()): 
     version: BACKUP_VERSION,
     exported_at: exportedAt.toISOString(),
     entities: {
+      contractors: (entities.contractors ?? []).map(withoutUserId),
       projects: entities.projects.map(withoutUserId),
       events: entities.events.map(withoutUserId),
       incomes: entities.incomes.map(withoutUserId),
@@ -85,6 +101,11 @@ export function buildBackupJson(entities: EntityRows, exportedAt = new Date()): 
 
 export function buildCsvFiles(entities: EntityRows) {
   return {
+    contractors: {
+      filename: 'caches-contractors.csv',
+      headers: [...CONTRACTOR_CSV_HEADERS],
+      content: serializeCsv([...CONTRACTOR_CSV_HEADERS], (entities.contractors ?? []).map((row) => pick(CONTRACTOR_CSV_HEADERS, row))),
+    },
     projects: {
       filename: 'caches-projects.csv',
       headers: [...PROJECT_CSV_HEADERS],
@@ -110,6 +131,7 @@ export function buildCsvFiles(entities: EntityRows) {
 
 export function buildExportSummary(entities: EntityRows) {
   return {
+    contractors: (entities.contractors ?? []).length,
     projects: entities.projects.length,
     events: entities.events.length,
     incomes: entities.incomes.length,

--- a/src/lib/portability/importValidation.test.ts
+++ b/src/lib/portability/importValidation.test.ts
@@ -48,13 +48,67 @@ describe('validateCsvImport', () => {
 
     expect(error).toBeNull()
     expect(preview.valid).toBe(true)
-    expect(preview.summary).toEqual({ project: 1, event: 1, income: 1, expense: 1 })
+    expect(preview.summary).toEqual({ contractor: 0, project: 1, event: 1, income: 1, expense: 1 })
     expect(preview.projects[0].payload).not.toHaveProperty('user_id')
     expect(preview.events[0].payload.start_datetime).toBe('2026-05-16T20:00:00.000Z')
     expect(preview.incomes[0].payload.amount).toBe(1234.56)
     expect(preview.incomes[0].payload.tax_rate).toBe(15.5)
     expect(preview.incomes[0]).not.toHaveProperty('project_id')
     expect(preview.expenses[0].payload.is_deductible).toBe(false)
+  })
+
+  it('acepta CSV legacy sin columnas de contratante', () => {
+    const legacyHeaders = IMPORT_HEADERS.filter((header) => ![
+      'contractor_key',
+      'contractor_name',
+      'billing_name',
+      'tax_id',
+      'email',
+      'phone',
+      'billing_address',
+    ].includes(header))
+    const legacyRow = legacyHeaders.map((header) => ({
+      entity: 'project',
+      project_key: 'p1',
+      name: 'Proyecto legacy',
+      start_date: '2026-05-01',
+    }[header] ?? '')).join(';')
+
+    const { preview, error } = validateCsvImport(`${legacyHeaders.join(';')}\n${legacyRow}\n`)
+
+    expect(error).toBeNull()
+    expect(preview.valid).toBe(true)
+    expect(preview.projects[0].contractor).toBeNull()
+  })
+
+  it('resuelve contratantes por clave o por nombre en preview', () => {
+    const { preview, error } = validateCsvImport(importCsv([
+      csvRow({
+        entity: 'contractor',
+        contractor_key: 'c1',
+        name: 'Contratante guardado',
+      }),
+      csvRow({
+        entity: 'project',
+        project_key: 'p1',
+        contractor_key: 'c1',
+        name: 'Proyecto',
+        start_date: '2026-05-01',
+      }),
+      csvRow({
+        entity: 'event',
+        event_key: 'e1',
+        contractor_name: 'Sala nueva',
+        name: 'Evento',
+        start_datetime: '2026-05-10 08:00',
+      }),
+    ]))
+
+    expect(error).toBeNull()
+    expect(preview.valid).toBe(true)
+    expect(preview.contractors[0].key).toBe('c1')
+    expect(preview.projects[0].contractor).toEqual({ type: 'key', value: 'c1' })
+    expect(preview.events[0].contractor).toEqual({ type: 'name', value: 'Sala nueva' })
   })
 
   it('rechaza cabeceras prohibidas antes de planificar filas', () => {

--- a/src/lib/portability/importValidation.ts
+++ b/src/lib/portability/importValidation.ts
@@ -2,7 +2,7 @@ import { parseDecimal } from '../decimal'
 import { DEFAULT_TZ, fromLocalInputValue, toIsoUtc } from '../datetime'
 import { isFormulaLike, parseCsv } from './csv'
 
-export const IMPORT_HEADERS = [
+export const REQUIRED_IMPORT_HEADERS = [
   'entity',
   'project_key',
   'event_key',
@@ -26,14 +26,30 @@ export const IMPORT_HEADERS = [
   'notes',
 ] as const
 
-export const FORBIDDEN_IMPORT_HEADERS = ['id', 'user_id', 'created_at', 'project_id', 'event_id'] as const
+export const OPTIONAL_IMPORT_HEADERS = [
+  'contractor_key',
+  'contractor_name',
+  'billing_name',
+  'tax_id',
+  'email',
+  'phone',
+  'billing_address',
+] as const
+
+export const IMPORT_HEADERS = [
+  ...REQUIRED_IMPORT_HEADERS,
+  ...OPTIONAL_IMPORT_HEADERS,
+] as const
+
+export const FORBIDDEN_IMPORT_HEADERS = ['id', 'user_id', 'created_at', 'project_id', 'event_id', 'contractor_id'] as const
 export const MAX_IMPORT_BYTES = 1024 * 1024
 export const MAX_IMPORT_ROWS = 500
 export const MAX_IMPORT_COLUMNS = 30
 export const MAX_IMPORT_CELL_LENGTH = 5000
 export const MAX_DISPLAYED_ERRORS = 100
 
-type Entity = 'project' | 'event' | 'income' | 'expense'
+type Entity = 'contractor' | 'project' | 'event' | 'income' | 'expense'
+type ContractorLink = { type: 'key' | 'name'; value: string } | null
 
 export type ImportError = {
   row: number
@@ -41,9 +57,24 @@ export type ImportError = {
   message: string
 }
 
+export type ImportContractor = {
+  row: number
+  key: string
+  payload: {
+    name: string
+    billing_name: string | null
+    tax_id: string | null
+    email: string | null
+    phone: string | null
+    billing_address: string | null
+    notes: string | null
+  }
+}
+
 export type ImportProject = {
   row: number
   key: string
+  contractor: ContractorLink
   payload: {
     name: string
     client: string | null
@@ -60,6 +91,7 @@ export type ImportEvent = {
   row: number
   key: string
   project_key: string | null
+  contractor: ContractorLink
   payload: {
     name: string
     client: string | null
@@ -90,6 +122,7 @@ export type ImportFinanceRow = {
 
 export type ImportPreview = {
   valid: boolean
+  contractors: ImportContractor[]
   projects: ImportProject[]
   events: ImportEvent[]
   incomes: ImportFinanceRow[]
@@ -109,13 +142,14 @@ type ParsedImportRow = {
 function emptyPreview(errors: ImportError[] = []): ImportPreview {
   return {
     valid: errors.length === 0,
+    contractors: [],
     projects: [],
     events: [],
     incomes: [],
     expenses: [],
     errors: errors.slice(0, MAX_DISPLAYED_ERRORS),
     hiddenErrorCount: Math.max(0, errors.length - MAX_DISPLAYED_ERRORS),
-    summary: { project: 0, event: 0, income: 0, expense: 0 },
+    summary: { contractor: 0, project: 0, event: 0, income: 0, expense: 0 },
   }
 }
 
@@ -125,6 +159,10 @@ function normalizeHeader(header: string): string {
 
 function compact(value: string | null | undefined): string {
   return String(value ?? '').trim()
+}
+
+function normalizeContractorName(value: string | null | undefined): string {
+  return compact(value).replace(/\s+/g, ' ').toLowerCase()
 }
 
 function optionalText(value: string | null | undefined): string | null {
@@ -229,6 +267,16 @@ function validateTaxRate(errorsByRow: Map<number, ImportError[]>, row: number, r
   return taxRate
 }
 
+function contractorLink(record: Record<string, string>): ContractorLink {
+  const key = optionalText(record.contractor_key)
+  if (key) return { type: 'key', value: key }
+
+  const name = optionalText(record.contractor_name)
+  if (name) return { type: 'name', value: name }
+
+  return null
+}
+
 export function validateCsvImport(text: string, options: { fileSize?: number } = {}): { preview: ImportPreview; error: Error | null } {
   const byteSize = options.fileSize ?? new Blob([text]).size
   if (byteSize > MAX_IMPORT_BYTES) {
@@ -257,7 +305,7 @@ export function validateCsvImport(text: string, options: { fileSize?: number } =
     }
   }
 
-  for (const requiredHeader of IMPORT_HEADERS) {
+  for (const requiredHeader of REQUIRED_IMPORT_HEADERS) {
     if (!headers.includes(requiredHeader)) {
       addError(errorsByRow, 1, requiredHeader, `Falta la cabecera ${requiredHeader}.`)
     }
@@ -286,7 +334,8 @@ export function validateCsvImport(text: string, options: { fileSize?: number } =
     }
   })
 
-  const summary: Record<Entity, number> = { project: 0, event: 0, income: 0, expense: 0 }
+  const summary: Record<Entity, number> = { contractor: 0, project: 0, event: 0, income: 0, expense: 0 }
+  const contractorKeyRows = new Map<string, number[]>()
   const projectKeyRows = new Map<string, number[]>()
   const eventKeyRows = new Map<string, number[]>()
 
@@ -309,13 +358,19 @@ export function validateCsvImport(text: string, options: { fileSize?: number } =
       }
     }
 
-    if (!['project', 'event', 'income', 'expense'].includes(compact(row.record.entity))) {
+    if (!['contractor', 'project', 'event', 'income', 'expense'].includes(compact(row.record.entity))) {
       addError(errorsByRow, row.row, 'entity', 'Entidad no reconocida.')
       row.entity = null
       continue
     }
 
     summary[row.entity as Entity] += 1
+
+    if (row.entity === 'contractor') {
+      const contractorKey = compact(row.record.contractor_key)
+      if (contractorKey === '') addError(errorsByRow, row.row, 'contractor_key', 'contractor_key es obligatorio.')
+      else contractorKeyRows.set(contractorKey, [...(contractorKeyRows.get(contractorKey) ?? []), row.row])
+    }
 
     if (row.entity === 'project') {
       const projectKey = compact(row.record.project_key)
@@ -330,8 +385,15 @@ export function validateCsvImport(text: string, options: { fileSize?: number } =
     }
   }
 
+  const duplicateContractorKeys = new Set([...contractorKeyRows.entries()].filter(([, rowNumbers]) => rowNumbers.length > 1).map(([key]) => key))
   const duplicateProjectKeys = new Set([...projectKeyRows.entries()].filter(([, rowNumbers]) => rowNumbers.length > 1).map(([key]) => key))
   const duplicateEventKeys = new Set([...eventKeyRows.entries()].filter(([, rowNumbers]) => rowNumbers.length > 1).map(([key]) => key))
+
+  for (const key of duplicateContractorKeys) {
+    for (const row of contractorKeyRows.get(key) ?? []) {
+      addError(errorsByRow, row, 'contractor_key', `contractor_key duplicado: ${key}.`)
+    }
+  }
 
   for (const key of duplicateProjectKeys) {
     for (const row of projectKeyRows.get(key) ?? []) {
@@ -346,12 +408,19 @@ export function validateCsvImport(text: string, options: { fileSize?: number } =
   }
 
   for (const row of rows) {
+    if (row.entity === 'contractor') {
+      if (compact(row.record.name) === '') addError(errorsByRow, row.row, 'name', 'El nombre es obligatorio.')
+    }
+
     if (row.entity === 'project') {
       if (compact(row.record.name) === '') addError(errorsByRow, row.row, 'name', 'El nombre es obligatorio.')
       const startDate = validateDateField(errorsByRow, row.row, row.record, 'start_date', true)
       const endDate = validateDateField(errorsByRow, row.row, row.record, 'end_date')
       if (startDate && endDate && endDate < startDate) {
         addError(errorsByRow, row.row, 'end_date', 'La fecha de fin no puede ser anterior al inicio.')
+      }
+      if (compact(row.record.contractor_key) && compact(row.record.contractor_name)) {
+        addError(errorsByRow, row.row, 'contractor_key', 'Indica contractor_key o contractor_name, no ambos.')
       }
     }
 
@@ -362,6 +431,9 @@ export function validateCsvImport(text: string, options: { fileSize?: number } =
       if (!start) addError(errorsByRow, row.row, 'start_datetime', 'Usa fecha y hora local YYYY-MM-DD HH:mm.')
       if (compact(row.record.end_datetime) && !end) addError(errorsByRow, row.row, 'end_datetime', 'Usa fecha y hora local YYYY-MM-DD HH:mm.')
       if (start && end && end.minutes < start.minutes) addError(errorsByRow, row.row, 'end_datetime', 'La fecha de fin no puede ser anterior al inicio.')
+      if (compact(row.record.contractor_key) && compact(row.record.contractor_name)) {
+        addError(errorsByRow, row.row, 'contractor_key', 'Indica contractor_key o contractor_name, no ambos.')
+      }
     }
 
     if (row.entity === 'income' || row.entity === 'expense') {
@@ -385,6 +457,12 @@ export function validateCsvImport(text: string, options: { fileSize?: number } =
     }
   }
 
+  const validContractorKeys = new Set(
+    rows
+      .filter((row) => row.entity === 'contractor' && !rowHasErrors(errorsByRow, row.row))
+      .map((row) => compact(row.record.contractor_key)),
+  )
+
   const validProjectKeys = new Set(
     rows
       .filter((row) => row.entity === 'project' && !rowHasErrors(errorsByRow, row.row))
@@ -392,6 +470,13 @@ export function validateCsvImport(text: string, options: { fileSize?: number } =
   )
 
   for (const row of rows) {
+    if (row.entity === 'project' || row.entity === 'event') {
+      const contractorKey = compact(row.record.contractor_key)
+      if (contractorKey && !validContractorKeys.has(contractorKey)) {
+        addError(errorsByRow, row.row, 'contractor_key', `No existe un contractor_key válido en el archivo: ${contractorKey}.`)
+      }
+    }
+
     if (row.entity === 'event') {
       const projectKey = compact(row.record.project_key)
       if (projectKey && !validProjectKeys.has(projectKey)) {
@@ -420,6 +505,7 @@ export function validateCsvImport(text: string, options: { fileSize?: number } =
 
   const preview: ImportPreview = {
     valid: false,
+    contractors: [],
     projects: [],
     events: [],
     incomes: [],
@@ -431,10 +517,27 @@ export function validateCsvImport(text: string, options: { fileSize?: number } =
 
   for (const row of rows) {
     if (!row.entity || rowHasErrors(errorsByRow, row.row)) continue
+    if (row.entity === 'contractor') {
+      preview.contractors.push({
+        row: row.row,
+        key: compact(row.record.contractor_key),
+        payload: {
+          name: compact(row.record.name),
+          billing_name: optionalText(row.record.billing_name),
+          tax_id: optionalText(row.record.tax_id),
+          email: optionalText(row.record.email),
+          phone: optionalText(row.record.phone),
+          billing_address: optionalText(row.record.billing_address),
+          notes: optionalText(row.record.notes),
+        },
+      })
+    }
+
     if (row.entity === 'project') {
       preview.projects.push({
         row: row.row,
         key: compact(row.record.project_key),
+        contractor: contractorLink(row.record),
         payload: {
           name: compact(row.record.name),
           client: optionalText(row.record.client),
@@ -453,6 +556,7 @@ export function validateCsvImport(text: string, options: { fileSize?: number } =
         row: row.row,
         key: compact(row.record.event_key),
         project_key: optionalText(row.record.project_key),
+        contractor: contractorLink(row.record),
         payload: {
           name: compact(row.record.name),
           client: optionalText(row.record.client),

--- a/src/pages/Calendar/CalendarEvents.jsx
+++ b/src/pages/Calendar/CalendarEvents.jsx
@@ -10,8 +10,10 @@ import { Modal } from '../../components/ui/Modal'
 import { useToast, ToastContainer } from '../../components/ui/Toast'
 import { EventForm } from '../Events/EventForm'
 import { useAuth } from '../../hooks/useAuth'
+import { useContractors } from '../../hooks/useContractors'
 import { useEvents } from '../../hooks/useEvents'
 import { useProjects } from '../../hooks/useProjects'
+import { formatContractorDisplay, getEventContractor } from '../../lib/contractors'
 import { formatDatetime } from '../../lib/formatters'
 import { AlertCircle, CalendarDays, Plus, X, ChevronDown, ChevronUp } from 'lucide-react'
 
@@ -57,6 +59,7 @@ export default function CalendarEvents() {
   const { user } = useAuth()
   const { events, loading, error, createEvent } = useEvents(user?.id)
   const { projects, loading: projectsLoading, error: projectsError } = useProjects(user?.id)
+  const { contractors, findOrCreateContractor } = useContractors(user?.id)
   const isMobile = useIsMobile()
   const [calendarDate, setCalendarDate] = useState(() => new Date())
   const [calendarView, setCalendarView] = useState(() => isMobile ? 'month' : 'month')
@@ -190,6 +193,9 @@ export default function CalendarEvents() {
         </div>
 
         {selectedEvent && (
+          (() => {
+            const selectedContractor = getEventContractor(selectedEvent, projects, contractors)
+            return (
           <div className={`
             w-full lg:w-80 bg-white rounded-xl border border-gray-200 p-5 flex flex-col gap-4
             lg:relative
@@ -213,8 +219,10 @@ export default function CalendarEvents() {
             </div>
             <div className="min-w-0">
               <h3 className="font-semibold text-gray-900 break-words">{selectedEvent.name}</h3>
-              {selectedEvent.client && (
-                <p className="text-sm text-gray-500 mt-0.5 break-words">{selectedEvent.client}</p>
+              {selectedContractor && (
+                <p className="text-sm text-gray-500 mt-0.5 break-words">
+                  {formatContractorDisplay(selectedContractor, { showInherited: true })}
+                </p>
               )}
             </div>
             <div className={`flex flex-col gap-2 text-sm text-gray-600 ${isMobile && !panelExpanded ? 'hidden' : ''}`}>
@@ -254,6 +262,8 @@ export default function CalendarEvents() {
               </Button>
             </Link>
           </div>
+            )
+          })()
         )}
       </div>
 
@@ -261,6 +271,8 @@ export default function CalendarEvents() {
         <EventForm
           initialData={newEventInitialData}
           projects={projects}
+          contractors={contractors}
+          onCreateContractor={findOrCreateContractor}
           onSubmit={handleCreate}
           onCancel={closeNewEvent}
           loading={saving}

--- a/src/pages/Calendar/CalendarProjects.jsx
+++ b/src/pages/Calendar/CalendarProjects.jsx
@@ -9,7 +9,9 @@ import { Modal } from '../../components/ui/Modal'
 import { useToast, ToastContainer } from '../../components/ui/Toast'
 import { ProjectForm } from '../Projects/ProjectForm'
 import { useAuth } from '../../hooks/useAuth'
+import { useContractors } from '../../hooks/useContractors'
 import { useProjects } from '../../hooks/useProjects'
+import { getProjectContractor } from '../../lib/contractors'
 import { formatDate } from '../../lib/formatters'
 import { getDefaultSelectedMonth } from '../../lib/projectYearCalendar'
 import { AlertCircle, FolderOpen, Plus, X, ChevronDown, ChevronUp, ChevronLeft, ChevronRight } from 'lucide-react'
@@ -29,6 +31,7 @@ function useIsMobile() {
 export default function CalendarProjects() {
   const { user } = useAuth()
   const { projects, loading, error, createProject } = useProjects(user?.id)
+  const { contractors, findOrCreateContractor } = useContractors(user?.id)
   const isMobile = useIsMobile()
   const [visibleYear, setVisibleYear] = useState(() => dayjs().year())
   const [selectedMonth, setSelectedMonth] = useState(() => dayjs().month())
@@ -126,6 +129,9 @@ export default function CalendarProjects() {
         </div>
 
         {selectedProject && (
+          (() => {
+            const selectedContractor = getProjectContractor(selectedProject, contractors)
+            return (
           <div className={`
             w-full lg:w-80 bg-white rounded-xl border border-gray-200 p-5 flex flex-col gap-4
             lg:relative
@@ -149,8 +155,8 @@ export default function CalendarProjects() {
             </div>
             <div className="min-w-0">
               <h3 className="font-semibold text-gray-900 break-words">{selectedProject.name}</h3>
-              {selectedProject.client && (
-                <p className="text-sm text-gray-500 mt-0.5 break-words">{selectedProject.client}</p>
+              {selectedContractor && (
+                <p className="text-sm text-gray-500 mt-0.5 break-words">{selectedContractor.name}</p>
               )}
             </div>
             <div className={`flex flex-col gap-2 text-sm text-gray-600 ${isMobile && !panelExpanded ? 'hidden' : ''}`}>
@@ -179,12 +185,16 @@ export default function CalendarProjects() {
               </Button>
             </Link>
           </div>
+            )
+          })()
         )}
       </div>
 
       <Modal isOpen={newModal} onClose={closeNewProject} title="Nuevo proyecto">
         <ProjectForm
           initialData={newProjectInitialData}
+          contractors={contractors}
+          onCreateContractor={findOrCreateContractor}
           onSubmit={handleCreate}
           onCancel={closeNewProject}
           loading={saving}

--- a/src/pages/Contractors/ContractorList.jsx
+++ b/src/pages/Contractors/ContractorList.jsx
@@ -1,0 +1,383 @@
+import { useMemo, useState } from 'react'
+import { AlertCircle, Building2, Edit, Mail, Phone, Plus, Search, Trash2 } from 'lucide-react'
+import { PageWrapper } from '../../components/layout/PageWrapper'
+import { Card } from '../../components/ui/Card'
+import { Button } from '../../components/ui/Button'
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
+import { Input, Textarea } from '../../components/ui/Input'
+import { Modal } from '../../components/ui/Modal'
+import { ToastContainer, useToast } from '../../components/ui/Toast'
+import { useAuth } from '../../hooks/useAuth'
+import { isContractorsSchemaMissing, useContractors } from '../../hooks/useContractors'
+
+const EMPTY_CONTRACTOR = {
+  name: '',
+  billing_name: '',
+  tax_id: '',
+  email: '',
+  phone: '',
+  billing_address: '',
+  notes: '',
+}
+
+function toForm(contractor) {
+  return {
+    ...EMPTY_CONTRACTOR,
+    ...contractor,
+    name: contractor?.name ?? '',
+    billing_name: contractor?.billing_name ?? '',
+    tax_id: contractor?.tax_id ?? '',
+    email: contractor?.email ?? '',
+    phone: contractor?.phone ?? '',
+    billing_address: contractor?.billing_address ?? '',
+    notes: contractor?.notes ?? '',
+  }
+}
+
+function ContractorForm({ initialData, loading, onCancel, onSubmit }) {
+  const [form, setForm] = useState(() => toForm(initialData))
+  const [error, setError] = useState('')
+
+  const handleChange = (event) => {
+    const { name, value } = event.target
+    setForm((current) => ({ ...current, [name]: value }))
+    setError('')
+  }
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    if (!form.name.trim()) {
+      setError('Pon un nombre para identificar el contratante.')
+      return
+    }
+
+    await onSubmit({
+      name: form.name.trim(),
+      billing_name: form.billing_name.trim() || null,
+      tax_id: form.tax_id.trim() || null,
+      email: form.email.trim() || null,
+      phone: form.phone.trim() || null,
+      billing_address: form.billing_address.trim() || null,
+      notes: form.notes.trim() || null,
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <section className="grid gap-3">
+        <Input
+          label="Nombre del contratante *"
+          name="name"
+          value={form.name}
+          onChange={handleChange}
+          placeholder="Ayuntamiento de Madrid"
+          required
+        />
+        <Input
+          label="Nombre fiscal"
+          name="billing_name"
+          value={form.billing_name}
+          onChange={handleChange}
+          placeholder="Razón social si es distinta"
+        />
+      </section>
+
+      <section className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <Input
+          label="NIF/CIF"
+          name="tax_id"
+          value={form.tax_id}
+          onChange={handleChange}
+          placeholder="B12345678"
+        />
+        <Input
+          label="Email"
+          name="email"
+          type="email"
+          value={form.email}
+          onChange={handleChange}
+          placeholder="contratacion@ejemplo.es"
+        />
+        <Input
+          label="Teléfono"
+          name="phone"
+          type="tel"
+          value={form.phone}
+          onChange={handleChange}
+          placeholder="+34 600 000 000"
+        />
+        <Input
+          label="Dirección fiscal"
+          name="billing_address"
+          value={form.billing_address}
+          onChange={handleChange}
+          placeholder="Calle, ciudad, provincia"
+        />
+      </section>
+
+      <Textarea
+        label="Notas"
+        name="notes"
+        value={form.notes}
+        onChange={handleChange}
+        placeholder="Condiciones habituales, contacto interno, observaciones..."
+      />
+
+      {error && <p className="rounded-lg bg-[var(--color-red-light)] px-3 py-2 text-sm text-[var(--color-red)]">{error}</p>}
+
+      <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+        <Button type="button" variant="secondary" onClick={onCancel} className="justify-center">
+          Cancelar
+        </Button>
+        <Button type="submit" disabled={loading} className="justify-center">
+          {loading ? 'Guardando...' : 'Guardar contratante'}
+        </Button>
+      </div>
+    </form>
+  )
+}
+
+function ContractorCard({ contractor, onEdit, onDelete }) {
+  return (
+    <Card className="flex h-full min-w-0 flex-col p-5">
+      <div className="flex items-start gap-3">
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--color-paper-dark)] text-[var(--color-ink-muted)]">
+          <Building2 size={18} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate text-sm font-semibold text-[var(--color-ink)]">{contractor.name}</h3>
+          {contractor.billing_name && contractor.billing_name !== contractor.name && (
+            <p className="mt-0.5 truncate text-xs text-[var(--color-ink-muted)]">{contractor.billing_name}</p>
+          )}
+          {contractor.tax_id && (
+            <p className="mt-1 text-xs text-[var(--color-ink-muted)]">{contractor.tax_id}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-2 text-sm text-[var(--color-ink-muted)]">
+        {contractor.email && (
+          <p className="flex min-w-0 items-center gap-2">
+            <Mail size={14} className="shrink-0" />
+            <span className="truncate">{contractor.email}</span>
+          </p>
+        )}
+        {contractor.phone && (
+          <p className="flex min-w-0 items-center gap-2">
+            <Phone size={14} className="shrink-0" />
+            <span className="truncate">{contractor.phone}</span>
+          </p>
+        )}
+        {contractor.billing_address && (
+          <p className="line-clamp-2 text-xs leading-5">{contractor.billing_address}</p>
+        )}
+        {contractor.notes && (
+          <p className="line-clamp-2 rounded-lg bg-[var(--color-surface-alt)] px-3 py-2 text-xs leading-5">{contractor.notes}</p>
+        )}
+      </div>
+
+      <div className="mt-auto flex justify-end gap-2 pt-4">
+        <Button type="button" variant="secondary" size="sm" onClick={() => onEdit(contractor)}>
+          <Edit size={14} />
+          Editar
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => onDelete(contractor)}
+          className="text-[var(--color-red)] hover:bg-[var(--color-red-light)]"
+          aria-label={`Eliminar contratante ${contractor.name}`}
+        >
+          <Trash2 size={14} />
+        </Button>
+      </div>
+    </Card>
+  )
+}
+
+export default function ContractorList() {
+  const { user } = useAuth()
+  const { contractors, loading, error, createContractor, updateContractor, deleteContractor } = useContractors(user?.id)
+  const schemaMissing = isContractorsSchemaMissing(error)
+  const { toasts, addToast, removeToast } = useToast()
+  const [search, setSearch] = useState('')
+  const [modalOpen, setModalOpen] = useState(false)
+  const [editingContractor, setEditingContractor] = useState(null)
+  const [saving, setSaving] = useState(false)
+  const [deleteConfirm, setDeleteConfirm] = useState(null)
+
+  const filteredContractors = useMemo(() => {
+    const query = search.trim().toLowerCase()
+    if (!query) return contractors
+
+    return contractors.filter((contractor) => [
+      contractor.name,
+      contractor.billing_name,
+      contractor.tax_id,
+      contractor.email,
+      contractor.phone,
+      contractor.billing_address,
+      contractor.notes,
+    ].some((value) => String(value ?? '').toLowerCase().includes(query)))
+  }, [contractors, search])
+
+  const openCreate = () => {
+    setEditingContractor(null)
+    setModalOpen(true)
+  }
+
+  const openEdit = (contractor) => {
+    setEditingContractor(contractor)
+    setModalOpen(true)
+  }
+
+  const closeModal = () => {
+    setModalOpen(false)
+    setEditingContractor(null)
+  }
+
+  const handleSubmit = async (payload) => {
+    setSaving(true)
+    const result = editingContractor
+      ? await updateContractor(editingContractor.id, payload)
+      : await createContractor(payload)
+    setSaving(false)
+
+    if (result.error) {
+      const duplicate = result.error.code === '23505'
+      addToast(duplicate ? 'Ya existe un contratante con ese nombre.' : 'No se ha podido guardar el contratante.', 'error')
+      return
+    }
+
+    addToast(editingContractor ? 'Contratante actualizado.' : 'Contratante creado.')
+    closeModal()
+  }
+
+  const requestDelete = (contractor) => {
+    setDeleteConfirm({
+      title: 'Eliminar contratante',
+      description: `Se eliminará "${contractor.name}". Los proyectos y eventos que lo usen no se borran, pero dejarán de tener este contratante asociado.`,
+      confirmLabel: 'Eliminar contratante',
+      onConfirm: async () => {
+        const { error: deleteError } = await deleteContractor(contractor.id)
+        if (deleteError) {
+          addToast('No se ha podido eliminar el contratante.', 'error')
+          return
+        }
+        addToast('Contratante eliminado.')
+        setDeleteConfirm(null)
+      },
+    })
+  }
+
+  return (
+    <PageWrapper title="Contratantes">
+      <div className="flex max-w-6xl flex-col gap-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <p className="text-sm text-[var(--color-ink-muted)]">
+              {filteredContractors.length} de {contractors.length} contratantes
+              {search ? ' con la búsqueda actual' : ''}
+            </p>
+          </div>
+          <Button onClick={openCreate} className="w-full justify-center sm:w-auto">
+            <Plus size={16} />
+            Nuevo contratante
+          </Button>
+        </div>
+
+        <Card className="p-3 sm:p-4">
+          <div className="relative min-w-0">
+            <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--color-ink-muted)]" />
+            <input
+              type="text"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Buscar por nombre, fiscal, email o teléfono"
+              className="min-h-11 w-full rounded-lg border border-[var(--color-paper-mid)] py-2 pl-9 pr-3 text-base outline-none focus:border-[var(--color-primary-500)] sm:text-sm"
+            />
+          </div>
+        </Card>
+
+        {error && (
+          <div className="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            <AlertCircle size={18} className="mt-0.5 shrink-0" />
+            <div>
+              <p className="font-medium">
+                {schemaMissing ? 'Falta aplicar la migración de contratantes.' : 'No se han podido cargar los contratantes.'}
+              </p>
+              {schemaMissing && (
+                <p className="mt-1">
+                  Aplica `supabase/migrations/20260513120000_contractors.sql` en la base de datos que usa esta sesión local y recarga la app.
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+
+        {loading ? (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {[1, 2, 3].map((item) => (
+              <Card key={item} className="p-5">
+                <div className="h-4 w-2/3 rounded bg-[var(--color-paper-dark)]" />
+                <div className="mt-3 h-3 w-1/2 rounded bg-[var(--color-paper-dark)]" />
+                <div className="mt-5 h-3 w-1/3 rounded bg-[var(--color-paper-dark)]" />
+              </Card>
+            ))}
+          </div>
+        ) : filteredContractors.length === 0 ? (
+          <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-[var(--color-paper-mid)] bg-[var(--color-surface-alt)] px-4 py-14 text-center">
+            <Building2 size={36} className="text-[var(--color-ink-muted)]" />
+            <p className="mt-3 text-sm font-medium text-[var(--color-ink)]">
+              {search ? 'No hay contratantes que coincidan' : 'No hay contratantes todavía'}
+            </p>
+            <p className="mt-1 max-w-sm text-sm text-[var(--color-ink-muted)]">
+              {search
+                ? 'Ajusta la búsqueda para encontrar otro resultado.'
+                : 'Crea contratantes para reutilizarlos en proyectos y eventos sin repetir el cliente en cada trabajo.'}
+            </p>
+            {!search && (
+              <Button size="sm" onClick={openCreate} className="mt-4">
+                <Plus size={16} />
+                Crear contratante
+              </Button>
+            )}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {filteredContractors.map((contractor) => (
+              <ContractorCard
+                key={contractor.id}
+                contractor={contractor}
+                onEdit={openEdit}
+                onDelete={requestDelete}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <Modal isOpen={modalOpen} onClose={closeModal} title={editingContractor ? 'Editar contratante' : 'Nuevo contratante'}>
+        <ContractorForm
+          key={editingContractor?.id ?? 'new-contractor'}
+          initialData={editingContractor}
+          loading={saving}
+          onCancel={closeModal}
+          onSubmit={handleSubmit}
+        />
+      </Modal>
+
+      <ConfirmDialog
+        isOpen={Boolean(deleteConfirm)}
+        title={deleteConfirm?.title}
+        description={deleteConfirm?.description}
+        confirmLabel={deleteConfirm?.confirmLabel}
+        onCancel={() => setDeleteConfirm(null)}
+        onConfirm={deleteConfirm?.onConfirm}
+      />
+
+      <ToastContainer toasts={toasts} onRemove={removeToast} />
+    </PageWrapper>
+  )
+}

--- a/src/pages/Data/Data.jsx
+++ b/src/pages/Data/Data.jsx
@@ -6,32 +6,11 @@ import { Button } from '../../components/ui/Button'
 import { useToast, ToastContainer } from '../../components/ui/Toast'
 import { useAuth } from '../../hooks/useAuth'
 import { useDataPortability } from '../../hooks/useDataPortability'
+import { IMPORT_HEADERS } from '../../lib/portability/index.ts'
 
 const MAX_FILE_SIZE_BYTES = 1024 * 1024
 const MAX_ROWS = 500
-const importTemplateHeaders = [
-  'entity',
-  'project_key',
-  'event_key',
-  'concept',
-  'name',
-  'client',
-  'category',
-  'status',
-  'start_date',
-  'end_date',
-  'start_datetime',
-  'end_datetime',
-  'amount',
-  'tax_rate',
-  'expected_date',
-  'paid_date',
-  'is_paid',
-  'expense_date',
-  'is_deductible',
-  'color',
-  'notes',
-]
+const importTemplateHeaders = [...IMPORT_HEADERS]
 
 const exportActions = [
   {
@@ -93,8 +72,16 @@ function buildDownloadBlob(result, action) {
 function buildImportTemplateCsv() {
   const exampleRows = [
     {
+      entity: 'contractor',
+      contractor_key: 'contratante-1',
+      name: 'Ayuntamiento de ejemplo',
+      billing_name: 'Ayuntamiento de ejemplo',
+      tax_id: 'P0000000A',
+    },
+    {
       entity: 'project',
       project_key: 'proyecto-1',
+      contractor_key: 'contratante-1',
       name: 'Proyecto de ejemplo',
       category: 'otros',
       status: 'draft',
@@ -107,6 +94,7 @@ function buildImportTemplateCsv() {
       entity: 'event',
       project_key: 'proyecto-1',
       event_key: 'evento-1',
+      contractor_name: 'Sala de ejemplo',
       name: 'Evento de ejemplo',
       category: 'otros',
       status: 'draft',
@@ -167,7 +155,7 @@ function getValidationSummary(validation) {
     (total, value) => total + (Number.isFinite(value) ? value : 0),
     0,
   )
-  const entityValidRows = ['projects', 'events', 'incomes', 'expenses'].reduce((total, key) => {
+  const entityValidRows = ['contractors', 'projects', 'events', 'incomes', 'expenses'].reduce((total, key) => {
     const rows = validation?.[key]
     return total + (Array.isArray(rows) ? rows.length : 0)
   }, 0)
@@ -485,7 +473,7 @@ export default function Data() {
             <div className="rounded-lg border border-[var(--color-paper-mid)] bg-[#FDFBF6] px-4 py-3 text-sm text-[var(--color-ink-muted)]">
               <p className="font-medium text-[var(--color-ink)]">Formato esperado</p>
               <p className="mt-1">
-                Usa punto y coma, fechas `YYYY-MM-DD`, eventos como `YYYY-MM-DD HH:mm`, importes con coma o punto decimal y claves locales `project_key` / `event_key`. El CSV no puede traer `id`, `user_id`, `created_at`, `project_id` ni `event_id`.
+                Usa punto y coma, fechas `YYYY-MM-DD`, eventos como `YYYY-MM-DD HH:mm`, importes con coma o punto decimal y claves locales `contractor_key`, `project_key` y `event_key`. El CSV no puede traer `id`, `user_id`, `created_at`, `project_id`, `event_id` ni `contractor_id`.
               </p>
               <p className="mt-1">
                 Las filas se crean desde cero: no actualizan registros existentes y no son una restauración atómica.

--- a/src/pages/Events/EventDetail.jsx
+++ b/src/pages/Events/EventDetail.jsx
@@ -12,11 +12,13 @@ import { Input, Select } from '../../components/ui/Input'
 import { useToast, ToastContainer } from '../../components/ui/Toast'
 import { EventForm } from './EventForm'
 import { useAuth } from '../../hooks/useAuth'
+import { useContractors } from '../../hooks/useContractors'
 import { useProfile } from '../../hooks/useProfile'
 import { useEvents } from '../../hooks/useEvents'
 import { useProjects } from '../../hooks/useProjects'
 import { useIncomes } from '../../hooks/useIncomes'
 import { useExpenses } from '../../hooks/useExpenses'
+import { formatContractorDisplay, getEventContractor } from '../../lib/contractors'
 import { formatCurrency, formatCurrencyPerHour, formatDate, formatDatetime, formatHours } from '../../lib/formatters'
 import { normalizeExpenseForm, normalizeIncomeForm } from '../../lib/financeForms'
 import { formatDueDescription, formatDueText, getDueDays } from '../../lib/dueDates'
@@ -55,12 +57,14 @@ export default function EventDetail() {
   const { profile } = useProfile(user?.id)
   const { events, loading: eventsLoading, error: eventsError, updateEvent, deleteEvent } = useEvents(user?.id)
   const { projects } = useProjects(user?.id)
+  const { contractors, findOrCreateContractor } = useContractors(user?.id)
   const { incomes, loading: incomesLoading, createIncome, updateIncome, deleteIncome } = useIncomes(user?.id, { eventId: id })
   const { expenses, loading: expensesLoading, createExpense, updateExpense, deleteExpense } = useExpenses(user?.id, { eventId: id })
   const { toasts, addToast, removeToast } = useToast()
 
   const event = events.find((e) => e.id === id)
   const project = event?.project_id ? projects.find((p) => p.id === event.project_id) : null
+  const eventContractor = getEventContractor(event, projects, contractors)
 
   const [editModal, setEditModal] = useState(false)
   const [savingEvent, setSavingEvent] = useState(false)
@@ -419,8 +423,10 @@ export default function EventDetail() {
                   <h2 className="min-w-0 truncate text-lg font-semibold text-[var(--color-ink)]">{event.name}</h2>
                   <QuietStatusBadge status={event.status} />
                 </div>
-                {event.client && (
-                  <p className="mt-1 text-sm text-[var(--color-ink-muted)]">{event.client}</p>
+                {eventContractor && (
+                  <p className="mt-1 text-sm text-[var(--color-ink-muted)]">
+                    {formatContractorDisplay(eventContractor, { showInherited: true })}
+                  </p>
                 )}
                 <p className="mt-1 text-xs text-[var(--color-ink-muted)]">
                   {formatDatetime(event.start_datetime)}
@@ -751,6 +757,8 @@ export default function EventDetail() {
         <EventForm
           initialData={event}
           projects={projects}
+          contractors={contractors}
+          onCreateContractor={findOrCreateContractor}
           onSubmit={handleUpdateEvent}
           onCancel={() => setEditModal(false)}
           loading={savingEvent}

--- a/src/pages/Events/EventForm.jsx
+++ b/src/pages/Events/EventForm.jsx
@@ -1,13 +1,17 @@
 import { useState } from 'react'
 import { Button } from '../../components/ui/Button'
 import { Input, Select, Textarea } from '../../components/ui/Input'
+import { ContractorSelector, NEW_CONTRACTOR_VALUE } from '../../components/contractors/ContractorSelector'
 import { EVENT_STATUSES, EVENT_CATEGORIES, DEFAULT_PROJECT_COLORS } from '../../lib/constants'
 import { toDatetimeLocal } from '../../lib/formatters'
+import { formatContractorDisplay, getProjectContractor } from '../../lib/contractors'
 import { buildEventPayload } from '../../lib/eventPayload'
 
 const EMPTY_FORM = {
   name: '',
   client: '',
+  contractor_id: '',
+  new_contractor_name: '',
   category: 'otros',
   status: 'draft',
   project_id: '',
@@ -43,7 +47,7 @@ const getDefaultEndDatetime = (startDatetime, multiDay = false) => {
   return `${endDatePart}T${endHours}:${endMinutes}`
 }
 
-export function EventForm({ initialData, projects = [], onSubmit, onCancel, loading }) {
+export function EventForm({ initialData, projects = [], contractors = [], onCreateContractor, onSubmit, onCancel, loading }) {
   const initialStartDatetime = toDatetimeLocal(initialData?.start_datetime)
   const initialEndDatetime = toDatetimeLocal(initialData?.end_datetime)
   const [form, setForm] = useState({
@@ -51,12 +55,15 @@ export function EventForm({ initialData, projects = [], onSubmit, onCancel, load
     ...initialData,
     name: initialData?.name ?? '',
     client: initialData?.client ?? '',
+    contractor_id: initialData?.contractor_id ?? '',
+    new_contractor_name: '',
     start_datetime: initialStartDatetime,
     end_datetime: initialEndDatetime,
     project_id: initialData?.project_id ?? '',
     notes: initialData?.notes ?? '',
   })
   const [error, setError] = useState('')
+  const [submittingContractor, setSubmittingContractor] = useState(false)
   const [isMultiDay, setIsMultiDay] = useState(() => {
     if (!initialEndDatetime) return false
     const startDate = initialStartDatetime.split('T')[0]
@@ -71,6 +78,13 @@ export function EventForm({ initialData, projects = [], onSubmit, onCancel, load
 
       if (name === 'start_datetime' && !isMultiDay && value) {
         updated.end_datetime = getDefaultEndDatetime(value)
+      }
+
+      if (name === 'project_id') {
+        const previousProjectContractorId = projects.find((project) => project.id === prev.project_id)?.contractor_id
+        const nextProjectContractorId = projects.find((project) => project.id === value)?.contractor_id ?? ''
+        const shouldInheritNextProject = !prev.contractor_id || prev.contractor_id === previousProjectContractorId
+        if (shouldInheritNextProject) updated.contractor_id = nextProjectContractorId
       }
 
       return updated
@@ -95,7 +109,7 @@ export function EventForm({ initialData, projects = [], onSubmit, onCancel, load
     }
   }
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault()
     if (!form.name.trim()) {
       setError('Pon un nombre para identificar el evento.')
@@ -109,16 +123,47 @@ export function EventForm({ initialData, projects = [], onSubmit, onCancel, load
       setError('La fecha de fin no puede ser anterior al inicio.')
       return
     }
+
+    const selectedProject = form.project_id ? projects.find((project) => project.id === form.project_id) : null
+    let contractorId = form.contractor_id || selectedProject?.contractor_id || null
+    if (form.contractor_id === NEW_CONTRACTOR_VALUE) {
+      if (!form.new_contractor_name.trim()) {
+        setError('Pon un nombre para el contratante.')
+        return
+      }
+      if (!onCreateContractor) {
+        setError('No se ha podido crear el contratante.')
+        return
+      }
+      setSubmittingContractor(true)
+      const { data, error } = await onCreateContractor(form.new_contractor_name)
+      setSubmittingContractor(false)
+      if (error || !data?.id) {
+        setError('No se ha podido crear el contratante.')
+        return
+      }
+      contractorId = data.id
+    }
+
+    const formPayload = { ...form }
+    delete formPayload.new_contractor_name
     const payload = buildEventPayload({
-      ...form,
+      ...formPayload,
       name: form.name.trim(),
-      client: form.client.trim(),
+      client: form.client.trim() || null,
+      contractor_id: contractorId,
       project_id: form.project_id || null,
       end_datetime: form.end_datetime || null,
-      notes: form.notes.trim(),
+      notes: form.notes.trim() || null,
     })
-    onSubmit(payload)
+    await onSubmit(payload)
   }
+
+  const selectedProject = form.project_id ? projects.find((project) => project.id === form.project_id) : null
+  const inheritedContractor = getProjectContractor(selectedProject, contractors)
+  const inheritedLabel = inheritedContractor
+    ? `Heredar: ${formatContractorDisplay(inheritedContractor)}`
+    : ''
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
@@ -135,12 +180,15 @@ export function EventForm({ initialData, projects = [], onSubmit, onCancel, load
           placeholder="Concierto en el Auditorio"
           required
         />
-        <Input
-          label="Cliente o contratante"
-          name="client"
-          value={form.client}
+        <ContractorSelector
+          contractors={contractors}
+          value={form.contractor_id}
+          newName={form.new_contractor_name}
+          clientValue={form.client}
+          inheritedLabel={inheritedLabel}
           onChange={handleChange}
-          placeholder="Ayuntamiento de Madrid"
+          onNewNameChange={handleChange}
+          onClientChange={handleChange}
         />
 
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
@@ -239,8 +287,8 @@ export function EventForm({ initialData, projects = [], onSubmit, onCancel, load
         <Button type="button" variant="secondary" onClick={onCancel} className="justify-center">
           Cancelar
         </Button>
-        <Button type="submit" disabled={loading} className="justify-center">
-          {loading ? 'Guardando...' : 'Guardar evento'}
+        <Button type="submit" disabled={loading || submittingContractor} className="justify-center">
+          {loading || submittingContractor ? 'Guardando...' : 'Guardar evento'}
         </Button>
       </div>
     </form>

--- a/src/pages/Events/EventList.jsx
+++ b/src/pages/Events/EventList.jsx
@@ -10,8 +10,10 @@ import { Select } from '../../components/ui/Input'
 import { useToast, ToastContainer } from '../../components/ui/Toast'
 import { EventForm } from './EventForm'
 import { useAuth } from '../../hooks/useAuth'
+import { useContractors } from '../../hooks/useContractors'
 import { useEvents } from '../../hooks/useEvents'
 import { useProjects } from '../../hooks/useProjects'
+import { getEventContractor } from '../../lib/contractors'
 import { formatDatetime } from '../../lib/formatters'
 import { EVENT_STATUSES, EVENT_CATEGORIES } from '../../lib/constants'
 
@@ -19,6 +21,7 @@ export default function EventList() {
   const { user } = useAuth()
   const { events, loading, error, createEvent } = useEvents(user?.id)
   const { projects, loading: projectsLoading, error: projectsError } = useProjects(user?.id)
+  const { contractors, findOrCreateContractor } = useContractors(user?.id)
   const { toasts, addToast, removeToast } = useToast()
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
@@ -51,9 +54,11 @@ export default function EventList() {
   const filtered = events.filter((e) => {
     const query = search.trim().toLowerCase()
     const project = projectById[e.project_id]
+    const contractor = getEventContractor(e, projects, contractors)
     const matchesSearch = !query ||
       e.name.toLowerCase().includes(query) ||
       e.client?.toLowerCase().includes(query) ||
+      contractor?.name.toLowerCase().includes(query) ||
       project?.name.toLowerCase().includes(query)
 
     if (!matchesSearch) return false
@@ -277,6 +282,7 @@ export default function EventList() {
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
             {filtered.map((event) => {
               const project = projectById[event.project_id]
+              const contractor = getEventContractor(event, projects, contractors)
               return (
                 <Link key={event.id} to={`/events/${event.id}`} className="block min-w-0">
                   <Card className="p-5 h-full hover:shadow-md transition-shadow cursor-pointer">
@@ -292,8 +298,8 @@ export default function EventList() {
                             <StatusBadge status={event.status} />
                           </div>
                         </div>
-                        {event.client && (
-                          <p className="text-sm text-gray-500 mt-0.5 truncate">{event.client}</p>
+                        {contractor && (
+                          <p className="text-sm text-gray-500 mt-0.5 truncate">{contractor.name}</p>
                         )}
                         <div className="mt-4 flex flex-wrap items-center gap-2 text-xs">
                           <span className="rounded-full bg-gray-100 px-2.5 py-1 font-medium text-gray-600">
@@ -318,6 +324,8 @@ export default function EventList() {
         <EventForm
           initialData={createFromProject ? { project_id: projectParam } : undefined}
           projects={projects}
+          contractors={contractors}
+          onCreateContractor={findOrCreateContractor}
           onSubmit={handleCreate}
           onCancel={closeCreateModal}
           loading={saving}

--- a/src/pages/Projects/ProjectDetail.jsx
+++ b/src/pages/Projects/ProjectDetail.jsx
@@ -12,11 +12,13 @@ import { Input, Select } from '../../components/ui/Input'
 import { useToast, ToastContainer } from '../../components/ui/Toast'
 import { ProjectForm } from './ProjectForm'
 import { useAuth } from '../../hooks/useAuth'
+import { useContractors } from '../../hooks/useContractors'
 import { useProfile } from '../../hooks/useProfile'
 import { useProjects } from '../../hooks/useProjects'
 import { useEvents } from '../../hooks/useEvents'
 import { useIncomes } from '../../hooks/useIncomes'
 import { useExpenses } from '../../hooks/useExpenses'
+import { getEventContractor, getProjectContractor } from '../../lib/contractors'
 import { formatCurrency, formatCurrencyPerHour, formatDate, formatDatetime, formatHours } from '../../lib/formatters'
 import { normalizeExpenseForm, normalizeIncomeForm } from '../../lib/financeForms'
 import { formatDueDescription, formatDueText, getDueDays } from '../../lib/dueDates'
@@ -53,6 +55,7 @@ export default function ProjectDetail() {
   const { user } = useAuth()
   const { profile } = useProfile(user?.id)
   const { projects, loading: projectsLoading, error: projectsError, updateProject, deleteProject } = useProjects(user?.id)
+  const { contractors, findOrCreateContractor } = useContractors(user?.id)
   const { events, loading: eventsLoading } = useEvents(user?.id, id)
   const eventIds = useMemo(() => events.map((e) => e.id), [events])
   const { incomes, loading: incomesLoading, createIncome, updateIncome, deleteIncome } = useIncomes(user?.id, { projectId: id, eventIds })
@@ -60,6 +63,7 @@ export default function ProjectDetail() {
   const { toasts, addToast, removeToast } = useToast()
 
   const project = projects.find((p) => p.id === id)
+  const projectContractor = getProjectContractor(project, contractors)
 
   const [editModal, setEditModal] = useState(false)
   const [savingProject, setSavingProject] = useState(false)
@@ -421,8 +425,8 @@ export default function ProjectDetail() {
                   <h2 className="min-w-0 truncate text-lg font-semibold text-[var(--color-ink)]">{project.name}</h2>
                   <QuietStatusBadge status={project.status} />
                 </div>
-                {project.client && (
-                  <p className="mt-1 text-sm text-[var(--color-ink-muted)]">{project.client}</p>
+                {projectContractor && (
+                  <p className="mt-1 text-sm text-[var(--color-ink-muted)]">{projectContractor.name}</p>
                 )}
                 <p className="mt-1 text-xs text-[var(--color-ink-muted)]">
                   {project.category} · {formatDate(project.start_date)}{project.end_date && ` – ${formatDate(project.end_date)}`}
@@ -528,6 +532,9 @@ export default function ProjectDetail() {
           ) : (
             <div className="flex flex-col gap-2">
               {events.map((event) => (
+                (() => {
+                  const eventContractor = getEventContractor(event, projects, contractors)
+                  return (
                 <Link
                   key={event.id}
                   to={`/events/${event.id}`}
@@ -537,11 +544,16 @@ export default function ProjectDetail() {
                     <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: event.color ?? '#4f98a3' }} />
                     <div className="min-w-0">
                       <p className="truncate text-sm font-medium text-gray-900">{event.name}</p>
-                      <p className="text-xs text-gray-400">{formatDatetime(event.start_datetime)}</p>
+                      <p className="text-xs text-gray-400">
+                        {formatDatetime(event.start_datetime)}
+                        {eventContractor ? ` · ${eventContractor.name}` : ''}
+                      </p>
                     </div>
                   </div>
                   <QuietStatusBadge status={event.status} />
                 </Link>
+                  )
+                })()
               ))}
             </div>
           )}
@@ -758,7 +770,14 @@ export default function ProjectDetail() {
       </div>
 
       <Modal isOpen={editModal} onClose={() => setEditModal(false)} title="Editar proyecto">
-        <ProjectForm initialData={project} onSubmit={handleUpdateProject} onCancel={() => setEditModal(false)} loading={savingProject} />
+        <ProjectForm
+          initialData={project}
+          contractors={contractors}
+          onCreateContractor={findOrCreateContractor}
+          onSubmit={handleUpdateProject}
+          onCancel={() => setEditModal(false)}
+          loading={savingProject}
+        />
       </Modal>
 
       <Modal isOpen={incomeModal} onClose={() => setIncomeModal(false)} title={editingIncome ? 'Editar ingreso' : 'Añadir ingreso'}>

--- a/src/pages/Projects/ProjectForm.jsx
+++ b/src/pages/Projects/ProjectForm.jsx
@@ -1,11 +1,14 @@
 import { useState } from 'react'
 import { Button } from '../../components/ui/Button'
 import { Input, Select, Textarea } from '../../components/ui/Input'
+import { ContractorSelector, NEW_CONTRACTOR_VALUE } from '../../components/contractors/ContractorSelector'
 import { PROJECT_STATUSES, PROJECT_CATEGORIES, DEFAULT_PROJECT_COLORS } from '../../lib/constants'
 
 const EMPTY_FORM = {
   name: '',
   client: '',
+  contractor_id: '',
+  new_contractor_name: '',
   category: 'otros',
   status: 'draft',
   start_date: '',
@@ -14,16 +17,19 @@ const EMPTY_FORM = {
   notes: '',
 }
 
-export function ProjectForm({ initialData, onSubmit, onCancel, loading }) {
+export function ProjectForm({ initialData, contractors = [], onCreateContractor, onSubmit, onCancel, loading }) {
   const [form, setForm] = useState({
     ...EMPTY_FORM,
     ...initialData,
     name: initialData?.name ?? '',
     client: initialData?.client ?? '',
+    contractor_id: initialData?.contractor_id ?? '',
+    new_contractor_name: '',
     end_date: initialData?.end_date ?? '',
     notes: initialData?.notes ?? '',
   })
   const [error, setError] = useState('')
+  const [submittingContractor, setSubmittingContractor] = useState(false)
 
   const handleChange = (e) => {
     const { name, value } = e.target
@@ -31,7 +37,7 @@ export function ProjectForm({ initialData, onSubmit, onCancel, loading }) {
     setError('')
   }
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault()
     if (!form.name.trim()) {
       setError('Pon un nombre para identificar el proyecto.')
@@ -45,12 +51,36 @@ export function ProjectForm({ initialData, onSubmit, onCancel, loading }) {
       setError('La fecha de fin no puede ser anterior a la de inicio.')
       return
     }
-    onSubmit({
-      ...form,
+
+    let contractorId = form.contractor_id || null
+    if (form.contractor_id === NEW_CONTRACTOR_VALUE) {
+      if (!form.new_contractor_name.trim()) {
+        setError('Pon un nombre para el contratante.')
+        return
+      }
+      if (!onCreateContractor) {
+        setError('No se ha podido crear el contratante.')
+        return
+      }
+      setSubmittingContractor(true)
+      const { data, error } = await onCreateContractor(form.new_contractor_name)
+      setSubmittingContractor(false)
+      if (error || !data?.id) {
+        setError('No se ha podido crear el contratante.')
+        return
+      }
+      contractorId = data.id
+    }
+
+    const payload = { ...form }
+    delete payload.new_contractor_name
+    await onSubmit({
+      ...payload,
       name: form.name.trim(),
-      client: form.client.trim(),
+      client: form.client.trim() || null,
+      contractor_id: contractorId,
       end_date: form.end_date || null,
-      notes: form.notes.trim(),
+      notes: form.notes.trim() || null,
     })
   }
 
@@ -69,12 +99,14 @@ export function ProjectForm({ initialData, onSubmit, onCancel, loading }) {
           placeholder="Concierto de primavera"
           required
         />
-        <Input
-          label="Cliente o contratante"
-          name="client"
-          value={form.client}
+        <ContractorSelector
+          contractors={contractors}
+          value={form.contractor_id}
+          newName={form.new_contractor_name}
+          clientValue={form.client}
           onChange={handleChange}
-          placeholder="Ayuntamiento de Madrid"
+          onNewNameChange={handleChange}
+          onClientChange={handleChange}
         />
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <Select label="Categoría" name="category" value={form.category} onChange={handleChange}>
@@ -150,8 +182,8 @@ export function ProjectForm({ initialData, onSubmit, onCancel, loading }) {
         <Button type="button" variant="secondary" onClick={onCancel} className="justify-center">
           Cancelar
         </Button>
-        <Button type="submit" disabled={loading} className="justify-center">
-          {loading ? 'Guardando...' : 'Guardar proyecto'}
+        <Button type="submit" disabled={loading || submittingContractor} className="justify-center">
+          {loading || submittingContractor ? 'Guardando...' : 'Guardar proyecto'}
         </Button>
       </div>
     </form>

--- a/src/pages/Projects/ProjectList.jsx
+++ b/src/pages/Projects/ProjectList.jsx
@@ -10,13 +10,16 @@ import { Select } from '../../components/ui/Input'
 import { useToast, ToastContainer } from '../../components/ui/Toast'
 import { ProjectForm } from './ProjectForm'
 import { useAuth } from '../../hooks/useAuth'
+import { useContractors } from '../../hooks/useContractors'
 import { useProjects } from '../../hooks/useProjects'
+import { getProjectContractor } from '../../lib/contractors'
 import { formatDate } from '../../lib/formatters'
 import { PROJECT_STATUSES, PROJECT_CATEGORIES } from '../../lib/constants'
 
 export default function ProjectList() {
   const { user } = useAuth()
   const { projects, loading, error, createProject } = useProjects(user?.id)
+  const { contractors, findOrCreateContractor } = useContractors(user?.id)
   const { toasts, addToast, removeToast } = useToast()
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -29,9 +32,11 @@ export default function ProjectList() {
 
   const filtered = projects.filter((p) => {
     const query = search.trim().toLowerCase()
+    const contractor = getProjectContractor(p, contractors)
     const matchesSearch = !query ||
       p.name.toLowerCase().includes(query) ||
-      p.client?.toLowerCase().includes(query)
+      p.client?.toLowerCase().includes(query) ||
+      contractor?.name.toLowerCase().includes(query)
 
     if (!matchesSearch) return false
     if (filterStatus && p.status !== filterStatus) return false
@@ -155,6 +160,9 @@ export default function ProjectList() {
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
             {filtered.map((project) => (
+              (() => {
+                const contractor = getProjectContractor(project, contractors)
+                return (
               <Link key={project.id} to={`/projects/${project.id}`} className="block min-w-0">
                 <Card className="p-5 h-full hover:shadow-md transition-shadow cursor-pointer">
                   <div className="flex items-start gap-3 min-w-0">
@@ -169,8 +177,8 @@ export default function ProjectList() {
                           <StatusBadge status={project.status} />
                         </div>
                       </div>
-                      {project.client && (
-                        <p className="text-sm text-gray-500 mt-0.5 truncate">{project.client}</p>
+                      {contractor && (
+                        <p className="text-sm text-gray-500 mt-0.5 truncate">{contractor.name}</p>
                       )}
                       <div className="mt-4 flex flex-wrap items-center gap-2 text-xs">
                         <span className="rounded-full bg-gray-100 px-2.5 py-1 font-medium text-gray-600">
@@ -185,6 +193,8 @@ export default function ProjectList() {
                   </div>
                 </Card>
               </Link>
+                )
+              })()
             ))}
           </div>
         )}
@@ -192,6 +202,8 @@ export default function ProjectList() {
 
       <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} title="Nuevo proyecto">
         <ProjectForm
+          contractors={contractors}
+          onCreateContractor={findOrCreateContractor}
           onSubmit={handleCreate}
           onCancel={() => setIsModalOpen(false)}
           loading={saving}

--- a/src/pages/Work/Work.jsx
+++ b/src/pages/Work/Work.jsx
@@ -1,12 +1,14 @@
 import { useMemo } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
-import { Briefcase, CalendarDays, ChevronRight, FolderOpen, Plus, Ticket } from 'lucide-react'
+import { Briefcase, Building2, CalendarDays, ChevronRight, FolderOpen, Plus, Ticket } from 'lucide-react'
 import { PageWrapper } from '../../components/layout/PageWrapper'
 import { Card } from '../../components/ui/Card'
 import { StatusBadge } from '../../components/ui/Badge'
 import { useAuth } from '../../hooks/useAuth'
+import { useContractors } from '../../hooks/useContractors'
 import { useProjects } from '../../hooks/useProjects'
 import { useEvents } from '../../hooks/useEvents'
+import { getEventContractor, getProjectContractor } from '../../lib/contractors'
 import { formatDateRange, formatDatetime } from '../../lib/formatters'
 
 const views = [
@@ -23,7 +25,9 @@ function QuietStatusBadge({ status }) {
   return <StatusBadge status={status} />
 }
 
-function EventRow({ event, compact = false }) {
+function EventRow({ event, projects = [], contractors = [], compact = false }) {
+  const contractor = getEventContractor(event, projects, contractors)
+
   return (
     <Link
       to={`/events/${event.id}`}
@@ -39,7 +43,7 @@ function EventRow({ event, compact = false }) {
         </span>
         <span className="mt-0.5 block truncate text-xs text-[#5C5149]">
           {formatDatetime(event.start_datetime)}
-          {event.client ? ` · ${event.client}` : ''}
+          {contractor ? ` · ${contractor.name}` : ''}
         </span>
       </span>
       <ChevronRight size={16} className="shrink-0 text-[#8A7A6D] transition-transform group-hover:translate-x-0.5" />
@@ -47,7 +51,9 @@ function EventRow({ event, compact = false }) {
   )
 }
 
-function ProjectBlock({ project, events }) {
+function ProjectBlock({ project, events, allProjects = [], contractors = [] }) {
+  const contractor = getProjectContractor(project, contractors)
+
   return (
     <Card className="overflow-hidden">
       <div className="flex flex-col gap-4 p-4 sm:p-5">
@@ -68,7 +74,7 @@ function ProjectBlock({ project, events }) {
               <QuietStatusBadge status={project.status} />
             </div>
             <p className="mt-1 truncate text-sm text-[#5C5149]">
-              {project.client ? `${project.client} · ` : ''}
+              {contractor ? `${contractor.name} · ` : ''}
               {formatDateRange(project.start_date, project.end_date)}
             </p>
           </div>
@@ -84,7 +90,7 @@ function ProjectBlock({ project, events }) {
         {events.length > 0 ? (
           <div className="grid gap-2">
             {events.map((event) => (
-              <EventRow key={event.id} event={event} compact />
+              <EventRow key={event.id} event={event} projects={allProjects} contractors={contractors} compact />
             ))}
           </div>
         ) : (
@@ -101,6 +107,7 @@ export default function Work() {
   const { user } = useAuth()
   const { projects, loading: projectsLoading, error: projectsError } = useProjects(user?.id)
   const { events, loading: eventsLoading, error: eventsError } = useEvents(user?.id)
+  const { contractors, loading: contractorsLoading, error: contractorsError, schemaReady: contractorsSchemaReady } = useContractors(user?.id)
   const [searchParams, setSearchParams] = useSearchParams()
 
   const currentView = views.some((view) => view.value === searchParams.get('view'))
@@ -124,8 +131,8 @@ export default function Work() {
     [events, projectIds]
   )
 
-  const loading = projectsLoading || eventsLoading
-  const error = projectsError || eventsError
+  const loading = projectsLoading || eventsLoading || contractorsLoading
+  const error = projectsError || eventsError || (contractorsSchemaReady ? contractorsError : null)
   const showProjects = currentView === 'all' || currentView === 'projects'
   const showEvents = currentView === 'all' || currentView === 'events'
   const visibleProjectCount = showProjects ? projects.length : 0
@@ -156,6 +163,10 @@ export default function Work() {
             <Link to="/events" className={linkButtonClass}>
               <Plus size={16} />
               Evento
+            </Link>
+            <Link to="/contractors" className={secondaryLinkButtonClass}>
+              <Building2 size={16} />
+              Contratantes
             </Link>
           </div>
         </div>
@@ -238,6 +249,8 @@ export default function Work() {
                       key={project.id}
                       project={project}
                       events={eventsByProject.get(project.id) ?? []}
+                      allProjects={projects}
+                      contractors={contractors}
                     />
                   ))}
                 </div>
@@ -251,7 +264,7 @@ export default function Work() {
                 </h2>
                 <div className="grid gap-2 xl:grid-cols-2">
                   {standaloneEvents.map((event) => (
-                    <EventRow key={event.id} event={event} />
+                    <EventRow key={event.id} event={event} projects={projects} contractors={contractors} />
                   ))}
                 </div>
               </section>

--- a/supabase/migrations/20260513120000_contractors.sql
+++ b/supabase/migrations/20260513120000_contractors.sql
@@ -1,0 +1,103 @@
+create table public.contractors (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  name text not null,
+  billing_name text,
+  tax_id text,
+  email text,
+  phone text,
+  billing_address text,
+  notes text,
+  created_at timestamptz default now(),
+  constraint contractors_name_not_blank check (btrim(name) <> '')
+);
+
+alter table public.projects
+  add column contractor_id uuid references public.contractors(id) on delete set null;
+
+alter table public.events
+  add column contractor_id uuid references public.contractors(id) on delete set null;
+
+alter table public.contractors
+  add constraint contractors_id_user_id_key unique (id, user_id);
+
+alter table public.projects
+  add constraint projects_contractor_user_fkey
+  foreign key (contractor_id, user_id)
+  references public.contractors(id, user_id)
+  on delete set null (contractor_id);
+
+alter table public.events
+  add constraint events_contractor_user_fkey
+  foreign key (contractor_id, user_id)
+  references public.contractors(id, user_id)
+  on delete set null (contractor_id);
+
+create unique index contractors_user_normalized_name_key
+  on public.contractors (
+    user_id,
+    lower(regexp_replace(btrim(name), '\s+', ' ', 'g'))
+  );
+
+create index projects_contractor_id_idx on public.projects(contractor_id);
+create index events_contractor_id_idx on public.events(contractor_id);
+
+alter table public.contractors enable row level security;
+
+create policy "contractors: usuario propio" on public.contractors
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+with source_contractors as (
+  select
+    user_id,
+    min(name) as name,
+    lower(regexp_replace(btrim(name), '\s+', ' ', 'g')) as normalized_name
+  from (
+    select user_id, nullif(btrim(client), '') as name
+    from public.projects
+    where client is not null and btrim(client) <> ''
+    union all
+    select user_id, nullif(btrim(client), '') as name
+    from public.events
+    where client is not null and btrim(client) <> ''
+  ) source
+  where name is not null
+  group by user_id, lower(regexp_replace(btrim(name), '\s+', ' ', 'g'))
+)
+insert into public.contractors (user_id, name)
+select user_id, name
+from source_contractors
+on conflict do nothing;
+
+update public.projects project
+set contractor_id = contractor.id
+from public.contractors contractor
+where project.contractor_id is null
+  and project.client is not null
+  and btrim(project.client) <> ''
+  and project.user_id = contractor.user_id
+  and lower(regexp_replace(btrim(project.client), '\s+', ' ', 'g')) =
+    lower(regexp_replace(btrim(contractor.name), '\s+', ' ', 'g'));
+
+update public.events event
+set contractor_id = project.contractor_id
+from public.projects project
+where event.contractor_id is null
+  and event.project_id = project.id
+  and event.user_id = project.user_id
+  and project.contractor_id is not null;
+
+update public.events event
+set contractor_id = contractor.id
+from public.contractors contractor
+where event.contractor_id is null
+  and event.client is not null
+  and btrim(event.client) <> ''
+  and event.user_id = contractor.user_id
+  and lower(regexp_replace(btrim(event.client), '\s+', ' ', 'g')) =
+    lower(regexp_replace(btrim(contractor.name), '\s+', ' ', 'g'));
+
+comment on table public.contractors is
+  'Reusable structured contractors for beta 19. Legacy projects.client and events.client remain as fallback text.';


### PR DESCRIPTION
## Summary

Cierra RELEASE-0.1.0-beta.19 con contratantes estructurados como primer slice seguro de CACH-B0004.

Incluye:
- tabla `contractors`, RLS y backfill desde `client` legacy;
- `contractor_id` opcional en proyectos y eventos;
- herencia persistida proyecto -> evento;
- hook `useContractors`, selector, `/contractors` y creación inline;
- export/import de contratantes con compatibilidad legacy;
- Product Brain de beta 19 cerrado.

## Product Brain

- Release: `RELEASE-0.1.0-beta.19`
- Issues: `CACH-0057`, `CACH-0058`, `CACH-0059`, `CACH-0060`, `CACH-0061`
- Parent: `CACH-B0004`

## Validation

- [x] `npm run verify:pr -- --base origin/main`
- [x] `npm run pb:guard`
- [x] `npm run release:sync-check` antes del cierre documental
- [x] Supabase remoto verificado con SQL read-only: tabla, columnas, RLS, policy y backfill
- [x] `npx supabase migration repair 20260513120000 --status applied --linked`
- [x] Smoke manual autenticado confirmado: `/work`, `/contractors` y herencia contratante proyecto -> evento

## Deploy

Producción requiere merge a `main`, tag `v0.1.0-beta.19` y smoke posterior sobre `https://app.caches.es`.

## Memory

Memoria: actualizada. Se añadió guardrail para migraciones manuales SQL Editor + `migration repair`, y regla de learning loop en cierre.