### PR TITLE
[codex] Add progressive SDD gates

### DIFF
--- a/.agents/skills/product-brain-sdd-review/SKILL.md
+++ b/.agents/skills/product-brain-sdd-review/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: product-brain-sdd-review
-description: Review Product Brain CACH issues for lightweight spec-driven readiness before implementation. Use when asked for SDD review, spec readiness, issue readiness, requirements-to-validation traceability, or avoiding Product Brain token dump. Do not use to create issues, edit docs, implement code, or replace pb:ready-check.
+description: Review Product Brain CACH issues for progressive spec-driven readiness before implementation. Use when asked for SDD review, spec readiness, issue readiness, requirements-to-validation traceability, Nivel 2 readiness, or avoiding Product Brain token dump. Do not use to create issues, edit docs, implement code, or replace pb:ready-check.
 ---
 
 # Product Brain SDD Review
 
 ## Purpose
 
-Review whether a Product Brain issue is executable as a lightweight spec without turning Caches into a heavy spec framework.
+Review whether a Product Brain issue is executable as a progressive spec without turning Caches into a heavy spec framework.
 
-This skill is read-only by default. It checks semantic readiness: observable requirements, bounded scope, enough technical design for risky work, derivable tasks, validation traceability, and low risk of stale duplicated context.
+This skill is read-only by default. It checks semantic readiness: observable requirements, bounded scope, the right SDD level, enough technical design for risky work, derivable tasks, validation traceability, and low risk of stale duplicated context.
 
 ## When to use this skill
 
@@ -18,6 +18,7 @@ This skill is read-only by default. It checks semantic readiness: observable req
 - A feature, bug, or slice looks ambiguous even though `pb:ready-check` passes structurally.
 - A planner draft needs a quality pass before agents implement it.
 - You need to decide whether an idea should become a slice, spike, ADR, or remain deferred in the intake queue.
+- The issue may require SDD Nivel 2 because it is `size: m`, data/security/infra, finance/Supabase/auth/calendar, multi-component, multi-agent, multi-PR, or repeatedly ambiguous.
 
 ## When not to use this skill
 
@@ -37,8 +38,10 @@ This skill is read-only by default. It checks semantic readiness: observable req
 - Parent initiative, release document, ADRs, or source touchpoints only when referenced by the issue or needed to judge readiness.
 - `docs/project/process/definition-of-ready.md`
 - `docs/project/process/definition-of-done.md`
+- `docs/project/process/sdd-levels.md`
 - `docs/project/templates/ISSUE_TEMPLATE.md`
 - `scripts/brain/ready-check.mjs` when checking script-backed gates.
+- `scripts/brain/sdd-check.mjs` when checking SDD level gates.
 
 ## Procedure
 
@@ -49,19 +52,24 @@ This skill is read-only by default. It checks semantic readiness: observable req
    - Criteria describe observable behavior or user-visible/system-visible outcomes.
    - Criteria avoid placeholders, generic "works correctly" wording, and implementation-only chores without value.
    - For `feature` and `bug`, prefer scenario language such as `Cuando... entonces...` or `WHEN... THEN...` when it clarifies behavior, but do not require it mechanically.
-5. Judge design sufficiency:
+5. Judge SDD level:
+   - Nivel 1 is enough for `xs/s` low-risk work with objective, explicit scope, AC IDs and validation traceability.
+   - Nivel 2 is required for `size: m`, `area: data|security|infra`, components `finance|supabase|auth-onboarding|calendar`, multi-component work, multi-agent/PR work, or repeated ambiguity.
+   - Nivel 3 means create or update an ADR/decision plus executable child slices; do not use it by default.
+6. Judge design sufficiency:
    - `size: xs` can stay lightweight.
    - `size: m`, `area: data|security|infra`, components `finance|supabase|auth-onboarding`, or multi-component work should include a short `Plan tecnico` or equivalent notes.
    - The plan should name contracts, hooks, migrations, APIs, UX states, or affected modules when relevant, without freezing unnecessary implementation details.
-6. Judge task derivability:
+   - Nivel 2 should include `Escenarios SDD`, `Contrato tecnico`, AC-to-validation mapping, and `Riesgos y rollback` when data/security/infra/finance/Supabase/auth is involved.
+7. Judge task derivability:
    - An implementer can identify the first files/modules to inspect.
    - Dependencies, blockers, and out-of-scope items are explicit enough to avoid scope creep.
    - Initiatives are not treated as executable; recommend a slice when needed.
-7. Judge validation and traceability:
+8. Judge validation and traceability:
    - Each important criterion has a plausible automated, browser, manual, SQL/RLS, or review check.
    - Validation is specific to the domain, not only generic `lint/build`.
    - Close evidence should be possible without rewriting the spec after the fact.
-8. Judge drift and token discipline:
+9. Judge drift and token discipline:
    - The issue references ADRs, memory, source touchpoints, or process docs instead of copying long global rules.
    - The issue is small enough for one focused implementation pass.
    - No stale historical context is required to understand the executable work.
@@ -73,6 +81,7 @@ This skill is read-only by default. It checks semantic readiness: observable req
 Verdict: Ready | Ready with risks | Not ready
 
 Gaps:
+- Nivel SDD: ...
 - Requisitos: ...
 - Diseno tecnico: ...
 - Tareas derivables: ...

--- a/.memory/feedback_product_brain.md
+++ b/.memory/feedback_product_brain.md
@@ -9,6 +9,7 @@ Product Brain debe ayudar a implementar, no bloquear merges con proceso excesivo
 - Para orientar agentes, usar `npm run pb:orient -- --json` y abrir solo issue, parent, release o source-touchpoints relevantes.
 - `BACKLOG.md`, `DIGEST.md` e índices son generados o semi-generados; no editarlos a mano salvo emergencia, regenerar con `pb:index`/`pb:digest`.
 - Cierre y readiness se validan con `pb:ready-check CACH-XXXX` y `pb:close-check CACH-XXXX`.
