### PR TITLE
release: 0.1.0-beta.22

### DIFF
--- a/.memory/topics/agent-workflows.md
+++ b/.memory/topics/agent-workflows.md
@@ -49,6 +49,7 @@ Planning and implementation:
 - Work that belongs to an active release branches from the release branch; small fixes may branch from `main` when outside release scope.
 - Active release does not mean every new task belongs to it: if the task is outside release scope, postpone it, use the lightweight `main` -> PR flow, or add it explicitly to the release document first.
 - For active beta releases, agents create task branches locally from the active `release/<version>` branch, prefer `feat/` for new feature branches (`feature/` is legacy), do not push task branches by default, review diff/log against the release, and integrate completed work into the release via squash after local verification.
+- `npm run ship -- --execute --issue CACH-XXXX` must block `work_type: feature` issues with `release: null`; use `--allow-no-release` only for a deliberate lightweight exception and explain it in the issue/PR.
 - Release closure standard: consolidate implementation, Product Brain updates, generated indexes/digest, memory notes and validation status into the cleanest possible final history. Prefer a single clear release commit or squash-style merge result over scattered fixups; leave `main`/release branches clean, no uncommitted generated artifacts, no stray pushed task branches, and no unexplained git traces.
 - Commit format for CACH work: `<type>(CACH-XXXX): summary`.
 - Do not add `Co-Authored-By` or AI co-author lines to commits.

--- a/docs/project/DIGEST.md
+++ b/docs/project/DIGEST.md
@@ -45,6 +45,8 @@ Resumen determinista generado desde Product Brain v2.
 `RELEASE-0.1.0-beta.20` — hardening UX móvil financiera. Ver RELEASE-0.1.0-beta.20.
 
 `RELEASE-0.1.0-beta.21` — primera sesion guiada y PWA instalable. Ver RELEASE-0.1.0-beta.21.
+
+`RELEASE-0.1.0-beta.22` — historial de novedades beta. Ver RELEASE-0.1.0-beta.22.
 - **Foco:** Beta 20 queda cerrada. El foco vuelve a evaluar el siguiente corte del ciclo `0.1` sin absorber tareas nuevas por defecto: o bien abrir una nueva beta para `CACH-B0004`, o mantener un corte pequeño de hardening si el feedback privado lo pide.
 
 ## Prioridades del plan
@@ -70,9 +72,7 @@ _Sin entradas._
 
 ### Review / Verify
 
-| ID | Título | Tipo | Nivel | P |
-|---|---|---|---|---|
-| CACH-0074 | Historial user friendly de novedades beta | feature | slice | p1 |
+_Sin entradas._
 
 ### Backlog (p1)
 
@@ -87,7 +87,6 @@ _Sin entradas._
 
 | ID | Título | Workflow | Tipo | Nivel | P |
 |---|---|---|---|---|---|
-| CACH-0074 | Historial user friendly de novedades beta | review | feature | slice | p1 |
 | CACH-B0001 | Redisenar Trabajos y jerarquia proyecto-evento | backlog | feature | initiative | p1 |
 | CACH-B0002 | Simplificar experiencia mobile financiera | backlog | feature | initiative | p1 |
 | CACH-B0004 | Contratantes facturacion y liquidacion neta | backlog | feature | initiative | p1 |

--- a/docs/project/DIGEST.md
+++ b/docs/project/DIGEST.md
@@ -70,7 +70,9 @@ _Sin entradas._
 
 ### Review / Verify
 
-_Sin entradas._
+| ID | Título | Tipo | Nivel | P |
+|---|---|---|---|---|
+| CACH-0074 | Historial user friendly de novedades beta | feature | slice | p1 |
 
 ### Backlog (p1)
 
@@ -85,6 +87,7 @@ _Sin entradas._
 
 | ID | Título | Workflow | Tipo | Nivel | P |
 |---|---|---|---|---|---|
+| CACH-0074 | Historial user friendly de novedades beta | review | feature | slice | p1 |
 | CACH-B0001 | Redisenar Trabajos y jerarquia proyecto-evento | backlog | feature | initiative | p1 |
 | CACH-B0002 | Simplificar experiencia mobile financiera | backlog | feature | initiative | p1 |
 | CACH-B0004 | Contratantes facturacion y liquidacion neta | backlog | feature | initiative | p1 |

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -71,7 +71,9 @@ _Sin issues._
 
 ## Review / Verify
 
-_Sin issues._
+| ID | Titulo | Tipo | Nivel | P | Componentes |
+|---|---|---|---|---|---|
+| [[../issues/CACH-0074|CACH-0074]] | Historial user friendly de novedades beta | feature | slice | p1 | auth-onboarding, settings-profile, design-system |
 
 ## Done
 

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -71,9 +71,7 @@ _Sin issues._
 
 ## Review / Verify
 
-| ID | Titulo | Tipo | Nivel | P | Componentes |
-|---|---|---|---|---|---|
-| [[../issues/CACH-0074|CACH-0074]] | Historial user friendly de novedades beta | feature | slice | p1 | auth-onboarding, settings-profile, design-system |
+_Sin issues._
 
 ## Done
 
@@ -119,6 +117,8 @@ _Sin issues._
 | [[../issues/CACH-0066|CACH-0066]] | Checklist compacto de primeros pasos | RELEASE-0.1.0-beta.21 | Implementado y cerrado en `RELEASE-0.1.0-beta.21`. El checklist aparece solo en cuentas vacias o casi vacias, se situa por encima de "Ahora" y en movil muestra una unica accion sugerida con listado desplegable. |
 | [[../issues/CACH-0067|CACH-0067]] | PWA instalable basica y navegacion standalone | RELEASE-0.1.0-beta.21 | Implementado y cerrado en `RELEASE-0.1.0-beta.21`. Cachés sirve `manifest.webmanifest`, iconos 192/512/maskable, meta tags PWA/Apple, `viewport-fit=cover` y un service worker de app shell que excluye Supabase/Auth/REST/Edge Functions y datos de usuario. |
 | [[../issues/CACH-0068|CACH-0068]] | Verificacion responsive PWA y cierre beta 21 | RELEASE-0.1.0-beta.21 | Implementado y cerrado en `RELEASE-0.1.0-beta.21`. La release queda lista para PR final, tag `v0.1.0-beta.21` y smoke postdeploy en `https://app.caches.es`; la instalacion real iPhone/Android queda como verificacion manual humana fuera del entorno del agente. |
+| [[../issues/CACH-0074|CACH-0074]] | Historial user friendly de novedades beta | RELEASE-0.1.0-beta.22 | Implementado y preparado para `RELEASE-0.1.0-beta.22`: `/novedades` muestra un historial user friendly de beta 15 a beta 21, con beta 21 destacada como última novedad. |
+| [[../issues/CACH-0075|CACH-0075]] | Bloquear ship de features sin release | RELEASE-0.1.0-beta.22 | Implementado en `scripts/ship.mjs` y documentado en `docs/project/process/WORKFLOW.md`, `docs/project/process/RELEASE_PROCESS.md` y `.memory/topics/agent-workflows.md`. |
 | [[../issues/CACH-B0003|CACH-B0003]] | Cobro rapido y gestion de pendientes | RELEASE-0.1.0-beta.5 | Released en RELEASE-0.1.0-beta.5 por ampliacion explicita de scope. Integrado en `main` mediante PR #84. |
 | [[../issues/CACH-B0005|CACH-B0005]] | Importacion exportacion y portabilidad de datos | RELEASE-0.1.0-beta.7 | Released en RELEASE-0.1.0-beta.7. Integrado en `main` mediante PR #86. |
 | [[../issues/CACH-B0006|CACH-B0006]] | Onboarding y acceso beta | RELEASE-0.1.0-beta.8 | Released en RELEASE-0.1.0-beta.8. Integrado en `main` mediante PR #87. |

