### PR TITLE
docs(CACH-0063): cerrar beta 20

### DIFF
--- a/docs/project/DIGEST.md
+++ b/docs/project/DIGEST.md
@@ -23,7 +23,7 @@ Resumen determinista generado desde Product Brain v2.
 
 ## Estado operacional
 
-- **Release activa:** RELEASE-0.1.0-beta.20 — Hardening UX móvil financiera
+- **Release activa:** No hay release activa en este momento.
 - **Últimos cortes:** `RELEASE-0.1.0-beta.10` — emails transaccionales beta con Brevo. Ver RELEASE-0.1.0-beta.10.
 
 `RELEASE-0.1.0-beta.12` — pulido proyecto-evento y borrados seguros. Ver RELEASE-0.1.0-beta.12.
@@ -41,15 +41,16 @@ Resumen determinista generado desde Product Brain v2.
 `RELEASE-0.1.0-beta.18` — cierre P1 UX core. Ver RELEASE-0.1.0-beta.18.
 
 `RELEASE-0.1.0-beta.19` — contratantes estructurados. Ver RELEASE-0.1.0-beta.19.
-- **Foco:** `RELEASE-0.1.0-beta.20` queda abierta como hardening UX móvil financiera antes de abrir liquidación neta o facturación completa. El scope es `CACH-0063`: unificar la barra contextual de detalles de proyecto y evento sin tocar fórmulas, schema, RLS ni semántica financiera.
+
+`RELEASE-0.1.0-beta.20` — hardening UX móvil financiera. Ver RELEASE-0.1.0-beta.20.
+- **Foco:** Beta 20 queda cerrada. El foco vuelve a evaluar el siguiente corte del ciclo `0.1` sin absorber tareas nuevas por defecto: o bien abrir una nueva beta para `CACH-B0004`, o mantener un corte pequeño de hardening si el feedback privado lo pide.
 
 ## Prioridades del plan
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
 2. Mantener el feedback beta simple antes de introducir analitica de producto.
 3. No introducir PostHog, Plausible ni analitica de eventos sin issue/ADR posterior.
-4. En beta 20, mantener el alcance limitado a `CACH-0063`; cualquier cambio de datos o fórmula queda fuera.
-5. No abrir liquidacion neta, facturacion completa ni CRM salvo issue nueva con criterios de datos/RLS.
+4. No abrir liquidacion neta, facturacion completa ni CRM salvo issue nueva con criterios de datos/RLS.
 
 ## Tablero
 
@@ -115,4 +116,4 @@ _Sin entradas._
 
 ## Próxima acción
 
-Implementar `CACH-0063` desde `release/0.1.0-beta.20`, validar responsive en detalles de proyecto/evento y cerrar la release mediante PR única a `main`.
+Decidir si el próximo corte es `CACH-B0004` liquidación neta gasto-ingreso o un hardening pequeño derivado del feedback beta.

--- a/docs/project/plans/CURRENT_PLAN.md
+++ b/docs/project/plans/CURRENT_PLAN.md
@@ -18,11 +18,11 @@ generated: false
 
 ## Foco actual
 
-`RELEASE-0.1.0-beta.20` queda abierta como hardening UX móvil financiera antes de abrir liquidación neta o facturación completa. El scope es `CACH-0063`: unificar la barra contextual de detalles de proyecto y evento sin tocar fórmulas, schema, RLS ni semántica financiera.
+Beta 20 queda cerrada. El foco vuelve a evaluar el siguiente corte del ciclo `0.1` sin absorber tareas nuevas por defecto: o bien abrir una nueva beta para `CACH-B0004`, o mantener un corte pequeño de hardening si el feedback privado lo pide.
 
 ## Release activa
 
-[[../releases/RELEASE-0.1.0-beta.20|RELEASE-0.1.0-beta.20]] — hardening UX móvil financiera.
+No hay release activa en este momento.
 
 Últimos cortes:
 
@@ -46,14 +46,14 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 - Beta 17 cierra `CACH-0052`: feedback simple propio en Supabase y PostHog diferido.
 - Beta 18 cierra `CACH-0054`, `CACH-0055` y `CACH-0056`: notas contextuales, quick forms financieros y calendario de eventos separado del plan anual.
 - Beta 19 cierra el primer corte de `CACH-B0004`: contratantes estructurados, schema/RLS, hooks, portabilidad, UX mínima y regresión financiera.
+- Beta 20 cierra `CACH-0063`: `BottomActionBar` compartido en detalles de proyecto y evento.
 
 ## Prioridades
 
 1. Mantener el ciclo `0.1` enfocado en confianza, portabilidad y primera sesion.
 2. Mantener el feedback beta simple antes de introducir analitica de producto.
 3. No introducir PostHog, Plausible ni analitica de eventos sin issue/ADR posterior.
-4. En beta 20, mantener el alcance limitado a `CACH-0063`; cualquier cambio de datos o fórmula queda fuera.
-5. No abrir liquidacion neta, facturacion completa ni CRM salvo issue nueva con criterios de datos/RLS.
+4. No abrir liquidacion neta, facturacion completa ni CRM salvo issue nueva con criterios de datos/RLS.
 
 ## Plan operativo
 
@@ -66,7 +66,7 @@ Beta 13: [[../releases/RELEASE-0.1.0-beta.13|RELEASE-0.1.0-beta.13]] — dashboa
 
 ## Próximo checkpoint
 
-Implementar `CACH-0063` desde `release/0.1.0-beta.20`, validar responsive en detalles de proyecto/evento y cerrar la release mediante PR única a `main`.
+Decidir si el próximo corte es `CACH-B0004` liquidación neta gasto-ingreso o un hardening pequeño derivado del feedback beta.
 
 ## Siguiente release candidata
 

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -19,11 +19,11 @@ release_current: true
 
 ## Release activa
 