+- SDD es progresivo por niveles: Nivel 1 sigue siendo issue ejecutable ligera; Nivel 2 se exige via `pb:sdd-check` para `size: m`, datos/seguridad/infra, finance/Supabase/auth/calendar, multi-componente, varios agentes/PRs o dolor repetido de ambiguedad. Contrato canonico: `docs/project/process/sdd-levels.md`.
 - Las tareas pequeñas (fixes, chores, mejoras menores) van directamente de `main` a `main` por PR. No requieren release activa ni release branch.
 - Las release branches (`release/<version>`) se usan solo para releases multi-issue o estabilizaciones reales.
 - Una release activa no absorbe tareas nuevas por defecto: si la tarea no pertenece a esa release, se aplaza, va por flujo ligero desde `main`, o se anade explicitamente al documento de la release.
@@ -38,6 +39,7 @@ npm run pb:orient   # Orientación mínima para agentes
 npm run pb:check    # Validar frontmatter, índices y wikilinks internos
 npm run pb:guard    # Validación completa para docs/project/ o scripts/brain/
 npm run pb:ready-check -- CACH-XXXX # Antes de mover issue a ready
+npm run pb:sdd-check -- CACH-XXXX # Gate SDD por niveles para issue ejecutable
 npm run pb:close-check -- CACH-XXXX # Antes de cerrar issue como done
 npm run pb:pull    # Importar cambios del vault de iCloud
 npm run pb:push    # Exportar cambios al vault de iCloud

--- a/.memory/topics/portable-skills.md
+++ b/.memory/topics/portable-skills.md
@@ -18,10 +18,16 @@
 - Durable memory: `cultura-learning-loop` vive en `.agents/skills/cultura-learning-loop/SKILL.md` y convierte incidentes, conversaciones o brechas de proceso en causa raíz, guardrails, memoria/Product Brain/tests/docs y verificación. No es diario operativo ni memoria automática.
 - Source: `.agents/skills/cultura-learning-loop/SKILL.md`; incidente feedback/Supabase remoto 2026-05-12.
 
+## 2026-05-19 - product-brain-sdd-review: SDD Progresivo Por Niveles
+
+- Context: Se subio SDD de gate ligero a modelo progresivo por niveles para anticipar rework por ambiguedad sin adoptar un framework pesado.
+- Durable memory: `product-brain-sdd-review` revisa SDD Nivel 1/Nivel 2 de forma semantica read-only. Nivel 2 aplica a `size: m`, datos/seguridad/infra, finance/Supabase/auth/calendar, multi-componente, varios agentes/PRs o ambiguedad repetida; debe pedir escenarios, contrato tecnico, matriz AC-validacion y rollback cuando aplique.
+- Source: `.agents/skills/product-brain-sdd-review/SKILL.md`; `docs/project/process/sdd-levels.md`; `scripts/brain/sdd-check.mjs`; `docs/project/issues/CACH-0097.md`.
+
 ## 2026-05-12 - product-brain-sdd-review: SDD Ligero Sin Agente Nuevo
 
 - Context: Se hizo challenge con agentes docs/testing/review y experto SDD temporal sobre como encajar Product Brain con spec-driven development.
-- Durable memory: no crear agente OpenCode experto en SDD por defecto. Usar la skill portable `product-brain-sdd-review` como compuerta semantica read-only para revisar si una issue CACH es ejecutable: requisitos observables, plan tecnico cuando aplica, tareas derivables, validacion trazable y bajo riesgo de drift/token dump.
+- Durable memory: superseded por el modelo de SDD progresivo del 2026-05-19. Mantener la regla de no crear agente OpenCode experto en SDD por defecto; usar la skill portable `product-brain-sdd-review` como compuerta semantica read-only.
 - Source: `.agents/skills/product-brain-sdd-review/SKILL.md`; `docs/agent-skills-strategy.md`; `scripts/brain/ready-check.mjs`.
 
 ## 2026-05-03 - Skills Use A Single Source With Claude Symlinks

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ Skills disponibles:
 | `agent-context-maintenance` | Mantener higiene de contexto, prompts y presupuestos de carga. |
 | `product-brain-orient` | Orientar agentes sobre Product Brain v2 sin cargar todo `docs/project/`. |
 | `product-brain-capture` | Capturar ideas, decisiones o contexto en Product Brain. |
-| `product-brain-sdd-review` | Revisar si una issue CACH está lista para ejecución con SDD ligero. |
+| `product-brain-sdd-review` | Revisar si una issue CACH está lista para ejecución con SDD por niveles. |
 | `caveman` | Modo de comunicación ultraconciso con excepciones para seguridad, datos y reviews. |
 | `react-doctor` | Ejecutar React Doctor como escaneo advisory de salud React. |
 

--- a/TECHDOC.md
+++ b/TECHDOC.md
@@ -185,7 +185,7 @@ La carpeta `.agents/skills/` contiene la fuente única de workflows portables ba
 | `agent-context-maintenance` | Mantener higiene de contexto, prompts y presupuestos de carga. |
 | `product-brain-orient` | Orientar agentes sobre Product Brain v2 sin cargar todo el árbol. |
 | `product-brain-capture` | Capturar ideas, decisiones o contexto en Product Brain. |
-| `product-brain-sdd-review` | Revisar si una issue CACH está lista para ejecución con SDD ligero. |
+| `product-brain-sdd-review` | Revisar si una issue CACH está lista para ejecución con SDD por niveles. |
 | `caveman` | Modo de salida ultraconciso con excepciones de seguridad y exactitud. |
 | `react-doctor` | Ejecutar React Doctor como diagnóstico advisory de salud React. |
 