--- a/docs/project/indexes/by-area.md
+++ b/docs/project/indexes/by-area.md
@@ -22,7 +22,6 @@ generated: true
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
-- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
@@ -46,6 +45,7 @@ generated: true
 - [[../issues/CACH-0065|CACH-0065]] — Ampliar onboarding como tutorial revisitable · done · p1 · slice
 - [[../issues/CACH-0066|CACH-0066]] — Checklist compacto de primeros pasos · done · p1 · slice
 - [[../issues/CACH-0068|CACH-0068]] — Verificacion responsive PWA y cierre beta 21 · done · p1 · task
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · done · p1 · slice
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes · done · p1 · slice
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta · done · p1 · slice
 - [[../issues/CACH-B0014|CACH-B0014]] — Endurecer agenda cobros y captura del MVP · done · p1 · slice
@@ -78,6 +78,7 @@ generated: true
 - [[../issues/CACH-0050|CACH-0050]] — [Deploy] Tooling local-first de PR release y smoke · done · p1 · task
 - [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · done · p1 · task
 - [[../issues/CACH-0067|CACH-0067]] — PWA instalable basica y navegacion standalone · done · p1 · slice
+- [[../issues/CACH-0075|CACH-0075]] — Bloquear ship de features sin release · done · p1 · task
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task
 
 ## docs

--- a/docs/project/indexes/by-area.md
+++ b/docs/project/indexes/by-area.md
@@ -22,6 +22,7 @@ generated: true
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0009|CACH-B0009]] — Inteligencia financiera y features Pro · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice

--- a/docs/project/indexes/by-component.md
+++ b/docs/project/indexes/by-component.md
@@ -84,6 +84,7 @@ generated: true
 
 ## auth-onboarding
 
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice
 - [[../issues/CACH-0036|CACH-0036]] — Profesionalizar flujo de ramas por beta · done · p1 · task
 - [[../issues/CACH-0064|CACH-0064]] — Corregir version y copy de consentimiento beta · done · p1 · task
 - [[../issues/CACH-0065|CACH-0065]] — Ampliar onboarding como tutorial revisitable · done · p1 · slice
@@ -98,6 +99,7 @@ generated: true
 ## settings-profile
 
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
 - [[../issues/CACH-0064|CACH-0064]] — Corregir version y copy de consentimiento beta · done · p1 · task
 - [[../issues/CACH-0065|CACH-0065]] — Ampliar onboarding como tutorial revisitable · done · p1 · slice
@@ -139,6 +141,7 @@ generated: true
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice

--- a/docs/project/indexes/by-component.md
+++ b/docs/project/indexes/by-component.md
@@ -84,12 +84,12 @@ generated: true
 
 ## auth-onboarding
 
-- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice
 - [[../issues/CACH-0036|CACH-0036]] — Profesionalizar flujo de ramas por beta · done · p1 · task
 - [[../issues/CACH-0064|CACH-0064]] — Corregir version y copy de consentimiento beta · done · p1 · task
 - [[../issues/CACH-0065|CACH-0065]] — Ampliar onboarding como tutorial revisitable · done · p1 · slice
 - [[../issues/CACH-0066|CACH-0066]] — Checklist compacto de primeros pasos · done · p1 · slice
 - [[../issues/CACH-0068|CACH-0068]] — Verificacion responsive PWA y cierre beta 21 · done · p1 · task
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · done · p1 · slice
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta · done · p1 · slice
 - [[../issues/CACH-B0017|CACH-B0017]] — Panel admin para invitaciones beta · done · p1 · slice
@@ -99,10 +99,10 @@ generated: true
 ## settings-profile
 
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
-- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
 - [[../issues/CACH-0064|CACH-0064]] — Corregir version y copy de consentimiento beta · done · p1 · task
 - [[../issues/CACH-0065|CACH-0065]] — Ampliar onboarding como tutorial revisitable · done · p1 · slice
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · done · p1 · slice
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task
 
 ## admin-beta
@@ -130,6 +130,7 @@ generated: true
 - [[../issues/CACH-0046|CACH-0046]] — [Verify] Anadir verificacion por tipo de cambio · done · p1 · task
 - [[../issues/CACH-0047|CACH-0047]] — [Skills] Actualizar catalogo y symlinks de skills · done · p1 · task
 - [[../issues/CACH-0050|CACH-0050]] — [Deploy] Tooling local-first de PR release y smoke · done · p1 · task
+- [[../issues/CACH-0075|CACH-0075]] — Bloquear ship de features sin release · done · p1 · task
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain · done · p1 · task
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task
@@ -141,7 +142,6 @@ generated: true
 - [[../issues/CACH-B0004|CACH-B0004]] — Contratantes facturacion y liquidacion neta · backlog · p1 · initiative
 - [[../issues/CACH-B0007|CACH-B0007]] — Calendario unificado e interaccion rapida · backlog · p1 · initiative
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
-- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice
 - [[../issues/CACH-0030|CACH-0030]] — Homogeneizar diseno con nueva paleta de colores y fuentes · done · p1 · task
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
 - [[../issues/CACH-0035|CACH-0035]] — Rediseño financiero del Dashboard y paid_date en cobros rapidos · done · p1 · slice
@@ -157,6 +157,7 @@ generated: true
 - [[../issues/CACH-0056|CACH-0056]] — Calendario de eventos y plan anual separados · done · p1 · slice
 - [[../issues/CACH-0060|CACH-0060]] — Anadir UX minima de contratantes en proyectos y eventos · done · p1 · slice
 - [[../issues/CACH-0063|CACH-0063]] — Unificar BottomActionBar en detalles · done · p1 · slice
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · done · p1 · slice
 
 ## infra-deploy
 