-`RELEASE-0.1.0-beta.20` — hardening UX móvil financiera. Ver [[RELEASE-0.1.0-beta.20]].
+No hay release activa en este momento.
 
 ## Rama activa
 
-`release/0.1.0-beta.20`
+No aplica. Las siguientes tareas pequeñas salen de `main` salvo que se abra una nueva release.
 
 ## Últimos cortes
 
@@ -45,18 +45,20 @@ release_current: true
 
 `RELEASE-0.1.0-beta.19` — contratantes estructurados. Ver [[RELEASE-0.1.0-beta.19]].
 
+`RELEASE-0.1.0-beta.20` — hardening UX móvil financiera. Ver [[RELEASE-0.1.0-beta.20]].
+
 ## Scope actual
 
-Hardening pequeño antes de abrir liquidación neta o facturación completa. El corte se limita a consolidar la deuda residual de `CACH-B0002`: un patrón compartido de barra contextual móvil en detalles de proyecto y evento.
+Sin scope activo. Beta 20 quedó cerrada con `CACH-0063`: patrón compartido de barra contextual móvil en detalles de proyecto y evento.
 
 Issues incluidas:
 
-- [[../issues/CACH-0063|CACH-0063]] — Unificar BottomActionBar en detalles.
+- No aplica hasta abrir nueva release.
 
 ## Regla de trabajo para esta release
 
-Las ramas de tarea salen de `release/0.1.0-beta.20`. No tocar fórmulas financieras, hooks públicos, schema, RLS, Supabase remoto, liquidación neta, facturación ni CRM. La verificación visual debe cubrir `/events/:id` y `/projects/:id` en 320 px, 390 px, 768 px y desktop.
+No hay release activa. Las tareas fuera de release usan el flujo ligero desde `main`; si se abre una nueva beta, documentar primero release, scope, rama y criterios.
 
 ## Como cerrar esta release
 
-Beta 20 se cierra mediante PR única `release/0.1.0-beta.20` -> `main`, CI verde, `npm run lint`, `npm run build`, `npm run pb:guard`, `npm run release:sync-check` y smoke visual de los detalles afectados.
+Beta 20 ya está cerrada mediante PR #106, CI verde, tag `v0.1.0-beta.20` y smoke postdeploy básico de rutas SPA.

--- a/docs/project/releases/RELEASE-0.1.0-beta.20.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.20.md
@@ -16,17 +16,17 @@ tags:
   - mobile
   - finance
 generated: false
-release_phase: active
-release_current: true
+release_phase: released
+release_current: false
 release_branch: release/0.1.0-beta.20
-release_tag: null
-release_pr: null
+release_tag: v0.1.0-beta.20
+release_pr: https://github.com/dignacioconde/culturApp/pull/106
 ---
 # RELEASE-0.1.0-beta.20 — Hardening UX móvil financiera
 
 ## Estado
 
-Active.
+Released.
 
 ## Rama de release
 
@@ -106,18 +106,18 @@ Cerrar la deuda residual de UX móvil financiera consolidada en `CACH-B0002`: un
 
 ## Checklist de salida
 
-- [ ] PR `release/0.1.0-beta.20` -> `main` abierta
-- [ ] CI en verde
-- [ ] PR mergeada en `main`
-- [ ] Tag creado desde `main` si aplica
-- [ ] Produccion verificada o marcada no aplica
-- [ ] Rama remota `release/0.1.0-beta.20` eliminada si aplica
-- [ ] Release notes actualizadas
-- [ ] Issues marcadas como `done`
-- [ ] Estado actual actualizado
-- [ ] Current Release actualizado
-- [ ] Backlog actualizado
-- [ ] Proximos pasos documentados
+- [x] PR `release/0.1.0-beta.20` -> `main` abierta
+- [x] CI en verde
+- [x] PR mergeada en `main`
+- [x] Tag creado desde `main` si aplica
+- [x] Produccion verificada o marcada no aplica
+- [x] Rama remota `release/0.1.0-beta.20` eliminada si aplica
+- [x] Release notes actualizadas
+- [x] Issues marcadas como `done`
+- [x] Estado actual actualizado
+- [x] Current Release actualizado
+- [x] Backlog actualizado
+- [x] Proximos pasos documentados
 
 ## Release notes
 
@@ -144,4 +144,4 @@ Cerrar la deuda residual de UX móvil financiera consolidada en `CACH-B0002`: un
 
 ## Resultado final
 
-Implementación integrada y validada localmente en la rama `release/0.1.0-beta.20`. Pendiente PR a `main`, CI, merge, tag si aplica y verificación de producción.
+Release cerrada mediante PR #106 a `main`. Tag `v0.1.0-beta.20` preparado desde `main`; produccion verificada en `https://app.caches.es` con smoke de rutas SPA. Auth/CRUD smoke queda fuera del script al no haber credenciales `SMOKE_EMAIL`/`SMOKE_PASSWORD`.


### PR DESCRIPTION
## Qué cambia

- Marca `RELEASE-0.1.0-beta.20` como released.
- Actualiza Current Release sin release activa.
- Actualiza Current Plan tras cerrar beta 20.
- Regenera `DIGEST.md`.

## Validación

- `npm run pb:guard`
- `git diff --check`
- Smoke postdeploy previo sobre `https://app.caches.es` OK para `/`, `/login`, `/dashboard`, `/work` y `/calendar/events`.

## Memoria

Memoria: no aplica.