--- a/docs/project/START_HERE.md
+++ b/docs/project/START_HERE.md
@@ -51,7 +51,7 @@ npm run pb:retrieve  # Retrieval local por perfil/query/issue para orientar agen
 npm run pb:check    # Validar frontmatter, índices y wikilinks internos
 npm run pb:guard     # Validación completa para cambios en docs/project/ o scripts/brain/
 npm run pb:ready-check -- CACH-XXXX # Antes de mover una issue a ready
-npm run pb:sdd-check -- CACH-XXXX # Gate SDD ligero de una issue ejecutable
+npm run pb:sdd-check -- CACH-XXXX # Gate SDD por niveles de una issue ejecutable
 npm run pb:close-check -- CACH-XXXX # Antes de cerrar una issue como done
 npm run pb:pull     # Importar cambios del vault de iCloud
 npm run pb:push     # Exportar cambios al vault de iCloud
@@ -77,7 +77,7 @@ Leer además solo si aplica:
 
 Ejecutar `npm run pb:guard` antes de cerrar cambios en `docs/project/` o `scripts/brain/`. Para cambios documentales acotados, `npm run pb:check` sigue siendo útil como validación rápida.
 
-La coherencia issue-release, el tablero, los wikilinks e indices se validan con `pb:guard`/`pb:check`. Si se mueven issues, ADRs, knowledge o releases, ejecutar tambien `npm run pb:index`. Antes de pasar una issue a `ready`, usar `pb:ready-check CACH-XXXX`; antes de marcarla como `done`, usar `pb:close-check CACH-XXXX`.
+La coherencia issue-release, el tablero, los wikilinks e indices se validan con `pb:guard`/`pb:check`. Si se mueven issues, ADRs, knowledge o releases, ejecutar tambien `npm run pb:index`. Antes de pasar una issue a `ready`, usar `pb:ready-check CACH-XXXX` y `pb:sdd-check CACH-XXXX`; antes de marcarla como `done`, usar `pb:close-check CACH-XXXX`.
 
 Los IDs canónicos de issues son los nombres de archivo completos, por ejemplo `CACH-0026` y `CACH-B0001`. No usar formas cortas como `CACH-026` o `CACH-B001` en wikilinks.
 

--- a/docs/project/backlog/BACKLOG.md
+++ b/docs/project/backlog/BACKLOG.md
@@ -5,7 +5,7 @@ id: PB-BACKLOG
 title: Backlog operativo
 lifecycle: active
 created: 2026-05-05
-updated: 2026-05-18
+updated: 2026-05-19
 aliases:
   - Backlog operativo
   - Backlog
@@ -150,6 +150,7 @@ _Sin issues._
 | [[../issues/CACH-0088|CACH-0088]] | QA final de beta 23 visual total | RELEASE-0.1.0-beta.23 | QA final ejecutada sobre la beta 23 ampliada a visual total: workers integrados, barrido de restos legacy completado, matriz visual autenticada validada y calendario de eventos comprobado con scroll horizontal movil. |
 | [[../issues/CACH-0095|CACH-0095]] | Validadores de policies documentales del Product Brain | null | Implementado y validado en la PR https://github.com/dignacioconde/culturApp/pull/112. |
 | [[../issues/CACH-0096|CACH-0096]] | Retrieval local y gate SDD ligero para Product Brain | null | Implementado y validado en la PR https://github.com/dignacioconde/culturApp/pull/112. |
+| [[../issues/CACH-0097|CACH-0097]] | Escalado SDD por niveles para Product Brain | null | Implementado localmente: SDD pasa de gate ligero a SDD progresivo por niveles, con Nivel 2 documentado y exigible por `pb:sdd-check` para futuras issues ejecutables de mayor riesgo. |
 | [[../issues/CACH-B0018|CACH-B0018]] | Adaptador Codex-native para perfiles Cultura | RELEASE-0.1.0-beta.9 | Sin resultado documentado. |
 
 ## Regla de mantenimiento

--- a/docs/project/indexes/by-area.md
+++ b/docs/project/indexes/by-area.md
@@ -5,7 +5,7 @@ id: PB-BY-AREA
 title: Issues por area
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-18
+updated: 2026-05-19
 aliases:
   - Issues por area
 tags:
@@ -116,6 +116,7 @@ generated: true
 - [[../issues/CACH-0080|CACH-0080]] — Inventariar gaps funcionales Lovable fuera de beta 23 · done · p2 · task
 - [[../issues/CACH-0095|CACH-0095]] — Validadores de policies documentales del Product Brain · done · p2 · task
 - [[../issues/CACH-0096|CACH-0096]] — Retrieval local y gate SDD ligero para Product Brain · done · p2 · slice
+- [[../issues/CACH-0097|CACH-0097]] — Escalado SDD por niveles para Product Brain · done · p2 · slice
 
 ## security
 

--- a/docs/project/indexes/by-component.md
+++ b/docs/project/indexes/by-component.md
@@ -5,7 +5,7 @@ id: PB-BY-COMPONENT
 title: Issues por componente
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-18
+updated: 2026-05-19
 aliases:
   - Issues por componente
 tags:
@@ -154,6 +154,7 @@ generated: true
 - [[../issues/CACH-0080|CACH-0080]] — Inventariar gaps funcionales Lovable fuera de beta 23 · done · p2 · task
 - [[../issues/CACH-0095|CACH-0095]] — Validadores de policies documentales del Product Brain · done · p2 · task
 - [[../issues/CACH-0096|CACH-0096]] — Retrieval local y gate SDD ligero para Product Brain · done · p2 · slice
+- [[../issues/CACH-0097|CACH-0097]] — Escalado SDD por niveles para Product Brain · done · p2 · slice
 
 ## agents
 