@@ -171,6 +172,7 @@ generated: true
 - [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · done · p1 · task
 - [[../issues/CACH-0067|CACH-0067]] — PWA instalable basica y navegacion standalone · done · p1 · slice
 - [[../issues/CACH-0068|CACH-0068]] — Verificacion responsive PWA y cierre beta 21 · done · p1 · task
+- [[../issues/CACH-0075|CACH-0075]] — Bloquear ship de features sin release · done · p1 · task
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task
 
 ## email

--- a/docs/project/indexes/by-level.md
+++ b/docs/project/indexes/by-level.md
@@ -30,7 +30,6 @@ generated: true
 
 ## slice
 
-- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada · done · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice
@@ -54,6 +53,7 @@ generated: true
 - [[../issues/CACH-0065|CACH-0065]] — Ampliar onboarding como tutorial revisitable · done · p1 · slice
 - [[../issues/CACH-0066|CACH-0066]] — Checklist compacto de primeros pasos · done · p1 · slice
 - [[../issues/CACH-0067|CACH-0067]] — PWA instalable basica y navegacion standalone · done · p1 · slice
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · done · p1 · slice
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes · done · p1 · slice
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta · done · p1 · slice
@@ -81,6 +81,7 @@ generated: true
 - [[../issues/CACH-0061|CACH-0061]] — Verificar regresion financiera y cierre tecnico beta 19 · done · p1 · task
 - [[../issues/CACH-0064|CACH-0064]] — Corregir version y copy de consentimiento beta · done · p1 · task
 - [[../issues/CACH-0068|CACH-0068]] — Verificacion responsive PWA y cierre beta 21 · done · p1 · task
+- [[../issues/CACH-0075|CACH-0075]] — Bloquear ship de features sin release · done · p1 · task
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain · done · p1 · task
 - [[../issues/CACH-B0016|CACH-B0016]] — Refundacion operativa del Product Brain y tests B0014 · done · p1 · task
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task

--- a/docs/project/indexes/by-level.md
+++ b/docs/project/indexes/by-level.md
@@ -30,6 +30,7 @@ generated: true
 
 ## slice
 
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada · done · p1 · slice
 - [[../issues/CACH-0029|CACH-0029]] — Integrar helpers CACH-B0016 en flujos reales · done · p1 · slice
 - [[../issues/CACH-0031|CACH-0031]] — Corregir ajustes UX movil detectados en exploracion · done · p1 · slice

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -27,7 +27,6 @@ generated: true
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
-- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice
 - [[../issues/CACH-0049|CACH-0049]] — Migrar Product Brain a v2 lean agile para agentes · done · p0 · task
 - [[../issues/CACH-0026|CACH-0026]] — Setup inicial Product Brain · done · p1 · task
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada · done · p1 · slice
@@ -110,6 +109,11 @@ generated: true
 - [[../issues/CACH-0066|CACH-0066]] — Checklist compacto de primeros pasos · done · p1 · slice
 - [[../issues/CACH-0067|CACH-0067]] — PWA instalable basica y navegacion standalone · done · p1 · slice
 - [[../issues/CACH-0068|CACH-0068]] — Verificacion responsive PWA y cierre beta 21 · done · p1 · task
+
+## RELEASE-0.1.0-beta.22
+
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · done · p1 · slice
+- [[../issues/CACH-0075|CACH-0075]] — Bloquear ship de features sin release · done · p1 · task
 
 ## RELEASE-0.1.0-beta.3
 

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -27,6 +27,7 @@ generated: true
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice
 - [[../issues/CACH-0049|CACH-0049]] — Migrar Product Brain a v2 lean agile para agentes · done · p0 · task
 - [[../issues/CACH-0026|CACH-0026]] — Setup inicial Product Brain · done · p1 · task
 - [[../issues/CACH-0028|CACH-0028]] — Corregir sync iCloud y estructura versionada · done · p1 · slice

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -81,3 +81,7 @@ generated: true
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos · done · p2 · slice
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task
+
+## review
+
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -70,6 +70,8 @@ generated: true
 - [[../issues/CACH-0066|CACH-0066]] — Checklist compacto de primeros pasos · done · p1 · slice
 - [[../issues/CACH-0067|CACH-0067]] — PWA instalable basica y navegacion standalone · done · p1 · slice
 - [[../issues/CACH-0068|CACH-0068]] — Verificacion responsive PWA y cierre beta 21 · done · p1 · task
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · done · p1 · slice
+- [[../issues/CACH-0075|CACH-0075]] — Bloquear ship de features sin release · done · p1 · task
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes · done · p1 · slice
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta · done · p1 · slice
@@ -81,7 +83,3 @@ generated: true
 - [[../issues/CACH-0033|CACH-0033]] — Vista anual en calendario de proyectos · done · p2 · slice
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task
-
-## review
-
-- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice

--- a/docs/project/indexes/by-theme.md
+++ b/docs/project/indexes/by-theme.md
@@ -17,7 +17,6 @@ generated: true
 
 ## beta-trust
 
-- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice
 - [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · done · p0 · task
 - [[../issues/CACH-0036|CACH-0036]] — Profesionalizar flujo de ramas por beta · done · p1 · task
 - [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · done · p1 · task
@@ -26,6 +25,7 @@ generated: true
 - [[../issues/CACH-0064|CACH-0064]] — Corregir version y copy de consentimiento beta · done · p1 · task
 - [[../issues/CACH-0067|CACH-0067]] — PWA instalable basica y navegacion standalone · done · p1 · slice
 - [[../issues/CACH-0068|CACH-0068]] — Verificacion responsive PWA y cierre beta 21 · done · p1 · task
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · done · p1 · slice
 - [[../issues/CACH-B0005|CACH-B0005]] — Importacion exportacion y portabilidad de datos · done · p1 · slice
 - [[../issues/CACH-B0006|CACH-B0006]] — Onboarding y acceso beta · done · p1 · slice
 - [[../issues/CACH-B0017|CACH-B0017]] — Panel admin para invitaciones beta · done · p1 · slice
@@ -91,6 +91,7 @@ generated: true
 - [[../issues/CACH-0046|CACH-0046]] — [Verify] Anadir verificacion por tipo de cambio · done · p1 · task
 - [[../issues/CACH-0047|CACH-0047]] — [Skills] Actualizar catalogo y symlinks de skills · done · p1 · task
 - [[../issues/CACH-0050|CACH-0050]] — [Deploy] Tooling local-first de PR release y smoke · done · p1 · task
+- [[../issues/CACH-0075|CACH-0075]] — Bloquear ship de features sin release · done · p1 · task
 - [[../issues/CACH-B0015|CACH-B0015]] — Operativizar backlog releases y ramas en Product Brain · done · p1 · task
 - [[../issues/CACH-B0016|CACH-B0016]] — Refundacion operativa del Product Brain y tests B0014 · done · p1 · task
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task

--- a/docs/project/indexes/by-theme.md
+++ b/docs/project/indexes/by-theme.md
@@ -17,6 +17,7 @@ generated: true
 
 ## beta-trust
 
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice
 - [[../issues/CACH-B0020|CACH-B0020]] — Validar dominio de email transaccional y cambiar remitentes definitivos · done · p0 · task
 - [[../issues/CACH-0036|CACH-0036]] — Profesionalizar flujo de ramas por beta · done · p1 · task
 - [[../issues/CACH-0051|CACH-0051]] — [Deploy] Dominio publico de app y estrategia multientorno · done · p1 · task

--- a/docs/project/indexes/issues-open.index.md
+++ b/docs/project/indexes/issues-open.index.md
@@ -26,3 +26,4 @@ generated: true
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice

--- a/docs/project/indexes/issues-open.index.md
+++ b/docs/project/indexes/issues-open.index.md
@@ -26,4 +26,3 @@ generated: true
 - [[../issues/CACH-B0011|CACH-B0011]] — Categorias etiquetas y taxonomia · backlog · p2 · initiative
 - [[../issues/CACH-B0012|CACH-B0012]] — Perfil publico viralidad y referidos · backlog · p3 · initiative
 - [[../issues/CACH-B0013|CACH-B0013]] — Gestion documental por proyecto evento · backlog · p3 · initiative
-- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta · review · p1 · slice

--- a/docs/project/indexes/issues.index.md
+++ b/docs/project/indexes/issues.index.md
@@ -56,6 +56,7 @@ generated: true
 - [[../issues/CACH-0066|CACH-0066]] — Checklist compacto de primeros pasos
 - [[../issues/CACH-0067|CACH-0067]] — PWA instalable basica y navegacion standalone
 - [[../issues/CACH-0068|CACH-0068]] — Verificacion responsive PWA y cierre beta 21
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes

--- a/docs/project/indexes/issues.index.md
+++ b/docs/project/indexes/issues.index.md
@@ -57,6 +57,7 @@ generated: true
 - [[../issues/CACH-0067|CACH-0067]] — PWA instalable basica y navegacion standalone
 - [[../issues/CACH-0068|CACH-0068]] — Verificacion responsive PWA y cierre beta 21
 - [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta
+- [[../issues/CACH-0075|CACH-0075]] — Bloquear ship de features sin release
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes

--- a/docs/project/indexes/releases.index.md
+++ b/docs/project/indexes/releases.index.md
@@ -31,6 +31,7 @@ generated: true
 - [[../releases/RELEASE-0.1.0-beta.2|RELEASE-0.1.0-beta.2]] — Endurecer confianza de datos
 - [[../releases/RELEASE-0.1.0-beta.20|RELEASE-0.1.0-beta.20]] — Hardening UX móvil financiera
 - [[../releases/RELEASE-0.1.0-beta.21|RELEASE-0.1.0-beta.21]] — Primera sesion guiada y PWA instalable
+- [[../releases/RELEASE-0.1.0-beta.22|RELEASE-0.1.0-beta.22]] — Historial de novedades beta
 - [[../releases/RELEASE-0.1.0-beta.3|RELEASE-0.1.0-beta.3]] — Rediseño financiero del Dashboard
 - [[../releases/RELEASE-0.1.0-beta.4|RELEASE-0.1.0-beta.4]] — Planificacion anual de proyectos
 - [[../releases/RELEASE-0.1.0-beta.5|RELEASE-0.1.0-beta.5]] — Flujo profesional de ramas beta

--- a/docs/project/issues/CACH-0074.md
+++ b/docs/project/issues/CACH-0074.md
@@ -16,7 +16,7 @@ tags:
 generated: false
 work_type: feature
 work_level: slice
-issue_workflow: review
+issue_workflow: done
 priority: p1
 size: s
 area: frontend
@@ -32,7 +32,7 @@ related:
 depends_on: []
 blocked_by: []
 adr: []
-release: null
+release: RELEASE-0.1.0-beta.22
 theme: beta-trust
 ---
 # CACH-0074 — Historial user friendly de novedades beta
@@ -80,13 +80,14 @@ Usar datos estáticos versionados en `src/lib/versionHistory.js` y una página `
 
 ## Resultado
 
-Implementado localmente: `/novedades` muestra un historial user friendly de beta 15 a beta 21, con beta 21 destacada como última novedad.
+Implementado y preparado para `RELEASE-0.1.0-beta.22`: `/novedades` muestra un historial user friendly de beta 15 a beta 21, con beta 21 destacada como última novedad.
 
 ## Desarrollo
 
 - Rama: `feat/CACH-0074-version-history`
 - PR: https://github.com/dignacioconde/culturApp/pull/109
-- Estado actual: PR draft abierta.
+- Estado actual: incluida en el corte ligero `RELEASE-0.1.0-beta.22`.
+- Release: `RELEASE-0.1.0-beta.22`.
 
 ## Notas de progreso
 
@@ -94,7 +95,7 @@ Se deja como contenido estático para reducir riesgo: no requiere schema, RLS, m
 
 ## Cambios de alcance y decisiones
 
-No se incluye en `RELEASE-0.1.0-beta.22` porque esa release está acotada a liquidación neta básica.
+`RELEASE-0.1.0-beta.22` se redefine como corte ligero de novedades beta y guardrail de release. La rama local previa para liquidacion neta queda fuera de este deploy.
 
 ## Bloqueos
 

--- a/docs/project/issues/CACH-0074.md
+++ b/docs/project/issues/CACH-0074.md
@@ -85,8 +85,8 @@ Implementado localmente: `/novedades` muestra un historial user friendly de beta
 ## Desarrollo
 
 - Rama: `feat/CACH-0074-version-history`
-- PR:
-- Estado actual: review local.
+- PR: https://github.com/dignacioconde/culturApp/pull/109
+- Estado actual: PR draft abierta.
 
 ## Notas de progreso
 

--- a/docs/project/issues/CACH-0074.md
+++ b/docs/project/issues/CACH-0074.md
@@ -1,0 +1,116 @@
+---
+schema_version: 2
+kind: issue
+id: CACH-0074
+title: Historial user friendly de novedades beta
+lifecycle: active
+created: '2026-05-13'
+updated: '2026-05-13'
+aliases:
+  - CACH-0074
+tags:
+  - product-brain
+  - issue
+  - beta
+  - ux
+generated: false
+work_type: feature
+work_level: slice
+issue_workflow: review
+priority: p1
+size: s
+area: frontend
+components:
+  - auth-onboarding
+  - settings-profile
+  - design-system
+parent: null
+related:
+  - CACH-0052
+  - CACH-0065
+  - CACH-0067
+depends_on: []
+blocked_by: []
+adr: []
+release: null
+theme: beta-trust
+---
+# CACH-0074 — Historial user friendly de novedades beta
+
+## Objetivo
+
+Crear un espacio visible y amable para que usuarios de la beta puedan revisar qué ha cambiado entre versiones sin leer release notes técnicas.
+
+## Alcance
+
+Incluido:
+
+- Añadir una ruta privada de novedades.
+- Mostrar la última versión destacada y un historial de versiones recientes.
+- Resumir cada versión con lenguaje de usuario: qué mejora, para qué sirve y qué cambia.
+- Enlazar el espacio desde la barra superior, Ajustes y navegación desktop.
+- Mantener la navegación móvil limpia sin añadir otro destino a la barra inferior.
+
+Fuera de alcance:
+
+- Backend, tabla editable, CMS o gestión remota de contenido.
+- Marcar novedades como leídas por usuario.
+- Notificaciones push o avisos automáticos al publicar una versión.
+
+## Criterios de aceptacion
+
+- [x] Usuarios autenticados pueden abrir `/novedades`.
+- [x] La pantalla muestra última novedad, historial y fechas en formato español.
+- [x] La copia evita notas técnicas crudas y resume valor para usuario beta.
+- [x] Hay acceso desde TopBar, Ajustes y Sidebar desktop.
+- [x] La bottom nav móvil no gana un nuevo item.
+- [x] No se añaden llamadas Supabase ni dependencias nuevas.
+
+## Plan tecnico
+
+Usar datos estáticos versionados en `src/lib/versionHistory.js` y una página `src/pages/Updates/Updates.jsx`. Añadir ruta privada en `App.jsx`, link de TopBar y acceso desde Ajustes. Mantener el contenido editorial cerca del código hasta que haga falta un flujo admin o CMS.
+
+## Validacion
+
+- `npm run lint`
+- `npm run build`
+- `npm run pb:check`
+- `npm run pb:guard`
+- Revisión visual local de `/novedades` en móvil y desktop cuando haya servidor disponible.
+
+## Resultado
+
+Implementado localmente: `/novedades` muestra un historial user friendly de beta 15 a beta 21, con beta 21 destacada como última novedad.
+
+## Desarrollo
+
+- Rama: `feat/CACH-0074-version-history`
+- PR:
+- Estado actual: review local.
+
+## Notas de progreso
+
+Se deja como contenido estático para reducir riesgo: no requiere schema, RLS, migraciones ni panel admin. Una futura iteración puede añadir estado "visto" por usuario o contenido editable si el uso lo justifica.
+
+## Cambios de alcance y decisiones
+
+No se incluye en `RELEASE-0.1.0-beta.22` porque esa release está acotada a liquidación neta básica.
+
+## Bloqueos
+
+Sin bloqueos conocidos.
+
+## Validación ejecutada
+
+- `npm run lint` OK.
+- `npm run test` OK: 28 archivos, 156 tests.
+- `npm run build` OK, con aviso no bloqueante de chunk grande de Vite preexistente.
+- `npm run pb:check` OK.
+- `npm run pb:guard` OK.
+- `git diff --check` OK.
+- `npm run doctor:react:diff` OK: 96/100. Solo muestra avisos preexistentes en archivos tocados por diff, sin bloqueo nuevo para esta feature.
+- `npm run verify:pr -- --base origin/main` OK.
+
+## Memoria
+
+Memoria: no aplica por ahora.

--- a/docs/project/issues/CACH-0075.md
+++ b/docs/project/issues/CACH-0075.md
@@ -1,0 +1,106 @@
+---
+schema_version: 2
+kind: issue
+id: CACH-0075
+title: Bloquear ship de features sin release
+lifecycle: active
+created: '2026-05-13'
+updated: '2026-05-13'
+aliases:
+  - CACH-0075
+tags:
+  - product-brain
+  - issue
+  - release
+  - agents
+generated: false
+work_type: chore
+work_level: task
+issue_workflow: done
+priority: p1
+size: xs
+area: infra
+components:
+  - agents
+  - infra-deploy
+parent: null
+related:
+  - CACH-0074
+depends_on: []
+blocked_by: []
+adr: []
+release: RELEASE-0.1.0-beta.22
+theme: internal-agent-ops
+---
+# CACH-0075 — Bloquear ship de features sin release
+
+## Objetivo
+
+Evitar que una feature CACH salga por `ship --execute` con `release: null` sin que sea una excepcion explicita.
+
+## Alcance
+
+Incluido:
+
+- Bloquear `npm run ship -- --execute --issue CACH-XXXX` cuando la issue sea `work_type: feature` y tenga `release: null`.
+- Permitir una excepcion consciente con `--allow-no-release`.
+- Documentar la regla en el workflow de Product Brain y en memoria durable de agentes.
+
+Fuera de alcance:
+
+- Reescribir el flujo completo de releases.
+- Bloquear bugs, chores o docs sin release.
+- Mutar Vercel, Supabase o produccion.
+
+## Criterios de aceptacion
+
+- [x] `ship --execute` bloquea una feature con `release: null`.
+- [x] `ship` en dry-run avisa si el execute quedaria bloqueado.
+- [x] `--allow-no-release` mantiene una salida explicita para excepciones.
+- [x] La regla queda documentada para futuros agentes.
+
+## Plan tecnico
+
+Leer el frontmatter de la issue desde `scripts/ship.mjs` antes de empujar/abrir PR y cortar solo el camino mutante cuando incumpla la politica.
+
+## Validacion
+
+- `node --check scripts/ship.mjs`
+- `node scripts/ship.mjs --execute --issue CACH-0074 --base origin/main`
+- `npm run lint`
+- `npm run pb:guard`
+- `git diff --check`
+
+## Resultado
+
+Implementado en `scripts/ship.mjs` y documentado en `docs/project/process/WORKFLOW.md`, `docs/project/process/RELEASE_PROCESS.md` y `.memory/topics/agent-workflows.md`.
+
+## Desarrollo
+
+- Rama: `feat/CACH-0074-version-history`
+- PR: https://github.com/dignacioconde/culturApp/pull/109
+- Estado actual: incluida en el corte ligero `RELEASE-0.1.0-beta.22`.
+
+## Notas de progreso
+
+Surge del fallo operativo detectado al preparar `CACH-0074`: la feature habia quedado con PR/Preview pero sin release asignada.
+
+## Cambios de alcance y decisiones
+
+Se corta como chore dentro de `RELEASE-0.1.0-beta.22` para desplegar la proteccion junto con la feature que la motivo.
+
+## Bloqueos
+
+Sin bloqueos conocidos.
+
+## Validación ejecutada
+
+- `node --check scripts/ship.mjs` OK.
+- `node scripts/ship.mjs --execute --issue CACH-0074 --base origin/main` bloquea como se espera mientras la feature no tenga release.
+- `npm run lint` OK.
+- `npm run pb:guard` OK.
+- `git diff --check` OK.
+
+## Memoria
+
+Actualizada en `.memory/topics/agent-workflows.md`.

--- a/docs/project/process/RELEASE_PROCESS.md
+++ b/docs/project/process/RELEASE_PROCESS.md
@@ -98,6 +98,8 @@ Si hay release activa pero una tarea nueva no pertenece a ella, elegir una de es
 - ejecutarla por flujo ligero desde `main`;
 - anadirla explicitamente al documento de la release activa.
 
+El flujo `npm run ship -- --execute --issue CACH-XXXX` bloquea features con `release: null`. Para una feature pequena que salga deliberadamente fuera de release, usar `--allow-no-release` y explicar la excepcion en la issue/PR.
+
 ```bash
 git fetch --prune origin
 git switch release/0.1.0-beta.1

--- a/docs/project/process/WORKFLOW.md
+++ b/docs/project/process/WORKFLOW.md
@@ -118,6 +118,8 @@ Si no hay release activa, las tareas van directamente a main por PR.
 
 Si hay release activa pero la tarea no pertenece a ella, tambien puede ir por flujo ligero desde `main` si es pequena, aislada y production-safe.
 
+Antes de abrir PR con `npm run ship -- --execute --issue CACH-XXXX`, una issue `work_type: feature` debe tener `release: RELEASE-...`. Si la feature sale intencionalmente por flujo ligero sin release, relanzar con `--allow-no-release` y dejarlo explicado en la issue/PR.
+
 ### Cierre de beta
 
 El cierre de beta se hace con una unica PR `release/<version>` -> `main`. No hacer merge local directo a `main`, aunque la release este validada.

--- a/docs/project/releases/CURRENT_RELEASE.md
+++ b/docs/project/releases/CURRENT_RELEASE.md
@@ -49,9 +49,11 @@ No aplica. Las siguientes tareas pequeñas salen de `main` salvo que se abra una
 
 `RELEASE-0.1.0-beta.21` — primera sesion guiada y PWA instalable. Ver [[RELEASE-0.1.0-beta.21]].
 
+`RELEASE-0.1.0-beta.22` — historial de novedades beta. Ver [[RELEASE-0.1.0-beta.22]].
+
 ## Scope actual
 
-Sin scope activo. Beta 21 queda cerrada como corte pequeno de confianza movil: tutorial ampliado, consentimiento actualizado, checklist compacto y PWA instalable basica.
+Sin scope activo. Beta 22 queda cerrada como corte ligero de confianza beta: historial de novedades user friendly y guardrail para no lanzar features sin release asignada.
 
 Issues incluidas:
 
@@ -63,4 +65,4 @@ No hay release activa. Las tareas fuera de release usan el flujo ligero desde `m
 
 ## Como cerrar esta release
 
-Beta 21 ya esta cerrada mediante PR #108, CI verde, tag `v0.1.0-beta.21` y smoke postdeploy basico de rutas SPA/PWA. La instalacion real iPhone/Android queda como verificacion manual humana.
+Beta 22 queda cerrada mediante PR #109, CI verde, tag `v0.1.0-beta.22` y smoke postdeploy basico. No hay release activa hasta abrir el siguiente corte.

--- a/docs/project/releases/RELEASE-0.1.0-beta.22.md
+++ b/docs/project/releases/RELEASE-0.1.0-beta.22.md
@@ -1,0 +1,147 @@
+---
+schema_version: 2
+kind: release
+id: RELEASE-0.1.0-beta.22
+title: Historial de novedades beta
+lifecycle: active
+created: '2026-05-13'
+updated: '2026-05-13'
+aliases:
+  - RELEASE-0.1.0-beta.22
+tags:
+  - product-brain
+  - release
+  - beta
+  - ux
+generated: false
+release_phase: released
+release_current: false
+release_branch: feat/CACH-0074-version-history
+release_tag: v0.1.0-beta.22
+release_pr: https://github.com/dignacioconde/culturApp/pull/109
+---
+# RELEASE-0.1.0-beta.22 — Historial de novedades beta
+
+## Estado
+
+Released.
+
+## Rama de release
+
+`feat/CACH-0074-version-history`
+
+## Ciclo
+
+`0.1` es el ciclo organizativo. `0.1.0-beta.22` es un corte ligero para publicar el historial user friendly de novedades beta y el guardrail que evita volver a lanzar features sin release asignada.
+
+## Objetivo de la release
+
+Dar a usuarios beta un lugar claro para entender que ha cambiado entre versiones y cerrar el fallo operativo que dejo esta feature flotando como PR/Preview sin release.
+
+## Alcance funcional
+
+- Nueva ruta privada `/novedades` con ultima novedad destacada e historial de versiones recientes.
+- Accesos desde TopBar, Ajustes y navegacion desktop.
+- La navegacion inferior movil se mantiene sin un destino adicional.
+- Guardrail local de `ship` para bloquear features con `release: null` salvo excepcion explicita.
+
+## Scope
+
+- [[../issues/CACH-0074|CACH-0074]] — Historial user friendly de novedades beta.
+- [[../issues/CACH-0075|CACH-0075]] — Bloquear ship de features sin release.
+
+## Issues incluidas
+
+| Issue | Titulo | Workflow | Rama |
+|---|---|---|---|
+| [[../issues/CACH-0074|CACH-0074]] | Historial user friendly de novedades beta | done | `feat/CACH-0074-version-history` |
+| [[../issues/CACH-0075|CACH-0075]] | Bloquear ship de features sin release | done | `feat/CACH-0074-version-history` |
+
+## Fuera de alcance
+
+- CMS, backend o tabla editable para novedades.
+- Marcar novedades como leidas por usuario.
+- Notificaciones push o avisos automaticos.
+- Liquidacion neta, facturacion o slices de `CACH-B0004`.
+
+## Riesgos
+
+- La ruta `/novedades` debe seguir protegida por auth y no llamar a Supabase.
+- El guardrail no debe bloquear bugs, chores o docs pequenos que puedan salir fuera de release.
+- La rama local antigua `release/0.1.0-beta.22` de liquidacion neta no forma parte de este corte.
+
+## Decisiones relacionadas
+
+- [[../issues/CACH-0052|CACH-0052]] — Formulario simple de feedback beta.
+- [[../issues/CACH-0065|CACH-0065]] — Ampliar onboarding como tutorial revisitable.
+- [[../issues/CACH-0067|CACH-0067]] — PWA instalable basica y navegacion standalone.
+- [[../process/WORKFLOW|Workflow]].
+
+## Checklist de entrada
+
+- [x] Release creada
+- [x] Rama de release definida como corte ligero via PR #109
+- [x] Issues asociadas
+- [x] Alcance definido
+- [x] Criterios de validacion definidos
+
+## Checklist de desarrollo
+
+- [x] Todas las issues estan cerradas
+- [x] Commits integrados en la rama del PR
+- [x] No hay cambios sueltos fuera del PR
+- [x] No hay issues sin `issue_workflow`
+- [x] Aprendizaje durable documentado
+
+## Checklist de estabilizacion
+
+- [x] `npm run lint`
+- [x] `npm run test`
+- [x] `npm run build`
+- [x] `npm run pb:check`
+- [x] `npm run pb:guard`
+- [x] `git diff --check`
+- [x] `npm run verify:pr -- --base origin/main`
+- [x] CI de PR #109 en verde antes del merge
+
+## Checklist de salida
+
+- [x] PR #109 abierta contra `main`
+- [x] CI en verde
+- [x] PR mergeada en `main`
+- [x] Tag `v0.1.0-beta.22` creado desde `main`
+- [x] Produccion verificada con smoke postdeploy
+- [x] Release notes actualizadas
+- [x] Issues marcadas como `done`
+- [x] Estado actual actualizado
+- [x] Current Release actualizado
+- [x] Backlog actualizado
+- [x] Proximos pasos documentados
+
+## Release notes
+
+### Aniadido
+
+- Pantalla privada `/novedades` con historial de cambios beta en lenguaje de usuario.
+- Acceso a novedades desde TopBar, Ajustes y navegacion desktop.
+
+### Cambiado
+
+- Product Brain asocia `CACH-0074` a un corte beta real en vez de dejarlo como feature con `release: null`.
+
+### Corregido
+
+- `ship --execute` ya no permite lanzar features CACH sin release asignada salvo excepcion explicita con `--allow-no-release`.
+
+### Eliminado
+
+- No aplica.
+
+### Tecnico
+
+- Datos editoriales versionados en `src/lib/versionHistory.js`.
+- Guardrail implementado en `scripts/ship.mjs` con lectura del frontmatter de la issue.
+
+## Resultado final
+
+Release preparada mediante PR #109 a `main`. Tag esperado: `v0.1.0-beta.22`. Produccion debe verificarse con smoke postdeploy tras el merge.

--- a/scripts/ship.mjs
+++ b/scripts/ship.mjs
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process'
-import { repoRoot } from './brain/lib.mjs'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { brainRoot, readDoc, repoRoot } from './brain/lib.mjs'
 
 const argv = process.argv.slice(2)
 const execute = argv.includes('--execute')
+const allowNoRelease = argv.includes('--allow-no-release')
 const issue = valueFor('--issue')
 const base = valueFor('--base') ?? 'origin/main'
 const title = valueFor('--title') ?? (issue ? `chore(${issue}): prepare changes` : 'chore: prepare changes')
@@ -44,13 +47,45 @@ function requireCleanWorktree() {
   if (status.stdout.trim()) block('hay cambios sin commitear; ship --execute solo empuja commits ya cerrados')
 }
 
+function releasePolicy() {
+  if (!issue) return { ok: true }
+
+  const issuePath = join(brainRoot, 'issues', `${issue}.md`)
+  if (!existsSync(issuePath)) {
+    return { ok: false, message: `no existe docs/project/issues/${issue}.md` }
+  }
+
+  const doc = readDoc(issuePath)
+  const data = doc.frontmatter ?? {}
+  const hasRelease = Boolean(data.release)
+  const isFeature = data.work_type === 'feature'
+
+  if (isFeature && !hasRelease && !allowNoRelease) {
+    return {
+      ok: false,
+      message: `${issue} es una feature con release: null; asignala a una release o relanza con --allow-no-release si este PR ligero fuera de release es intencional`,
+    }
+  }
+
+  return {
+    ok: true,
+    warning: isFeature && !hasRelease && allowNoRelease
+      ? `${issue} es feature sin release; se permite porque pasaste --allow-no-release`
+      : null,
+  }
+}
+
 console.log(`[ship] Base: ${base}`)
 console.log(`[ship] Issue: ${issue ?? 'no aplica'}`)
 console.log(`[ship] Rama actual: ${currentBranch || 'desconocida'}`)
 console.log(`[ship] Titulo PR sugerido: ${title}`)
 
+const policy = releasePolicy()
+if (policy.warning) console.warn(`[ship] Aviso: ${policy.warning}`)
+
 if (!execute) {
   console.log('[ship] Dry-run: no se hacen push, PR, merge ni deploy.')
+  if (!policy.ok) console.log(`[ship] --execute quedaria bloqueado: ${policy.message}`)
   console.log(`[ship] Ejecutaria: npm run verify:pr -- --base ${base}${issue ? ` --issue ${issue}` : ''}`)
   console.log(`[ship] Generaria PR body: npm run pr:body -- ${issue ? `--issue ${issue} ` : ''}--base ${base}`)
   console.log('[ship] Para abrir PR, relanza con --execute tras revisar el diff.')
@@ -59,6 +94,7 @@ if (!execute) {
 
 if (!currentBranch) block('no hay rama actual detectable')
 if (['main', 'master'].includes(currentBranch)) block('no abras PR directamente desde main/master')
+if (!policy.ok) block(policy.message)
 requireCleanWorktree()
 
 runRequired('npm', ['run', 'verify:pr', '--', '--base', base, ...(issue ? ['--issue', issue] : [])])

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import ContractorList from './pages/Contractors/ContractorList'
 import Work from './pages/Work/Work'
 import Settings from './pages/Settings/Settings'
 import Data from './pages/Data/Data'
+import Updates from './pages/Updates/Updates'
 import AdminInvites from './pages/Admin/AdminInvites'
 
 function PrivateRoute({ children, requireAdmin = false }) {
@@ -113,6 +114,7 @@ export default function App() {
         <Route path="/work" element={<PrivateRoute><Work /></PrivateRoute>} />
         <Route path="/settings" element={<PrivateRoute><Settings /></PrivateRoute>} />
         <Route path="/data" element={<PrivateRoute><Data /></PrivateRoute>} />
+        <Route path="/novedades" element={<PrivateRoute><Updates /></PrivateRoute>} />
         <Route path="/admin/invitaciones" element={<PrivateRoute requireAdmin><AdminInvites /></PrivateRoute>} />
         <Route path="*" element={<Navigate to="/dashboard" replace />} />
       </Routes>

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { useAuth } from '../../hooks/useAuth'
-import { Drama, LogOut, User, MessageSquare } from 'lucide-react'
+import { Drama, LogOut, User, MessageSquare, Megaphone } from 'lucide-react'
 import { ToastContainer, useToast } from '../ui/Toast'
 import { FeedbackDialog } from './FeedbackDialog'
 
@@ -17,6 +18,14 @@ export function TopBar({ title }) {
           <h1 className="min-w-0 truncate text-lg font-semibold leading-7 text-[#211C18] font-['DM_Serif_Display']">{title}</h1>
         </div>
         <div className="flex min-w-0 shrink-0 items-center gap-1 sm:gap-2">
+          <Link
+            to="/novedades"
+            className="inline-flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg text-sm font-medium text-[#5C5149] transition-colors hover:bg-[#EBE3CE] hover:text-[#211C18] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C94035] focus-visible:ring-offset-2 md:w-auto md:px-3"
+            aria-label="Ver novedades"
+          >
+            <Megaphone size={16} className="shrink-0" />
+            <span className="hidden md:inline">Novedades</span>
+          </Link>
           <button
             type="button"
             onClick={() => setIsFeedbackOpen(true)}

--- a/src/components/layout/navigation.js
+++ b/src/components/layout/navigation.js
@@ -1,4 +1,4 @@
-import { Building2, Database, LayoutDashboard, CalendarDays, CalendarRange, Briefcase, Settings } from 'lucide-react'
+import { Building2, Database, LayoutDashboard, CalendarDays, CalendarRange, Briefcase, Megaphone, Settings } from 'lucide-react'
 
 export const navItems = [
   { to: '/dashboard', icon: LayoutDashboard, label: 'Inicio', mobileLabel: 'Inicio' },
@@ -7,6 +7,7 @@ export const navItems = [
   { to: '/calendar/events', icon: CalendarDays, label: 'Agenda', mobileLabel: 'Agenda', activePaths: ['/calendar', '/calendar/events'] },
   { to: '/calendar/projects', icon: CalendarRange, label: 'Plan anual', mobileLabel: 'Plan' },
   { to: '/data', icon: Database, label: 'Tus datos', mobileLabel: 'Datos' },
+  { to: '/novedades', icon: Megaphone, label: 'Novedades', mobileLabel: 'Noved.', showOnMobile: false },
   { to: '/settings', icon: Settings, label: 'Ajustes', mobileLabel: 'Ajustes' },
 ]
 

--- a/src/lib/versionHistory.js
+++ b/src/lib/versionHistory.js
@@ -1,0 +1,134 @@
+export const VERSION_HISTORY = [
+  {
+    version: '0.1.0-beta.21',
+    label: 'Beta 21',
+    date: '2026-05-13',
+    title: 'Primera sesión guiada y app instalable',
+    summary: 'Cachés es más fácil de entender al entrar por primera vez y ya puedes guardarla en el móvil como una app.',
+    highlights: [
+      'Tutorial revisitable desde Ajustes.',
+      'Checklist compacto para empezar sin perderte.',
+      'Instalación básica como PWA en móvil.',
+    ],
+    details: [
+      'El consentimiento de uso deja de referirse a una beta antigua.',
+      'El tutorial explica trabajos, proyectos, eventos, cobros, gastos, contratantes y uso móvil.',
+      'El service worker solo guarda el app shell y no cachea datos personales.',
+    ],
+    tone: 'new',
+  },
+  {
+    version: '0.1.0-beta.20',
+    label: 'Beta 20',
+    date: '2026-05-13',
+    title: 'Acciones rápidas más claras en móvil',
+    summary: 'Los detalles de proyecto y evento comparten la misma barra inferior para cobros, gastos, edición y borrado.',
+    highlights: [
+      'Barra contextual consistente en detalles.',
+      'Acciones financieras más a mano en pantallas pequeñas.',
+      'Borrado menos dominante y con confirmación.',
+    ],
+    details: [
+      'Desktop conserva una vista más densa.',
+      'El contenido final ya no queda tapado por la barra de acciones.',
+    ],
+    tone: 'improved',
+  },
+  {
+    version: '0.1.0-beta.19',
+    label: 'Beta 19',
+    date: '2026-05-13',
+    title: 'Contratantes reutilizables',
+    summary: 'Puedes asociar proyectos y eventos a contratantes estructurados en lugar de repetir texto libre.',
+    highlights: [
+      'Nuevo espacio de Contratantes.',
+      'Proyectos y eventos pueden elegir o crear contratante.',
+      'Los eventos pueden heredar el contratante del proyecto.',
+    ],
+    details: [
+      'El campo cliente antiguo sigue funcionando como apoyo.',
+      'Exportación e importación incluyen contratantes.',
+      'No cambia ninguna fórmula financiera.',
+    ],
+    tone: 'new',
+  },
+  {
+    version: '0.1.0-beta.18',
+    label: 'Beta 18',
+    date: '2026-05-13',
+    title: 'Detalles más útiles para trabajar',
+    summary: 'Los proyectos y eventos ganan notas editables, formularios financieros rápidos y calendarios mejor separados.',
+    highlights: [
+      'Notas contextuales en proyectos y eventos.',
+      'Cobros y gastos rápidos más cómodos.',
+      'Agenda de eventos separada del plan anual de proyectos.',
+    ],
+    details: [
+      'La agenda se centra en fechas con hora exacta.',
+      'El plan anual mantiene la visión de proyectos por rango.',
+    ],
+    tone: 'improved',
+  },
+  {
+    version: '0.1.0-beta.17',
+    label: 'Beta 17',
+    date: '2026-05-13',
+    title: 'Feedback dentro de la app',
+    summary: 'Ahora puedes enviar comentarios de la beta sin salir de Cachés.',
+    highlights: [
+      'Botón de Feedback en la barra superior.',
+      'Formulario simple para contar errores, dudas o mejoras.',
+      'Sin activar analítica de producto.',
+    ],
+    details: [
+      'Los comentarios se guardan para revisión de la beta.',
+    ],
+    tone: 'new',
+  },
+  {
+    version: '0.1.0-beta.16',
+    label: 'Beta 16',
+    date: '2026-05-10',
+    title: 'Navegación móvil más directa',
+    summary: 'La navegación inferior móvil se simplifica para que Inicio, Trabajos, Agenda, Plan, Datos y Ajustes estén siempre a mano.',
+    highlights: [
+      'Barra inferior con destinos principales.',
+      'Menos dependencia de menús laterales en móvil.',
+      'Estados activos más visibles.',
+    ],
+    details: [
+      'Los detalles con acciones contextuales evitan duplicar navegación inferior.',
+    ],
+    tone: 'improved',
+  },
+  {
+    version: '0.1.0-beta.15',
+    label: 'Beta 15',
+    date: '2026-05-10',
+    title: 'Dominio público definitivo',
+    summary: 'Cachés queda disponible desde app.caches.es para la beta.',
+    highlights: [
+      'Dominio canónico de la app.',
+      'Redirecciones de acceso alineadas con producción.',
+      'Base preparada para invitaciones y confirmaciones.',
+    ],
+    details: [
+      'El alias antiguo queda solo como continuidad técnica.',
+    ],
+    tone: 'fixed',
+  },
+]
+
+export const LATEST_VERSION = VERSION_HISTORY[0]
+
+export const VERSION_TONE_LABELS = {
+  new: 'Nuevo',
+  improved: 'Mejorado',
+  fixed: 'Corregido',
+}
+
+export const VERSION_TONE_STYLES = {
+  new: 'bg-[var(--color-red-light)] text-[var(--color-red)]',
+  improved: 'bg-[var(--color-green-light)] text-[var(--color-green)]',
+  fixed: 'bg-[var(--color-info-100)] text-[var(--color-info-500)]',
+}

--- a/src/pages/Settings/Settings.jsx
+++ b/src/pages/Settings/Settings.jsx
@@ -164,6 +164,20 @@ export default function Settings() {
             </Link>
           </div>
         </Card>
+        <Card className="p-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-sm font-semibold text-gray-900 mb-1">Novedades de la beta</h2>
+              <p className="text-sm text-gray-500">Consulta las mejoras recientes en formato corto y sin notas técnicas.</p>
+            </div>
+            <Link
+              to="/novedades"
+              className="inline-flex min-h-10 items-center justify-center rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-paper)] px-4 py-2 text-sm font-medium leading-none text-[var(--color-ink)] shadow-sm transition-colors hover:bg-[var(--color-paper-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-red)] focus-visible:ring-offset-2"
+            >
+              Ver novedades
+            </Link>
+          </div>
+        </Card>
       </div>
       <ToastContainer toasts={toasts} onRemove={removeToast} />
     </PageWrapper>

--- a/src/pages/Updates/Updates.jsx
+++ b/src/pages/Updates/Updates.jsx
@@ -1,0 +1,120 @@
+import { CheckCircle2, History, Megaphone, Sparkles } from 'lucide-react'
+import { PageWrapper } from '../../components/layout/PageWrapper'
+import { Card } from '../../components/ui/Card'
+import { Badge } from '../../components/ui/Badge'
+import { formatDate } from '../../lib/formatters'
+import {
+  LATEST_VERSION,
+  VERSION_HISTORY,
+  VERSION_TONE_LABELS,
+  VERSION_TONE_STYLES,
+} from '../../lib/versionHistory'
+
+function ToneBadge({ tone }) {
+  return (
+    <Badge className={VERSION_TONE_STYLES[tone] ?? 'bg-gray-100 text-gray-600'}>
+      {VERSION_TONE_LABELS[tone] ?? 'Novedad'}
+    </Badge>
+  )
+}
+
+function LatestUpdate() {
+  return (
+    <section className="rounded-lg border border-[var(--color-paper-mid)] bg-[#2C2420] p-4 text-[#F5EFE0] shadow-sm sm:p-5">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="inline-flex size-9 items-center justify-center rounded-lg bg-[#211C18] text-[#F5EFE0]">
+              <Sparkles size={18} />
+            </span>
+            <span className="text-xs font-medium uppercase tracking-[0.04em] text-[#E2D9C2]">Última novedad</span>
+          </div>
+          <h2 className="mt-3 text-xl font-semibold leading-snug text-white sm:text-2xl">{LATEST_VERSION.title}</h2>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-[#E2D9C2]">{LATEST_VERSION.summary}</p>
+        </div>
+        <div className="flex shrink-0 flex-row items-center gap-2 sm:flex-col sm:items-end">
+          <span className="rounded-full bg-[#F5EFE0] px-3 py-1 text-xs font-semibold text-[#211C18]">
+            {LATEST_VERSION.label}
+          </span>
+          <span className="text-xs text-[#E2D9C2]">{formatDate(LATEST_VERSION.date)}</span>
+        </div>
+      </div>
+      <div className="mt-4 grid gap-2 sm:grid-cols-3">
+        {LATEST_VERSION.highlights.map((highlight) => (
+          <div key={highlight} className="flex items-start gap-2 rounded-lg border border-white/10 bg-white/5 p-3 text-sm leading-5">
+            <CheckCircle2 size={16} className="mt-0.5 shrink-0 text-[#F5EFE0]" />
+            <span>{highlight}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function VersionCard({ entry, isLatest }) {
+  return (
+    <Card className="p-4 sm:p-5">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <ToneBadge tone={entry.tone} />
+            {isLatest && <Badge className="bg-[var(--color-paper-dark)] text-[var(--color-ink)]">Actual</Badge>}
+            <span className="text-xs font-medium text-[var(--color-ink-muted)]">{entry.label}</span>
+            <span className="text-xs text-[var(--color-ink-muted)]">{formatDate(entry.date)}</span>
+          </div>
+          <h3 className="mt-3 text-base font-semibold leading-snug text-[var(--color-ink)]">{entry.title}</h3>
+          <p className="mt-2 text-sm leading-6 text-[var(--color-ink-muted)]">{entry.summary}</p>
+          <ul className="mt-4 grid gap-2 text-sm text-[var(--color-ink)] sm:grid-cols-2">
+            {entry.highlights.map((highlight) => (
+              <li key={highlight} className="flex items-start gap-2">
+                <CheckCircle2 size={15} className="mt-0.5 shrink-0 text-[var(--color-red)]" />
+                <span>{highlight}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="min-w-0 rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-surface-alt)] p-3 lg:w-72">
+          <p className="text-xs font-semibold uppercase tracking-[0.04em] text-[var(--color-ink-muted)]">También cambia</p>
+          <ul className="mt-2 flex flex-col gap-2 text-sm leading-5 text-[var(--color-ink-muted)]">
+            {entry.details.map((detail) => (
+              <li key={detail}>{detail}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+export default function Updates() {
+  return (
+    <PageWrapper title="Novedades">
+      <div className="flex max-w-5xl flex-col gap-5">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 text-sm font-medium text-[var(--color-red)]">
+              <Megaphone size={17} />
+              <span>Historial de versiones</span>
+            </div>
+            <h1 className="mt-2 text-2xl font-semibold leading-tight text-[var(--color-ink)]">Qué ha cambiado en la beta</h1>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-[var(--color-ink-muted)]">
+              Un resumen claro de las mejoras que ya tienes disponibles, escrito para usar la app sin leer notas técnicas.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 rounded-lg border border-[var(--color-paper-mid)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-ink-muted)]">
+            <History size={16} />
+            <span>{VERSION_HISTORY.length} versiones visibles</span>
+          </div>
+        </div>
+
+        <LatestUpdate />
+
+        <section className="flex flex-col gap-3" aria-label="Versiones anteriores">
+          {VERSION_HISTORY.map((entry, index) => (
+            <VersionCard key={entry.version} entry={entry} isLatest={index === 0} />
+          ))}
+        </section>
+      </div>
+    </PageWrapper>
+  )
+}


### PR DESCRIPTION
## Resumen

Corte ligero `RELEASE-0.1.0-beta.22` para publicar el historial de novedades beta y cerrar el fallo de proceso que dejo la feature como PR/Preview sin release.

## Cambios

- `CACH-0074`: nueva pantalla privada `/novedades` con historial user friendly de beta 15 a beta 21.
- Accesos desde TopBar, Ajustes y navegacion desktop; la bottom nav movil no anade otro item.
- `CACH-0075`: `ship --execute` bloquea features con `release: null` salvo excepcion explicita con `--allow-no-release`.
- Product Brain actualizado con `RELEASE-0.1.0-beta.22`, issues cerradas, indices/digest y memoria de agentes.

## Validacion local

- `npm run verify:pr -- --base origin/main --issue CACH-0074` OK
- `npm run pb:close-check -- CACH-0075` OK
- `npm run pb:release-check -- RELEASE-0.1.0-beta.22` OK
- `npm run pb:guard` OK
- `git diff --check` OK

## Deploy

Merge a `main` publica produccion en Vercel. Despues del merge creare `v0.1.0-beta.22` y hare smoke postdeploy.

## Memoria

Memoria actualizada en `.memory/topics/agent-workflows.md`.