@@ -170,6 +171,7 @@ generated: true
 - [[../issues/CACH-0088|CACH-0088]] — QA final de beta 23 visual total · done · p2 · task
 - [[../issues/CACH-0095|CACH-0095]] — Validadores de policies documentales del Product Brain · done · p2 · task
 - [[../issues/CACH-0096|CACH-0096]] — Retrieval local y gate SDD ligero para Product Brain · done · p2 · slice
+- [[../issues/CACH-0097|CACH-0097]] — Escalado SDD por niveles para Product Brain · done · p2 · slice
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task
 
 ## design-system

--- a/docs/project/indexes/by-level.md
+++ b/docs/project/indexes/by-level.md
@@ -5,7 +5,7 @@ id: PB-BY-LEVEL
 title: Issues por nivel
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-18
+updated: 2026-05-19
 aliases:
   - Issues por nivel
 tags:
@@ -75,6 +75,7 @@ generated: true
 - [[../issues/CACH-0086|CACH-0086]] — Unificar pantallas secundarias operativas · done · p2 · slice
 - [[../issues/CACH-0087|CACH-0087]] — Unificar admin gates y layout global · done · p2 · slice
 - [[../issues/CACH-0096|CACH-0096]] — Retrieval local y gate SDD ligero para Product Brain · done · p2 · slice
+- [[../issues/CACH-0097|CACH-0097]] — Escalado SDD por niveles para Product Brain · done · p2 · slice
 
 ## task
 

--- a/docs/project/indexes/by-release.md
+++ b/docs/project/indexes/by-release.md
@@ -5,7 +5,7 @@ id: PB-BY-RELEASE
 title: Issues por release
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-18
+updated: 2026-05-19
 aliases:
   - Issues por release
 tags:
@@ -40,6 +40,7 @@ generated: true
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task
 - [[../issues/CACH-0095|CACH-0095]] — Validadores de policies documentales del Product Brain · done · p2 · task
 - [[../issues/CACH-0096|CACH-0096]] — Retrieval local y gate SDD ligero para Product Brain · done · p2 · slice
+- [[../issues/CACH-0097|CACH-0097]] — Escalado SDD por niveles para Product Brain · done · p2 · slice
 
 ## RELEASE-0.1.0-beta.1
 

--- a/docs/project/indexes/by-status.md
+++ b/docs/project/indexes/by-status.md
@@ -5,7 +5,7 @@ id: PB-BY-STATUS
 title: Issues por workflow
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-18
+updated: 2026-05-19
 aliases:
   - Issues por workflow
 tags:
@@ -103,4 +103,5 @@ generated: true
 - [[../issues/CACH-0088|CACH-0088]] — QA final de beta 23 visual total · done · p2 · task
 - [[../issues/CACH-0095|CACH-0095]] — Validadores de policies documentales del Product Brain · done · p2 · task
 - [[../issues/CACH-0096|CACH-0096]] — Retrieval local y gate SDD ligero para Product Brain · done · p2 · slice
+- [[../issues/CACH-0097|CACH-0097]] — Escalado SDD por niveles para Product Brain · done · p2 · slice
 - [[../issues/CACH-B0018|CACH-B0018]] — Adaptador Codex-native para perfiles Cultura · done · p2 · task

--- a/docs/project/indexes/by-theme.md
+++ b/docs/project/indexes/by-theme.md
@@ -5,7 +5,7 @@ id: PB-BY-THEME
 title: Issues por tema
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-18
+updated: 2026-05-19
 aliases:
   - Issues por tema
 tags:
@@ -116,6 +116,7 @@ generated: true
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task
 - [[../issues/CACH-0095|CACH-0095]] — Validadores de policies documentales del Product Brain · done · p2 · task
 - [[../issues/CACH-0096|CACH-0096]] — Retrieval local y gate SDD ligero para Product Brain · done · p2 · slice
+- [[../issues/CACH-0097|CACH-0097]] — Escalado SDD por niveles para Product Brain · done · p2 · slice
 
 ## none
 

--- a/docs/project/indexes/initiative-children.index.md
+++ b/docs/project/indexes/initiative-children.index.md
@@ -5,7 +5,7 @@ id: PB-INITIATIVE-CHILDREN
 title: Initiative Children Index
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-18
+updated: 2026-05-19
 aliases:
   - Initiative Children Index
 tags:
@@ -69,6 +69,7 @@ _Sin children._
 - [[../issues/CACH-0048|CACH-0048]] — [Context] Compactar workflow OpenCode · done · p2 · task
 - [[../issues/CACH-0095|CACH-0095]] — Validadores de policies documentales del Product Brain · done · p2 · task
 - [[../issues/CACH-0096|CACH-0096]] — Retrieval local y gate SDD ligero para Product Brain · done · p2 · slice
+- [[../issues/CACH-0097|CACH-0097]] — Escalado SDD por niveles para Product Brain · done · p2 · slice
 
 ## CACH-B0011 — Categorias etiquetas y taxonomia
 

--- a/docs/project/indexes/issues.index.md
+++ b/docs/project/indexes/issues.index.md
@@ -5,7 +5,7 @@ id: PB-ISSUES-INDEX
 title: Issues Index
 lifecycle: active
 created: 2026-05-10
-updated: 2026-05-18
+updated: 2026-05-19
 aliases:
   - Issues Index
 tags:
@@ -79,6 +79,7 @@ generated: true
 - [[../issues/CACH-0094|CACH-0094]] — QA y cierre de Beta 24 calendario
 - [[../issues/CACH-0095|CACH-0095]] — Validadores de policies documentales del Product Brain
 - [[../issues/CACH-0096|CACH-0096]] — Retrieval local y gate SDD ligero para Product Brain
+- [[../issues/CACH-0097|CACH-0097]] — Escalado SDD por niveles para Product Brain
 - [[../issues/CACH-B0001|CACH-B0001]] — Redisenar Trabajos y jerarquia proyecto-evento
 - [[../issues/CACH-B0002|CACH-B0002]] — Simplificar experiencia mobile financiera
 - [[../issues/CACH-B0003|CACH-B0003]] — Cobro rapido y gestion de pendientes

--- a/docs/project/issues/CACH-0097.md
+++ b/docs/project/issues/CACH-0097.md
@@ -1,0 +1,134 @@
+---
+schema_version: 2
+kind: issue
+id: CACH-0097
+title: Escalado SDD por niveles para Product Brain
+lifecycle: active
+created: '2026-05-19'
+updated: '2026-05-19'
+aliases:
+  - CACH-0097
+tags:
+  - product-brain
+  - issue
+  - sdd
+  - agents
+generated: false
+work_type: chore
+work_level: slice
+issue_workflow: done
+priority: p2
+size: s
+area: brain
+components:
+  - product-brain
+  - agents
+parent: CACH-B0010
+related:
+  - CACH-0096
+depends_on:
+  - CACH-0096
+blocked_by: []
+adr:
+  - ADR-0010
+release: null
+theme: internal-agent-ops
+---
+# CACH-0097 - Escalado SDD por niveles para Product Brain
+
+## Objetivo
+
+Subir el SDD de Cachés a un modelo progresivo por niveles para adelantarnos a rework por ambiguedad sin convertir el Product Brain en un framework pesado de specs.
+
+## Alcance
+
+Incluido:
+
+- Documentar Nivel 1, Nivel 2 y Nivel 3 en `docs/project/process/sdd-levels.md`.
+- Actualizar Definition of Ready, Workflow, START_HERE y la plantilla de issue para que Nivel 2 sea visible antes de ejecutar.
+- Endurecer `pb:sdd-check` para exigir secciones Nivel 2 en issues ejecutables con riesgo o complejidad.
+- Alinear la skill `product-brain-sdd-review` y las tablas de referencia de skills.
+- Regenerar indices/digest del Product Brain.
+
+Fuera de alcance:
+
+- Framework externo de specs, carpetas `.specify/`, task dumps generados o ADR obligatorio para cada issue.
+- Embeddings, vector DB o cambios de RAG.
+- Cambios en `src/`, Supabase, runtime o UX de Cachés.
+- Migracion masiva de issues cerradas.
+
+## Criterios de aceptacion
+
+- [x] AC1: Existe una guia canonica de SDD por niveles con triggers claros para Nivel 2 y no-goals de proceso pesado.
+- [x] AC2: La plantilla de issue y el workflow explican que `pb:guard --phase ready --issue CACH-XXXX` ejecuta ready-check y sdd-check.
+- [x] AC3: `pb:sdd-check` exige Escenarios SDD, Contrato tecnico y matriz `ACn -> validacion` cuando una issue ejecutable activa Nivel 2.
+- [x] AC4: La skill `product-brain-sdd-review`, README y TECHDOC hablan de SDD por niveles y no de solo SDD ligero.
+- [x] AC5: Product Brain queda consistente con indices/digest frescos y checks relevantes en verde.
+
+## Plan tecnico
+
+Actualizar solo superficie de proceso y tooling local: documentos `docs/project/process/**`, plantilla `docs/project/templates/ISSUE_TEMPLATE.md`, skill `.agents/skills/product-brain-sdd-review/SKILL.md`, referencias en README/TECHDOC y `scripts/brain/sdd-check.mjs`. Mantener el gate acotado a issues ejecutables (`ready`, `in_progress`, `review`) para no romper historico ni backlog.
+
+## Escenarios SDD
+
+- Cuando una issue ejecutable sea `size: m`, datos/seguridad/infra, finance/Supabase/auth/calendar o multi-componente, entonces `pb:sdd-check` exige Nivel 2 antes de tratarla como lista.
+- Cuando una issue sea `xs/s` de bajo riesgo y tenga objetivo, alcance, ACs y validacion trazable, entonces Nivel 1 sigue siendo suficiente.
+- Cuando una decision afecte varias slices o releases, entonces se usa Nivel 3 con ADR/decision y slices hijas ejecutables, no una spec monolitica.
+
+## Contrato tecnico
+
+- `docs/project/process/sdd-levels.md` define el contrato humano de niveles.
+- `scripts/brain/sdd-check.mjs` aplica triggers Nivel 2 con funciones locales y sin estado persistente.
+- `docs/project/templates/ISSUE_TEMPLATE.md` expone secciones opcionales que pasan a obligatorias solo si el gate detecta Nivel 2.
+- `docs/project/process/WORKFLOW.md` mantiene `pb:guard --phase ready --issue` como compuerta operativa.
+
+## Riesgos y rollback
+
+Riesgo principal: subir friccion en tareas pequeñas. Mitigacion: Nivel 2 solo se exige por triggers concretos y Nivel 1 sigue siendo el default.
+
+Rollback: revertir esta slice de docs/script. No toca runtime, datos, Supabase ni produccion.
+
+## Validacion
+
+- AC1 -> revisar `docs/project/process/sdd-levels.md`.
+- AC2 -> revisar `docs/project/templates/ISSUE_TEMPLATE.md`, `docs/project/process/WORKFLOW.md` y `docs/project/START_HERE.md`.
+- AC3 -> `npm run pb:sdd-check -- CACH-0097 --json` en copia temporal con `issue_workflow: ready`.
+- AC4 -> `npm run verify:skills`, revisar README y TECHDOC.
+- AC5 -> `npm run pb:guard`, `npm run context:check`, `npm run lint` y `git diff --check`.
+
+## Resultado
+
+Implementado localmente: SDD pasa de gate ligero a SDD progresivo por niveles, con Nivel 2 documentado y exigible por `pb:sdd-check` para futuras issues ejecutables de mayor riesgo.
+
+## Desarrollo
+
+- Rama: `codex/cach-0097-sdd-levels`
+- PR: https://github.com/dignacioconde/culturApp/pull/113
+- Estado actual: done.
+
+## Notas de progreso
+
+El cambio se hizo como slice de tooling interno bajo CACH-B0010 porque afecta agentes, Product Brain y scripts locales, no el producto usuario final.
+
+## Cambios de alcance y decisiones
+
+No se introduce Nivel 3 automatico. Si una decision gobierna varias slices o releases, se crea ADR/decision y se mantienen slices hijas ejecutables.
+
+## Bloqueos
+
+No aplica.
+
+## Validación ejecutada
+
+- `npm run pb:sdd-check -- CACH-0097 --json` en copia temporal con `issue_workflow: ready` — OK.
+- `npm run pb:guard -- --phase ready --issue CACH-0097 --json` en copia temporal regenerada — OK.
+- `npm run pb:sdd-check -- CACH-0097 --json` en copia temporal sin `Escenarios SDD` — falla como esperado.
+- `npm run pb:guard -- --json` — OK.
+- `npm run verify:skills` — OK.
+- `npm run context:check` — OK.
+- `npm run lint` — OK.
+- `git diff --check` — OK.
+
+## Memoria
+
+Actualizada en `.memory/feedback_product_brain.md` y `.memory/topics/portable-skills.md`.

--- a/docs/project/process/README.md
+++ b/docs/project/process/README.md
@@ -5,7 +5,7 @@ id: PB-PROCESS
 title: Process
 lifecycle: active
 created: '2026-05-05'
-updated: '2026-05-18'
+updated: '2026-05-19'
 aliases:
   - Process
   - Sistema operativo de producto
@@ -27,6 +27,7 @@ Sistema operativo ligero para desarrollar Cachés desde el Product Brain.
 - [[RELEASE_PROCESS]] — crear, activar, estabilizar y cerrar releases.
 - [[definition-of-ready]] — INVEST aplicado a Cachés.
 - [[definition-of-done]] — salida mínima honesta de una issue.
+- [[sdd-levels]] — SDD progresivo: Nivel 1 ligero, Nivel 2 para riesgo/complejidad y Nivel 3 excepcional.
 - [[id-policy]] — política única de IDs `CACH-NNNN`.
 - [[frontmatter-schema]] — schema humano del frontmatter validado por Zod.
 - [[document-types-registry]] — tipos documentales, políticas de carga e indexación.

--- a/docs/project/process/WORKFLOW.md
+++ b/docs/project/process/WORKFLOW.md
@@ -5,7 +5,7 @@ id: PB-PROCESS-WORKFLOW
 title: Workflow
 lifecycle: active
 created: '2026-05-05'
-updated: '2026-05-13'
+updated: '2026-05-19'
 aliases:
   - Workflow
   - Thin Product Brain Workflow
@@ -166,6 +166,16 @@ Campos opcionales: release, rama sugerida, riesgos, dependencias, notas técnica
 
 Además del cuerpo, toda issue debe usar el frontmatter v2 de `frontmatter-schema.md` (`schema_version: 2`, `kind: issue`, `lifecycle`, `issue_workflow`, `work_type`, `work_level`, `size`, `components`, etc.). No usar `type/status` top-level en documentos nuevos.
 
+### SDD por niveles
+
+Usar [[sdd-levels]] como compuerta progresiva:
+
+- Nivel 1: issue ejecutable ligera para tareas `xs/s` de bajo riesgo.
+- Nivel 2: spec slice para `size: m`, datos/RLS/seguridad/infra, finanzas, Supabase, auth, calendarios complejos, trabajo multi-componente, varios agentes/PRs o dolor repetido de ambiguedad.
+- Nivel 3: decision/ADR o dossier solo si una regla gobierna varias slices o releases.
+
+Antes de mover una issue a `ready`, `pb:guard --phase ready --issue CACH-XXXX` ejecuta `pb:ready-check` y `pb:sdd-check`. Si el cambio activa Nivel 2, la issue debe incluir escenarios, contrato tecnico, matriz `ACn -> validacion` y riesgos/rollback cuando aplique.
+
 ---
 
 ## Cuándo crear ADR
@@ -198,6 +208,7 @@ Son bloqueantes para PR o merge:
 - `npm run build` — si se toca código de app o tooling que afecta build.
 - `npm run pb:guard` — si se toca `docs/project/` o `scripts/brain/`.
 - `npm run pb:ready-check -- CACH-XXXX` — antes de mover una issue a `ready`.
+- `npm run pb:sdd-check -- CACH-XXXX` — gate SDD por niveles para issues ejecutables; tambien se ejecuta desde `pb:guard --phase ready --issue`.
 - `npm run pb:close-check -- CACH-XXXX` — antes de marcar una issue como `done` o cerrar trabajo trazado.
 - Verificación DB remoto — si se toca `supabase/migrations/` o la feature depende de schema/policy/RPC nuevo: confirmar migración aplicada/verificada en remoto, o declarar explícitamente que la funcionalidad no está lista en producción.
 

--- a/docs/project/process/definition-of-ready.md
+++ b/docs/project/process/definition-of-ready.md
@@ -5,7 +5,7 @@ id: PB-DEFINITION-READY
 title: Definition of Ready
 lifecycle: active
 created: '2026-05-05'
-updated: '2026-05-08'
+updated: '2026-05-19'
 aliases:
   - Definition of Ready
 tags:
@@ -30,3 +30,11 @@ Una issue esta lista cuando cumple INVEST sin teatro.
 ## Regla beta
 
 Ninguna `initiative` entra en `issue_workflow: ready`. Para ejecutar, crear una `slice` hija con `parent`, `components`, criterios verificables y validacion esperada.
+
+## SDD por niveles
+
+Toda issue ejecutable debe pasar Nivel 1 de [[sdd-levels]].
+
+Antes de mover a `ready`, usar Nivel 2 cuando haya riesgo o complejidad: `size: m`, datos/RLS/seguridad/infra, finanzas, Supabase, auth, calendarios complejos, trabajo multi-componente, varios agentes/PRs o historial de rework por ambiguedad.
+
+Nivel 2 anade escenarios, contrato tecnico, matriz `ACn -> validacion` y riesgos/rollback cuando aplique. No convierte la issue en PRD largo: el objetivo es que un implementador pueda actuar sin reabrir producto.

--- a/docs/project/process/sdd-levels.md
+++ b/docs/project/process/sdd-levels.md
@@ -1,0 +1,88 @@
+---
+schema_version: 2
+kind: process
+id: PB-SDD-LEVELS
+title: SDD por niveles
+lifecycle: active
+created: 2026-05-19
+updated: 2026-05-19
+aliases:
+  - SDD por niveles
+  - SDD Nivel 2
+  - Nivel 2 SDD
+  - Spec-driven development
+  - Spec slice
+tags:
+  - product-brain
+  - process
+  - sdd
+  - agents
+generated: false
+load_policy: profile_only
+index_policy: index_metadata_only
+---
+# SDD por niveles
+
+Caches usa SDD progresivo: suficiente especificacion para reducir rework, sin convertir cada tarea en un PRD largo ni duplicar reglas globales.
+
+## Nivel 1 - Issue ejecutable
+
+Nivel por defecto para tareas `xs` o `s` de bajo riesgo.
+
+Requiere:
+
+- Objetivo claro.
+- Alcance con `Incluido` y `Fuera de alcance`.
+- Criterios de aceptacion como checklist con IDs `AC1`, `AC2`, etc.
+- Validacion esperada que mencione cada `ACn`.
+- Plan tecnico corto cuando lo pida `pb:ready-check` o `pb:sdd-check`.
+
+Gates:
+
+- `npm run pb:ready-check -- CACH-XXXX`
+- `npm run pb:sdd-check -- CACH-XXXX`
+
+## Nivel 2 - Spec slice
+
+Nivel obligatorio antes de ejecutar una issue si aparece cualquiera de estos triggers:
+
+- `size: m`.
+- `area: data`, `security` o `infra`.
+- Componentes `finance`, `supabase`, `auth-onboarding` o `calendar`.
+- Trabajo multi-componente.
+- Trabajo que vaya a varios agentes, varias PRs o una release multi-issue.
+- Cambio con migraciones, RLS, permisos, calculos financieros, sincronizacion, estados complejos de UI o riesgo alto de drift.
+- Dolor repetido: criterios ambiguos, rework por scope, validacion que no prueba los ACs o agentes que no encuentran el contexto.
+
+Requiere todo el Nivel 1 y ademas:
+
+- `Escenarios SDD`: al menos un escenario observable con forma `Cuando... entonces...` o `Given/When/Then`.
+- `Contrato tecnico`: contratos, modulos, hooks, schemas, policies, scripts, estados UX o superficies afectadas.
+- `Validacion`: matriz ligera `ACn -> check/evidencia` dentro de la seccion de validacion.
+- `Riesgos y rollback`: obligatorio cuando hay datos, seguridad, infra, finanzas, Supabase o auth.
+
+El Nivel 2 no debe copiar contexto global. Debe enlazar ADRs, source touchpoints, memoria o docs canonicos cuando haga falta.
+
+## Nivel 3 - Decision o dossier
+
+Nivel excepcional, no automatico. Usarlo solo cuando una decision gobierna varias slices o releases.
+
+Requiere:
+
+- ADR o decision canonica si cambia arquitectura, modelo de datos, seguridad, finanzas o proceso durable.
+- Initiative o parent que agrupe slices.
+- Slices hijas ejecutables con Nivel 1 o Nivel 2.
+
+No crear por defecto:
+
+- Carpetas `.specify/`.
+- Task dumps generados.
+- Vector DB, embeddings o RAG pesado.
+- Specs que repitan `AGENTS.md`, memoria o `WORKFLOW`.
+
+## Relacionado
+
+- [[definition-of-ready]]
+- [[definition-of-done]]
+- [[WORKFLOW]]
+- [[retrieval-profiles]]

--- a/docs/project/templates/ISSUE_TEMPLATE.md
+++ b/docs/project/templates/ISSUE_TEMPLATE.md
@@ -48,9 +48,28 @@ Que esta incluido y que queda fuera.
 
 Solo si aplica: obligatorio para `size: m`, datos/RLS/seguridad/infra, `finance`, `supabase`, `auth-onboarding` o cambios multi-componente. Mantener corto: contratos afectados, hooks/modulos esperados, migraciones, estados UX o riesgos de integracion. No copiar reglas globales ni cerrar una solucion innecesariamente.
 
+## Escenarios SDD
+
+Solo Nivel 2. Usar cuando haya riesgo o complejidad: `size: m`, datos/RLS/seguridad/infra, `finance`, `supabase`, `auth-onboarding`, `calendar`, cambios multi-componente, varios agentes/PRs o ambiguedad repetida.
+
+- Cuando <situacion observable>, entonces <resultado esperado>.
+
+## Contrato tecnico
+
+Solo Nivel 2. Nombrar contratos, modulos, hooks, schemas, policies, scripts, estados UX o superficies afectadas. Mantenerlo como mapa de trabajo, no como implementacion cerrada.
+
+## Riesgos y rollback
+
+Solo Nivel 2 cuando haya datos, seguridad, infra, finanzas, Supabase o auth. Indicar riesgo principal y como revertir, desactivar o verificar que no rompe produccion.
+
 ## Validacion
 
 Checks esperados al terminar. Deben mencionar los IDs `AC1`, `AC2`, etc. que cubren y ser especificos del dominio cuando toque datos, seguridad, infra, finanzas, Supabase, calendario o sistema visual.
+
+Para Nivel 2, usar matriz ligera:
+
+- AC1 -> check/evidencia concreta.
+- AC2 -> check/evidencia concreta.
 
 ## Resultado
 

--- a/scripts/brain/sdd-check.mjs
+++ b/scripts/brain/sdd-check.mjs
@@ -14,6 +14,8 @@ const structuralPlaceholderPattern = /\b(tbd|pendiente|por definir|placeholder)\
 const genericCriterionPattern = /^(funciona correctamente|se mejora|mejora general|implementar|hacer|actualizar|validar)$/i
 const riskyAreas = new Set(['data', 'infra', 'security'])
 const technicalPlanComponents = new Set(['finance', 'supabase', 'auth-onboarding'])
+const advancedSddComponents = new Set(['finance', 'supabase', 'auth-onboarding', 'calendar'])
+const rollbackComponents = new Set(['finance', 'supabase', 'auth-onboarding'])
 
 function fail(message) {
   errors.push(message)
@@ -47,6 +49,22 @@ function requiresTechnicalPlan(data) {
   )
 }
 
+function requiresAdvancedSdd(data) {
+  return (
+    data.size === 'm' ||
+    riskyAreas.has(data.area) ||
+    data.components.some((component) => advancedSddComponents.has(component)) ||
+    data.components.length > 1
+  )
+}
+
+function requiresRollbackPlan(data) {
+  return (
+    riskyAreas.has(data.area) ||
+    data.components.some((component) => rollbackComponents.has(component))
+  )
+}
+
 function explicitScope(scope) {
   return /\bIncluido\b/i.test(scope) && /Fuera de alcance/i.test(scope)
 }
@@ -54,6 +72,26 @@ function explicitScope(scope) {
 function validationMentionsAllCriteria(validation, ids) {
   const normalized = validation.toUpperCase()
   return ids.every((id) => normalized.includes(id))
+}
+
+function validationMapsAllCriteria(validation, ids) {
+  const lines = validation
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+
+  return ids.every((id) => lines.some((line) => new RegExp(`\\b${id}\\b`, 'i').test(line)))
+}
+
+function hasScenarioShape(scenarios) {
+  return scenarios
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .some((line) => (
+      /\b(cuando|when|given|dado)\b/i.test(line) &&
+      /\b(entonces|then)\b/i.test(line)
+    ))
 }
 
 function validateIssueLinks(data) {
@@ -117,6 +155,29 @@ if (!issueId) {
         if (requiresTechnicalPlan(data)) {
           const plan = sectionContent(doc.content, ['Plan tecnico', 'Plan técnico', 'Technical Plan', 'Implementation Plan'])
           if (!meaningful(plan)) fail('Plan tecnico requerido para size m, area/componente de riesgo o trabajo multi-componente')
+        }
+
+        if (requiresAdvancedSdd(data)) {
+          const scenarios = sectionContent(doc.content, ['Escenarios SDD', 'Escenarios', 'Scenarios'])
+          if (!meaningful(scenarios) || !hasScenarioShape(scenarios)) {
+            fail('SDD Nivel 2 requiere Escenarios SDD con al menos un Cuando/Entonces o Given/When/Then')
+          }
+
+          const contract = sectionContent(doc.content, ['Contrato tecnico', 'Contrato técnico', 'Contrato', 'Technical Contract'])
+          if (!meaningful(contract)) {
+            fail('SDD Nivel 2 requiere Contrato tecnico con contratos, modulos, datos, scripts o estados afectados')
+          }
+
+          if (ids.length > 0 && !validationMapsAllCriteria(validation, ids)) {
+            fail(`SDD Nivel 2 requiere matriz ACn -> validacion para: ${ids.join(', ')}`)
+          }
+        }
+
+        if (requiresRollbackPlan(data)) {
+          const rollback = sectionContent(doc.content, ['Riesgos y rollback', 'Riesgos', 'Rollback'])
+          if (!meaningful(rollback)) {
+            fail('SDD Nivel 2 requiere Riesgos y rollback para datos, seguridad, infra, finanzas, Supabase o auth')
+          }
         }
 
         validateIssueLinks(data)


### PR DESCRIPTION
## Resumen

- Añade `CACH-0097` y `docs/project/process/sdd-levels.md` como contrato canónico para SDD por niveles.
- Actualiza Workflow, Definition of Ready, START_HERE y la plantilla de issue para activar Nivel 2 cuando haya riesgo o complejidad.
- Endurece `pb:sdd-check` para exigir escenarios, contrato técnico, matriz AC-validación y rollback cuando aplica.
- Alinea `product-brain-sdd-review`, memoria durable, README/TECHDOC e índices generados.

## Impacto

Esto mantiene Thin Product Brain como default, pero da una compuerta más fuerte antes de que aparezcan dolores de ambigüedad en issues medianas, multi-componente o sensibles.

## Validación

- `npm run pb:guard -- --json`
- `npm run verify:skills`
- `npm run context:check`
- `npm run lint`
- `npm run verify:pr -- --base origin/main`
- `git diff --check --cached`
- `pb:guard --phase ready --issue CACH-0097` en copia temporal regenerada
- test negativo: `pb:sdd-check` falla si falta `Escenarios SDD` en una issue Nivel 2

## Memoria

- Actualizada en `.memory/feedback_product_brain.md` y `.memory/topics/portable-skills.md`.

## Product Brain

- Issue: `docs/project/issues/CACH-0097.md`
- Product Brain actualizado: sí
- Validación PB: `pb:guard` OK